### PR TITLE
Definition of <external_source_product_identifier> Update

### DIFF
--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Wed Dec 23 09:53:15 EST 2020
+; Thu Dec 24 09:33:58 EST 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Wed Dec 23 09:53:15 EST 2020
+; Thu Dec 24 09:33:58 EST 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/dd11179.pins
+++ b/model-ontology/src/ontology/Data/dd11179.pins
@@ -1,4 +1,4 @@
-; Wed Dec 23 10:04:47 EST 2020
+; Thu Dec 24 09:52:40 EST 2020
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -84291,7 +84291,7 @@
 ([vm.0001_NASA_PDS_1.pds.Header.pds.parsing_standard_id.288436824] of  ValueMeaning
 
 	(beginDate "2009-06-09")
-	(description "The Header is governed by the standard Flexible Image Transport System %28FITS%29, Version 4.0.")
+	(description "The Header is governed by the standard Flexible Image Transport System (FITS), Version 4.0.")
 	(endDate "2019-12-31"))
 
 ([vm.0001_NASA_PDS_1.pds.Header.pds.parsing_standard_id.69962462] of  ValueMeaning


### PR DESCRIPTION
Definition of <external_source_product_identifier> refers to non-existent documentation.

In the definition of <external_source_product_identifier> modify the sentence: "For guidelines on the construction of this identifier, refer to section 2.6.1.2 of the Data Provider's Handbook." to read "For guidelines on the construction of this identifier, refer to section E.2.6.1.2 of the Data Provider's Handbook."

Resolves #275
Refs CCB-313

