### PR TITLE
Issue #312 - LDDTool fails to create "All LDD" version of the WebHelp DD

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -164,7 +164,6 @@ public class DMDocument extends Object {
 	static boolean LDDToolAnnotateDefinitionFlag;
 	static String LDDToolSingletonClassTitle = "USER";
 	static DOMClass LDDToolSingletonDOMClass = null;
-	static ArrayList <String> LDDImportNameSpaceIdNCArr = new ArrayList <String> ();
 	
 	static boolean mapToolFlag = false;
 	
@@ -178,10 +177,14 @@ public class DMDocument extends Object {
 	static ArrayList <LDDDOMParser> LDDDOMModelArr;
 	
 	// Schemas, Stewards and Namespaces (SchemaFileDefn)
+	// *** initialized from the config file - maybe rename, to be used only during initialization of LDDSchemaFileSortMap ***
 	static TreeMap <String, SchemaFileDefn> masterAllSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();	// all namespaces in config.properties file.
+	// *** deprecate and only use masterPDSSchemaFileDefn, move  ***
 	static TreeMap <String, SchemaFileDefn> masterSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();		// namespaces that will be written to XML Schema, etc (*** One only, since LDDs are not ingested anymore ***)
-	static ArrayList <SchemaFileDefn> LDDSchemaFileSortArr;
+	// *** to be use only for LDDs ***
 	static TreeMap <String, SchemaFileDefn> LDDSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();		   
+	static ArrayList <SchemaFileDefn> LDDSchemaFileSortArr;
+	static ArrayList <String> LDDImportNameSpaceIdNCArr = new ArrayList <String> ();
 	
 	// Master Schemas, Stewards and Namespaces (SchemaFileDefn)
 	static SchemaFileDefn masterPDSSchemaFileDefn;
@@ -674,7 +677,7 @@ public class DMDocument extends Object {
 					mapToolFlag = true;
 					PDSOptionalFlag = true;
 				}
-				if (lArg.indexOf('d') > -1) {
+				if (lArg.indexOf('t') > -1) {
 					LDDToolAnnotateDefinitionFlag = true;
 				}
 				if (lArg.indexOf('M') > -1) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
@@ -62,13 +62,18 @@ class WriteDOMDocBook extends Object {
 			// the common and all LDDs that are stacked for this run
 			lSchemaFileDefnToWriteArr = new ArrayList <SchemaFileDefn> (DMDocument.LDDSchemaFileSortMap.values());
 		}
-		System.out.println("");
+		
+//		System.out.println("");
 		for (Iterator <SchemaFileDefn> i = lSchemaFileDefnToWriteArr.iterator(); i.hasNext();) {
 			SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();
-			classClassificationMap.put(lSchemaFileDefn.identifier, new ClassClassificationDefnDOM (lSchemaFileDefn.identifier));
-			attrClassificationMap.put(lSchemaFileDefn.identifier, new AttrClassificationDefnDOM (lSchemaFileDefn.identifier));
+//			classClassificationMap.put(lSchemaFileDefn.identifier, new ClassClassificationDefnDOM (lSchemaFileDefn.identifier));
+//			attrClassificationMap.put(lSchemaFileDefn.identifier, new AttrClassificationDefnDOM (lSchemaFileDefn.identifier));
+			classClassificationMap.put(lSchemaFileDefn.nameSpaceIdNC, new ClassClassificationDefnDOM (lSchemaFileDefn.nameSpaceIdNC));
+			attrClassificationMap.put(lSchemaFileDefn.nameSpaceIdNC, new AttrClassificationDefnDOM (lSchemaFileDefn.nameSpaceIdNC));
+//			System.out.println("debug WriteDOMDocBook lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier);
+//			System.out.println("                      lSchemaFileDefn.nameSpaceIdNC:" + lSchemaFileDefn.nameSpaceIdNC);
 		}
-
+		
 		classClassificationMap.put("pds.product", new ClassClassificationDefnDOM ("pds.product"));
 		classClassificationMap.put("pds.pds3", new ClassClassificationDefnDOM ("pds.pds3"));
 		classClassificationMap.put("pds.support", new ClassClassificationDefnDOM ("pds.support"));
@@ -144,7 +149,7 @@ class WriteDOMDocBook extends Object {
 	public void getClassClassification (DOMClass lClass) {
 		if (lClass.isDataType) return;
 		if (lClass.isUnitOfMeasure) return;
-			
+		
 		// classify the class by namespace and other criteria
 		ClassClassificationDefnDOM lClassClassificationDefn = classClassificationMap.get(lClass.nameSpaceIdNC);
 		if (lClassClassificationDefn != null) {			


### PR DESCRIPTION
LDDTool does not generate the complete "All LDD" version of the WebHelp PDS4 Data Dictionary Document.

This bug was caused by a prior fix. The bug caused all the specified LDD content to be ignored. The bug fix causes all of the LDD content to be included.

Resolves #312

