### PR TITLE
CCB-292 Add enumerated value to Units_of_Frequency

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetValueMeanings.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetValueMeanings.java
@@ -128,6 +128,7 @@ class GetValueMeanings extends Object{
 		lPVD = new PermValueDefn ("pds:Product_Observational/pds:Reference_List/pds:Internal_Reference.reference_type.data_to_derived_product", "data_to_derived_product", "The data product is associated to a derived product"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
 		lPVD = new PermValueDefn ("pds:Product_Ancillary/pds:Reference_List/pds:Internal_Reference.reference_type.ancillary_to_data", "ancillary_to_data", "The ancillary product is associated to a data product"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
+		lPVD = new PermValueDefn ("pds:Product_Ancillary/pds:Reference_List/pds:Internal_Reference.reference_type.ancillary_to_browse", "ancillary_to_browse", "The ancillary product is associated to a browse product"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
 		lPVD = new PermValueDefn ("pds:Product_Ancillary/pds:Context_Area/pds:Investigation_Area/pds:Internal_Reference.reference_type.ancillary_to_investigation", "ancillary_to_investigation", "The ancillary data product is associated to an investigation"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
 		lPVD = new PermValueDefn ("pds:Product_Ancillary/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.ancillary_to_target", "ancillary_to_target", "The ancillary data product is associated to a target"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
@@ -237,11 +238,11 @@ class GetValueMeanings extends Object{
 		lPVD = new PermValueDefn ("pds:Product_Document/pds:Context_Area/pds:Observing_System/pds:Observing_System_Component/pds:Internal_Reference.reference_type.document_to_instrument_host", "document_to_instrument_host", "The document is associated to an instrument host"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
 		lPVD = new PermValueDefn ("pds:Product_Document/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.document_to_target", "document_to_target", "The document is associated to a target"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
 		
-		
 		lPVD = new PermValueDefn ("pds:Product_Browse/pds:Reference_List/pds:Internal_Reference.reference_type.browse_to_data", "browse_to_data", "The browse product is associated to a data product"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
 		lPVD = new PermValueDefn ("pds:Product_Browse/pds:Reference_List/pds:Internal_Reference.reference_type.browse_to_thumbnail", "browse_to_thumbnail", "The browse product is associated to a thumbnail"); masterValueMeaningMap.put(lPVD.identifier, lPVD);
 		lPVD = new PermValueDefn ("pds:Product_Browse/pds:Reference_List/pds:Internal_Reference.reference_type.browse_to_browse", "browse_to_browse", "The browse product is associated to a different browse product."); masterValueMeaningMap.put(lPVD.identifier, lPVD);
 		lPVD = new PermValueDefn ("pds:Product_Browse/pds:Reference_List/pds:Internal_Reference.reference_type.browse_to_document", "browse_to_document", "The browse product is associated to a document."); masterValueMeaningMap.put(lPVD.identifier, lPVD);	
+		lPVD = new PermValueDefn ("pds:Product_Browse/pds:Reference_List/pds:Internal_Reference.reference_type.browse_to_ancillary", "browse_to_ancillary", "The browse product is associated to an ancillary product."); masterValueMeaningMap.put(lPVD.identifier, lPVD);	
 
 		lPVD = new PermValueDefn ("pds:Product_Thumbnail/pds:Reference_List/pds:Internal_Reference.reference_type.thumbnail_to_data", "thumbnail_to_data", "The thumbnail product is associated to a data product."); masterValueMeaningMap.put(lPVD.identifier, lPVD);	
 		lPVD = new PermValueDefn ("pds:Product_Thumbnail/pds:Reference_List/pds:Internal_Reference.reference_type.thumbnail_to_browse", "thumbnail_to_browse", "The thumbnail product is associated to a browse product."); masterValueMeaningMap.put(lPVD.identifier, lPVD);	

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Fri Aug 21 11:33:22 PDT 2020
+; Sat Aug 22 16:33:30 PDT 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -1197,7 +1197,8 @@
 	(specMesg "TBD")
 	(testValArr
 		"ancillary_to_data"
-		"ancillary_to_document"))
+		"ancillary_to_document"
+		"ancillary_to_browse"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100002529] of  Schematron_Rule
 
@@ -1226,7 +1227,8 @@
 		"browse_to_data"
 		"browse_to_thumbnail"
 		"browse_to_browse"
-		"browse_to_document"))
+		"browse_to_document"
+		"browse_to_ancillary"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Bundle%2Fpds%3AContext_Area.100002534] of  Schematron_Rule
 

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Fri Aug 21 11:33:21 PDT 2020
+; Sat Aug 22 16:33:30 PDT 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/dd11179.pins
+++ b/model-ontology/src/ontology/Data/dd11179.pins
@@ -1,4 +1,4 @@
-; Fri Aug 21 11:40:29 PDT 2020
+; Sat Aug 22 16:56:04 PDT 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -87254,7 +87254,7 @@
 ([vm.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.unit_id.107103] of  ValueMeaning
 
 	(beginDate "2009-06-09")
-	(description "The abbreviated unit for Units_of_Frequency (1/10^3 Hz)")
+	(description "The abbreviated unit for Units_of_Frequency %281%2F10^3 Hz%29")
 	(endDate "2019-12-31"))
 
 ([vm.0001_NASA_PDS_1.pds.Units_of_Frequency.pds.unit_id.2354] of  ValueMeaning


### PR DESCRIPTION
CCB-292	New enumerated values for reference_type. The request is to add the permissible values “ancillary_to_browse” to <Product_Ancillary.Reference_List. Internal_Reference.reference_type> and “browse_to_ancillary” to Product_Browse.Reference_List. Internal_Reference.reference_type. This request allows associations to be made between ancillary and browse products.

Resolves #214
Refs CCB-292

