### PR TITLE
CCB-311 - Value meanings for <rule_type> permissible values rewritten

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java
@@ -100,7 +100,7 @@ class WriteDOMDDJSONFile extends Object{
 		prDDPins.println("      " + formValue("Version") + ": " +  formValue(DMDocument.masterPDSSchemaFileDefn.ont_version_id) + " ,");
 		prDDPins.println("      " + formValue("Date") + ": " +  formValue(DMDocument.sTodaysDate) + " ,");
 		prDDPins.println("      " + formValue("Description") + ": " + formValue("This document is a dump of the contents of the PDS4 Data Dictionary") + " ,");
-		String lNSList = formValue("pds");
+		String lNSList = formValue("pds:");
 		String del = ", ";
 		for (Iterator <SchemaFileDefn> i = DMDocument.LDDSchemaFileSortArr.iterator(); i.hasNext();) {
 			SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();

--- a/model-ontology/src/ontology/Data/dd11179.pins
+++ b/model-ontology/src/ontology/Data/dd11179.pins
@@ -1,4 +1,4 @@
-; Wed Jan 13 09:40:55 EST 2021
+; Wed Jan 20 07:57:42 EST 2021
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -81995,25 +81995,25 @@
 ([vm.0001_NASA_PDS_1.pds.DD_Rule_Statement.pds.rule_type.-1850654380] of  ValueMeaning
 
 	(beginDate "2009-06-09")
-	(description "The rule statement type is Report.")
+	(description "Report rules are usually used for information-gathering. If the test succeeds, the associated message is displayed.")
 	(endDate "2019-12-31"))
 
 ([vm.0001_NASA_PDS_1.pds.DD_Rule_Statement.pds.rule_type.-2012458559] of  ValueMeaning
 
 	(beginDate "2009-06-09")
-	(description "The rule statement type is Assert Every.")
+	(description "An Assert Every rule is an extension to the Assert rule that uses the \"every\" qualifier to indicate every member of a defined set.")
 	(endDate "2019-12-31"))
 
 ([vm.0001_NASA_PDS_1.pds.DD_Rule_Statement.pds.rule_type.-976674761] of  ValueMeaning
 
 	(beginDate "2009-06-09")
-	(description "The rule statement type is Assert If.")
+	(description "An Assert IF rule is an extension to the Assert rule that limits the rule to the \"if-then\" pattern.")
 	(endDate "2019-12-31"))
 
 ([vm.0001_NASA_PDS_1.pds.DD_Rule_Statement.pds.rule_type.1970626406] of  ValueMeaning
 
 	(beginDate "2009-06-09")
-	(description "The rule statement type is generic Assert.")
+	(description "Assert rules are usually used for error detection. If the test fails, the associated message is displayed.")
 	(endDate "2019-12-31"))
 
 ([vm.0001_NASA_PDS_1.pds.DD_Value_Domain.pds.unit_of_measure_type.-1176052196] of  ValueMeaning


### PR DESCRIPTION
Modify the value meanings of the permissible values of <rule_type> to be more meaningful.

Assert - Assert rules are usually used for error detection. If the test fails, the associated message is displayed.

Assert Every - An Assert Every rule is an extension to the Assert rule that uses the "every" qualifier to indicate every member of a defined set.

Assert If - An Assert IF rule is an extension to the Assert rule that limits the rule to the "if-then" pattern.

Report - Report rules are usually used for information-gathering. If the test succeeds, the associated message is displayed.

Resolves #296
Refs CCB-311

