### PR TITLE
LDDTool: DocBook generation does not work from any file system location

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -387,8 +387,6 @@ public class DMDocument extends Object {
 		// set registryAttr
 		setRegistryAttrFlag ();
 		
-		// original location of deprecation code moved to end of file.
-		
 		// set exposed elements 
 		setexposedElementFlag ();
 		
@@ -809,6 +807,27 @@ public class DMDocument extends Object {
 			}
 		}
 //		registerMessage ("1>info Input File Name Checked: " + lSchemaFileDefn.LDDToolInputFileName);
+	}
+	
+	static public boolean checkCreateDirectory (String lDirectoryPathName) {
+		File file = new File(lDirectoryPathName);
+		if (file.exists() && file.isDirectory()) {
+//			System.out.println("debug checkCreateDirectory - Directory FOUND - lDirectoryPathName:" + lDirectoryPathName);
+			registerMessage ("0>info Found directory: " + lDirectoryPathName);
+			return true;
+		} else {
+			//Create the directory
+			boolean bool = file.mkdir();
+			if(bool){
+//				System.out.println("debug checkCreateDirectory - Directory CREATED - lDirectoryPathName:" + lDirectoryPathName);
+				registerMessage ("0>info Created directory: " + lDirectoryPathName);
+				return true;
+			}else{
+//				System.out.println("debug checkCreateDirectory - Directory CREATE FAILED - lDirectoryPathName:" + lDirectoryPathName);
+				registerMessage ("1>error Directory create failed: " + lDirectoryPathName);
+			}
+		}
+		return false;
 	}
 	
 	static public boolean checkFileName (String inputFileName) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
@@ -188,6 +188,10 @@ class WriteDOMDocBook extends Object {
 	
 //	print DocBook File
 	public void writeDocBook (SchemaFileDefn lSchemaFileDefn) throws java.io.IOException {
+		// check that directory exists
+		if (! DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/DD/")) {
+			return;
+		}		
 		String lFileName = lSchemaFileDefn.relativeFileSpecDDDocXML;
 		String lLabelVersionId = "_" + DMDocument.masterPDSSchemaFileDefn.lab_version_id;
 		String lDOMLabelVersionId = lLabelVersionId;


### PR DESCRIPTION
DocBook generation does not work from any file system location. Added code to check for the specified directory and creates the directory if needed.

Resolves #170
