### PR TITLE
Incorrect error messages for DD_Associate_External_Class

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -987,7 +987,7 @@ public class LDDDOMParser extends Object
 								String assertMsgPre = " must be equal to one of the following values"; 
 								if (pvCount == 1) assertMsgPre = " must be equal to the value"; 
 								lDOMAssert.assertStmt =  ". = (" + lAssertMsgValueList  + ")";	
-								lDOMAssert.assertMsg =  "The attribute " + lDOMRule.xpath + ":" + lDOMRule.attrTitle + assertMsgPre + " " + lAssertMsgValueList  + ".";
+								lDOMAssert.assertMsg =  "The attribute " + lDOMRule.xpath + assertMsgPre + " " + lAssertMsgValueList  + ".";
 								lDOMRule.assertArr.add(lDOMAssert);
 							}
 						}


### PR DESCRIPTION
The DD_Associate_External_Class schematron rule to test for valid values includes the attribute name twice in the rules error message. Removed code that duplicated the second occurence of the attribute name.

Resolves #235

----- REMOVE -----
Title ^^^^ above ^^^^ should follow good commit message best practices wherever possible.

A properly formed git commit subject line should always be able to complete the following sentence:

    If applied, this commit will <your subject line here>
----- REMOVE -----

**Summary***
Brief summary of changes if not sufficiently described by commit messages.

**Test Data and/or Report**
One of the following should be included here:
* Reference to regression test included in code (preferred wherever reasonable)
* Attach test data here + outputs of tests

**Related Issues**
Reference related issues here and use `Fixes` or `Resolves` for closing issues:
* for issues in this repo: #1, #2, #3
* for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
