### PR TITLE
IMTool - Cleanup warning messages

### DIFF
--- a/model-ontology/src/ontology/Data/MDPTNConfigClassDisp.xml
+++ b/model-ontology/src/ontology/Data/MDPTNConfigClassDisp.xml
@@ -236,8 +236,8 @@
 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.DD_Rule</Field> <Field>oM</Field> <Field>#18</Field> <Field>pds</Field> <Field>ops</Field> </Record> 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.DD_Rule_Statement</Field> <Field>oM</Field> <Field>#18</Field> <Field>pds</Field> <Field>ops</Field> </Record> 
-  <Record> <Field>Disposition</Field> <Field>N</Field> <Field>UpperModel.0001_NASA_PDS_1.Schematron_Rule</Field> <Field>oM</Field> <Field>#18</Field> <Field>pds</Field> <Field>ops</Field> </Record> 
-  <Record> <Field>Disposition</Field> <Field>N</Field> <Field>UpperModel.0001_NASA_PDS_1.Schematron_Assert</Field> <Field>oM</Field> <Field>#18</Field> <Field>pds</Field> <Field>ops</Field> </Record> 
+  <Record> <Field>Disposition</Field> <Field>I</Field> <Field>UpperModel.0001_NASA_PDS_1.Schematron_Rule</Field> <Field>oM</Field> <Field>#18</Field> <Field>pds</Field> <Field>ops</Field> </Record> 
+  <Record> <Field>Disposition</Field> <Field>I</Field> <Field>UpperModel.0001_NASA_PDS_1.Schematron_Assert</Field> <Field>oM</Field> <Field>#18</Field> <Field>pds</Field> <Field>ops</Field> </Record> 
 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.External_Reference_Extended</Field> <Field>oM</Field> <Field>#18</Field> <Field>pds</Field> <Field>ops</Field> </Record> 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Agency</Field> <Field>1M</Field> <Field>#18</Field> <Field>pds</Field> <Field>pds</Field> </Record> 

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Mon Aug 31 07:30:03 PDT 2020
+; Mon Aug 31 09:29:43 PDT 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Mon Aug 31 07:30:03 PDT 2020
+; Mon Aug 31 09:29:43 PDT 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -8742,14 +8742,6 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
-
-(defclass Cartography_Group "The Cartography Group class is a placeholder for soon forthcoming Imaging cartography classes."
-	(is-a TNDO_Supplemental)
-	(role concrete))
-
-(defclass Rings "The Rings class is an abstract class used to identify the RINGS namespace."
-	(is-a TNDO_Supplemental)
-	(role concrete))
 
 (defclass DD_Attribute_Full "The DD_Attribute_Full class provides a more complete definition of an attribute in the data dictionary."
 	(is-a TNDO_Supplemental)


### PR DESCRIPTION
Fix the problem causing the following warning messages

        WARNING Class disposition was not found - Y UpperModel.0001_NASA_PDS_1.Cartography_Group 1M #nm ns

        WARNING Class disposition was not found - Y UpperModel.0001_NASA_PDS_1.Rings 1M #nm ns

        WARNING Class omitted from build - Class Identifier:0001_NASA_PDS_1.pds.Schematron_Rule

        WARNING Class omitted from build - Class Identifier:0001_NASA_PDS_1.pds.Schematron_Assert

Resolves #225

