### PR TITLE
LDDTool LIDs for XML Schema Products do not contain IM or LDD VIDs

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteCoreXMLSchemaLabel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteCoreXMLSchemaLabel.java
@@ -68,7 +68,10 @@ class WriteCoreXMLSchemaLabel extends Object {
 		prSchematron.println("    xsi:schemaLocation=\"" + DMDocument.masterPDSSchemaFileDefn.nameSpaceURL +  lMasterFileId + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id);		
 		prSchematron.println("    " + DMDocument.masterPDSSchemaFileDefn.nameSpaceURLs +  lMasterFileId + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id + "/" + DMDocument.masterPDSSchemaFileDefn.modelShortName + "_" +  lMasterFileIdUpper + "_" + DMDocument.masterPDSSchemaFileDefn.lab_version_id + ".xsd\">");		
 		prSchematron.println("    <Identification_Area>");
-		String lLID = lSchemaFileDefn.urnPrefix + "system_bundle:xml_schema:" +  lSchemaFileDefn.nameSpaceIdNCLC + "-xml_schema";
+		
+		// generated and write the LID
+		String lLID = lSchemaFileDefn.urnPrefix + "system_bundle:xml_schema:" +  lSchemaFileDefn.nameSpaceIdNCLC + "-xml_schema" + "_" + DMDocument.masterPDSSchemaFileDefn.ont_version_id;
+		if (DMDocument.LDDToolFlag) lLID += "_" + DMDocument.masterLDDSchemaFileDefn.versionId;
 		prSchematron.println("        <logical_identifier>" + lLID.toLowerCase() + "</logical_identifier>");
 		prSchematron.println("        <version_id>" + lSchemaFileDefn.labelVersionId + "</version_id>");
 		prSchematron.println("        <title>" + DMDocument.masterPDSSchemaFileDefn.modelShortName + " XML Schema" + " - " + lSchemaFileDefn.nameSpaceIdNCUC + " V" + lSchemaFileDefn.ont_version_id + "</title>");


### PR DESCRIPTION
LDDTool generated LIDs for XML Schema Label Products do not contain IM or LDD Version Ids. Add the IM and LDD version ids.

   Example original LID : urn:nasa:pds:system_bundle:xml_schema:orex-xml_schema
   Example requested LID : urn:nasa:pds:system_bundle:xml_schema:orex-xml_schema_1.15.0.0_1.1.0.0

Resolves #283
