### PR TITLE
Issue #301 - LDDTool does not generate the correct namespace for PSA

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -150,6 +150,7 @@ public class DMDocument extends Object {
 	static boolean exportOWLFileFlag = false;
 	static boolean pds4ModelFlag = true;
 	static boolean printNamespaceFlag = false;			// print the configured namespaces to the log
+	static boolean disciplineMissionFlag = false;		//  set by -d; Omit the term "mission" from the namespace of a Mission dictionary
 	static int writeDOMCount = 0;						// LDDParser DOM Error write count; if exportDOMFlag=true then DOM code is executed and so error/warning messages are duplicated in log and txt file.
 	
 	// when true this flag indicates an LDDTool run for a namespace other than pds (i.e., Common)
@@ -703,6 +704,9 @@ public class DMDocument extends Object {
 					System.out.println(" ");
 					System.exit(0);
 				}
+				if (lArg.indexOf('d') > -1) {
+					disciplineMissionFlag = true;
+				}
 				if (lArg.indexOf('D') > -1) {
 					exportDDFileFlag = true;
 				}
@@ -866,17 +870,18 @@ public class DMDocument extends Object {
 			
 			System.out.println(" ");
 			System.out.println("Process control:");
-			System.out.println("  -p, --PDS4      Set the context to PDS4");
-			System.out.println("  -l, --LDD       Process a local data dictionary input file");
-			System.out.println("  -D, --DataDict  Write the Data Dictionary DocBook file.");
-			System.out.println("  -J, --JSON      Write the data dictionary to a JSON formatted file.");
-			System.out.println("  -m, --merge     Generate file to merge the local dictionary into the master dictionary");
-			System.out.println("  -M, --Mission   This option has no effect starting with PDS4 IM Version 1.14.0.0. See the LDDTool User's Manual for more information on how to provide this information.");
-			System.out.println("  -n, --nuance    Write nuance property maps to LDD schema annotation in JSON");
-			System.out.println("  -N, --Namespace Print the list of configured namespaces to the log");
-			System.out.println("  -1, --IM Spec   Write the Information Model Specification for an LDD.");
-			System.out.println("  -v, --version   Returns the LDDTool version number");
-			System.out.println("  -h, --help      Print this message");
+			System.out.println("  -p, --PDS4       Set the context to PDS4");
+			System.out.println("  -l, --LDD        Process a local data dictionary input file");
+//			System.out.println("  -d, --discipline Omit the term \"mission\" from the namespace of a Mission dictionary.");
+			System.out.println("  -D, --DataDict   Write the Data Dictionary DocBook file.");
+			System.out.println("  -J, --JSON       Write the data dictionary to a JSON formatted file.");
+			System.out.println("  -m, --merge      Generate file to merge the local dictionary into the master dictionary");
+			System.out.println("  -M, --Mission    This option has no effect starting with PDS4 IM Version 1.14.0.0. See the LDDTool User's Manual for more information on how to provide this information.");
+			System.out.println("  -n, --nuance     Write nuance property maps to LDD schema annotation in JSON");
+			System.out.println("  -N, --Namespace  Print the list of configured namespaces to the log");
+			System.out.println("  -1, --IM Spec    Write the Information Model Specification for an LDD.");
+			System.out.println("  -v, --version    Returns the LDDTool version number");
+			System.out.println("  -h, --help       Print this message");
 			
 			System.out.println(" ");
 			System.out.println("  -V, --IM Version - E.g., -V 1D00.");

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
@@ -261,20 +261,19 @@ class WriteDOMSchematron extends Object {
 		prSchematron.println("  <sch:ns uri=\"http://www.w3.org/2001/XMLSchema-instance\"" + " prefix=\"xsi\"/>");
 		if (lSchemaFileDefn.nameSpaceIdNC.compareTo(DMDocument.masterNameSpaceIdNCLC) == 0) {
 			// namespaces required: pds - latest version
-			prSchematron.println("  <sch:ns uri=\"http://pds.nasa.gov/pds4/" + DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id + "\" prefix=\"" + DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC + "\"/>");
+			prSchematron.println("  <sch:ns uri=\"" + DMDocument.masterPDSSchemaFileDefn.nameSpaceURL + DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id + "\" prefix=\"" + DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC + "\"/>");
 		} else {
 			// namespaces required: pds
-			prSchematron.println("  <sch:ns uri=\"http://pds.nasa.gov/pds4/" + DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id + "\" prefix=\"" + DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC + "\"/>");
+			prSchematron.println("  <sch:ns uri=\"" + DMDocument.masterPDSSchemaFileDefn.nameSpaceURL + DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id + "\" prefix=\"" + DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC + "\"/>");
 			// namespaces required: ldd
 			String governanceDirectory = "";
-			if (lSchemaFileDefn.isMission) governanceDirectory = lSchemaFileDefn.governanceLevel.toLowerCase() +  "/";
-			prSchematron.println("  <sch:ns uri=\"http://pds.nasa.gov/pds4/" + governanceDirectory + lSchemaFileDefn.nameSpaceIdNC + "/v" + lSchemaFileDefn.ns_version_id + "\" prefix=\"" + lSchemaFileDefn.nameSpaceIdNC + "\"/>");
+			if (lSchemaFileDefn.isMission && ! DMDocument.disciplineMissionFlag) governanceDirectory = lSchemaFileDefn.governanceLevel.toLowerCase() +  "/";
+			prSchematron.println("  <sch:ns uri=\"" + lSchemaFileDefn.nameSpaceURL + governanceDirectory + lSchemaFileDefn.nameSpaceIdNC + "/v" + lSchemaFileDefn.ns_version_id + "\" prefix=\"" + lSchemaFileDefn.nameSpaceIdNC + "\"/>");
 			// namespaces required: all other LDD discipline levels referenced; no mission level allowed
 			for (Iterator<String> i = DMDocument.LDDImportNameSpaceIdNCArr.iterator(); i.hasNext();) {
 				String lNameSpaceIdNC = (String) i.next();
 				String lVersionNSId = "TBD_lVersionNSId";
 				String lNameSpaceURL = "TBD_lNameSpaceURL";
-				
 				// omit this LDD schema file's namespace; namespace used as targetNamespace above
 				if (lNameSpaceIdNC.compareTo(lSchemaFileDefn.nameSpaceIdNC) == 0) continue;
 				


### PR DESCRIPTION
LDDTool does not generate the correct namespace for PSA dictionaries.

The primary namespace declaration in the generated Schematron file a) used the PDS namespace prefix and b) included the "mission" term. To omit the "mission" term, a new option was provided (-d).

Resolves #301

