### PR TITLE
LDDTool: uses wrong version of XSD when referencing IMG dictionary

### DIFF
--- a/model-ontology/src/ontology/Data/config.properties
+++ b/model-ontology/src/ontology/Data/config.properties
@@ -1,5 +1,5 @@
 #DMDOC settings
-#Wed Jul 27 12:00:00 PDT 2020
+#Wed Sep 22 12:00:00 PDT 2020
 toolVersionId=${project.version}
 buildDate=${buildNumber}
 infoModelVersionId=1.15.0.0
@@ -64,7 +64,7 @@ lSchemaFileDefn.geo.modelShortName=PDS4
 lSchemaFileDefn.geo.regAuthId=0001_NASA_PDS_1
 		
 lSchemaFileDefn.img.identifier=img
-lSchemaFileDefn.img.versionId=1.6.0.0
+lSchemaFileDefn.img.versionId=1.8.1.0
 lSchemaFileDefn.img.labelVersionId=1.21
 lSchemaFileDefn.img.isMaster=false
 lSchemaFileDefn.img.isDiscipline=true


### PR DESCRIPTION
LDDTool: uses the wrong version of XSD when referencing IMG dictionary. Updated config.properties file.

Resolves #229

