### PR TITLE
CCB-294 Add enumerated value to Units_of_Pixel_Resolution_Angular

### DIFF
--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Wed Aug 26 10:42:40 PDT 2020
+; Wed Aug 26 12:38:09 PDT 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Wed Aug 26 10:42:40 PDT 2020
+; Wed Aug 26 12:38:09 PDT 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -11660,7 +11660,7 @@
 	(single-slot unit_id
 ;+		(comment "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
 		(type STRING)
-;+		(value "deg/pixel" "arcsec/pixel" "radian/pixel")
+;+		(value "deg/pixel" "arcsec/pixel" "radian/pixel" "HA/pixel")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 

--- a/model-ontology/src/ontology/Data/dd11179.pins
+++ b/model-ontology/src/ontology/Data/dd11179.pins
@@ -1,4 +1,4 @@
-; Sat Aug 22 16:56:04 PDT 2020
+; Wed Aug 26 12:53:32 PDT 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -34241,6 +34241,7 @@
 
 	(administrationRecord [DD_1.15.0.0])
 	(containedIn1
+		[pv.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id.-61259280]
 		[pv.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id.314250550]
 		[pv.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id.-2050785475]
 		[pv.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id.-2108414696])
@@ -70991,6 +70992,14 @@
 	(usedIn [vm.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id.-2108414696])
 	(value "radian%2Fpixel"))
 
+([pv.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id.-61259280] of  PermissibleValue
+
+	(beginDate "2009-06-09")
+	(containing1 [EVD.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id])
+	(endDate "2019-12-31")
+	(usedIn [vm.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id.-61259280])
+	(value "HA%2Fpixel"))
+
 ([pv.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id.314250550] of  PermissibleValue
 
 	(beginDate "2009-06-09")
@@ -79488,6 +79497,7 @@
 	(measureName "Units_of_Pixel_Resolution_Angular")
 	(precision "TBD_precision")
 	(unitId
+		"HA%2Fpixel"
 		"arcsec%2Fpixel"
 		"deg%2Fpixel"
 		"radian%2Fpixel"))
@@ -87507,6 +87517,12 @@
 
 	(beginDate "2009-06-09")
 	(description "The abbreviated unit for Units_of_Pixel_Resolution_Angular is radian%2Fpixel")
+	(endDate "2019-12-31"))
+
+([vm.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id.-61259280] of  ValueMeaning
+
+	(beginDate "2009-06-09")
+	(description "The abbreviated unit for Units_of_Pixel_Resolution_Angular is HA/pixel when the angular measurement is given in units of hour angle.")
 	(endDate "2019-12-31"))
 
 ([vm.0001_NASA_PDS_1.pds.Units_of_Pixel_Resolution_Angular.pds.unit_id.314250550] of  ValueMeaning


### PR DESCRIPTION
CCB-294 Add enumerated value to Units_of_Pixel_Resolution_Angular. The request is to add the permissible value “HA/pixel” and its value meaning to the attribute <Units_of_Pixel_Resolution_Angular. unit_id>, a type of Unit_Of_Measure. This change supports providing resolution in the solar hour angle coordinate. This change request is reasonable.

Resolves #218
Refs CCB-294

