### PR TITLE
CCB-204 - Item 1 - Type Attribute Check - Reclassify message as Warning

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -1707,7 +1707,8 @@ public class LDDDOMParser extends Object
 					if (isMission)
 						DMDocument.registerMessage ("2>warning Attribute: <" + lDOMAttr.title + "> - The 'type' attribute must have at least one permissible value.");
 					else
-						DMDocument.registerMessage ("2>error Attribute: <" + lDOMAttr.title + "> - The 'type' attribute must have at least one permissible value.");
+//						DMDocument.registerMessage ("2>error Attribute: <" + lDOMAttr.title + "> - The 'type' attribute must have at least one permissible value.");
+						DMDocument.registerMessage ("2>warning Attribute: <" + lDOMAttr.title + "> - The 'type' attribute must have at least one permissible value.");
 				}
 			}
 		}


### PR DESCRIPTION
CCB-204 - Define and enforce best practices for discipline and project dictionaries.

1) Local dictionary attributes named "type" or with names ending in "_type" must have permissible value lists.  In the pds: and discipline namespaces these attributes are associated with search facets as well as value validation.

Reclassify CCB-204 messages written to the output log.  DDWG voted to change the error message to a warning for "type" attribute validation.

Resolves #179
Refs CCB-204

