### PR TITLE
CCB-304 - Cleanup unused Vector classes in IM before 2.0.0.0

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -296,6 +296,7 @@ public class DMDocument extends Object {
 		
 		// The current version is included to allow for -V currentIMVersion
 		alternateIMVersionArr = new ArrayList <String> ();
+		alternateIMVersionArr.add ("1G00");
 		alternateIMVersionArr.add ("1F00");
 		alternateIMVersionArr.add ("1E00");
 		alternateIMVersionArr.add ("1D00");
@@ -1467,6 +1468,13 @@ public class DMDocument extends Object {
 		deprecatedObjects2.add(new DeprecatedDefn ("ASCII_Date", "pds", "ASCII_Date", "", "", "", false));
 		deprecatedObjects2.add(new DeprecatedDefn ("ASCII_Date_Time", "pds", "ASCII_Date_Time", "", "", "", false));
 		deprecatedObjects2.add(new DeprecatedDefn ("ASCII_Date_Time_UTC", "pds", "ASCII_Date_Time_UTC", "", "", "", false));
+
+		deprecatedObjects2.add(new DeprecatedDefn ("Vector", "pds", "Vector", "", "", "", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Vector_Component", "pds", "Vector_Component", "", "", "", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Vector_Cartesian_3", "pds", "Vector_Cartesian_3", "", "", "", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Vector_Cartesian_3_Acceleration", "pds", "Vector_Cartesian_3_Acceleration", "", "", "", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Vector_Cartesian_3_Position", "pds", "Vector_Cartesian_3_Position", "", "", "", false));
+		deprecatedObjects2.add(new DeprecatedDefn ("Vector_Cartesian_3_Velocity", "pds", "Vector_Cartesian_3_Velocity", "", "", "", false));		
 		
 		// get ArrayList for *** testing only ***
 		deprecatedAttrValueArr = new ArrayList <String> ();


### PR DESCRIPTION
The IM contains several generic vector classes that appear to be unused.
Deprecate the following vector classes in the core information model:
			Vector
			Vector_Component
			Vector_Cartesian_3
			Vector_Cartesian_3_Acceleration
			Vector_Cartesian_3_Position
			Vector_Cartesian_3_Velocity

Bugfix  - Add "1G00" to alternateIMVersionArr

Resolves #252
Refs CCB-304

----- REMOVE -----
Title ^^^^ above ^^^^ should follow good commit message best practices wherever possible.

A properly formed git commit subject line should always be able to complete the following sentence:

    If applied, this commit will <your subject line here>
----- REMOVE -----

**Summary***
Brief summary of changes if not sufficiently described by commit messages.

**Test Data and/or Report**
One of the following should be included here:
* Reference to regression test included in code (preferred wherever reasonable)
* Attach test data here + outputs of tests

**Related Issues**
Reference related issues here and use `Fixes` or `Resolves` for closing issues:
* for issues in this repo: #1, #2, #3
* for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
