### PR TITLE
LDDTool - Update JSON output to include dependencies in output

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java
@@ -100,6 +100,14 @@ class WriteDOMDDJSONFile extends Object{
 		prDDPins.println("      " + formValue("Version") + ": " +  formValue(DMDocument.masterPDSSchemaFileDefn.ont_version_id) + " ,");
 		prDDPins.println("      " + formValue("Date") + ": " +  formValue(DMDocument.sTodaysDate) + " ,");
 		prDDPins.println("      " + formValue("Description") + ": " + formValue("This document is a dump of the contents of the PDS4 Data Dictionary") + " ,");
+		String lNSList = formValue("pds");
+		String del = ", ";
+		for (Iterator <SchemaFileDefn> i = DMDocument.LDDSchemaFileSortArr.iterator(); i.hasNext();) {
+			SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();
+			lNSList += del + formValue(lSchemaFileDefn.nameSpaceId);
+//			del = ", ";
+		}
+		prDDPins.println("      " + formValue("namespaces") + ": [" + lNSList + "] ,");
 	}
 	
 	// Format the Boolean String for JSON


### PR DESCRIPTION
Update JSON output to include dependencies in output.

From the current JSON output, there is no way of determining dependencies for the LDDs until you parse the JSON. We should add something to the top of the JSON that includes that.

Resolves #293

