### PR TITLE
LDDTool: update LDD attribute - check only for "type" and "_type"

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -1687,7 +1687,7 @@ public class LDDDOMParser extends Object
 		for (Iterator <DOMAttr> i = attrArr.iterator(); i.hasNext();) {
 			DOMAttr lDOMAttr = (DOMAttr) i.next();
 			int lTitleLength = lDOMAttr.title.length();
-			if ((lTitleLength >= 4) && (lDOMAttr.title.indexOf("type") == lTitleLength - 4)) {
+			if (((lTitleLength >= 5) && (lDOMAttr.title.indexOf("_type") == lTitleLength - 5)) || lDOMAttr.title.compareTo("type") == 0) {
 				if (lDOMAttr.domPermValueArr.size() < 1) {
 					if (isMission)
 						DMDocument.registerMessage ("2>warning Attribute: <" + lDOMAttr.title + "> - The 'type' attribute must have at least one permissible value.");


### PR DESCRIPTION
LDDTool: update LDD attribute checking to only check for "type" and "_type". The ERROR attributed to “subtype” is itself an error. It is only of type “type” if it ends in “_type” (or is only “type”). A subType should not be checked.

Resolves #230
Refs CCB-204
