### PR TITLE
LDDTool should write the PSA namespace without Mission

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
@@ -280,7 +280,7 @@ class XML4LabelSchemaDOM extends Object {
 		} else {
 			// namespaces required: ldd - latest version
 			String governanceDirectory = "";
-			if (lSchemaFileDefn.isMission) governanceDirectory = lSchemaFileDefn.governanceLevel.toLowerCase() +  "/";
+			if (lSchemaFileDefn.isMission && ! DMDocument.disciplineMissionFlag) governanceDirectory = lSchemaFileDefn.governanceLevel.toLowerCase() +  "/";
 			prXML.println("    targetNamespace=\"" + lSchemaFileDefn.nameSpaceURL + governanceDirectory + lSchemaFileDefn.nameSpaceIdNC + "/v" + lSchemaFileDefn.ns_version_id + "\"");
 			prXML.println("    xmlns:" + lSchemaFileDefn.nameSpaceIdNC + "=\"" + lSchemaFileDefn.nameSpaceURL + governanceDirectory + lSchemaFileDefn.nameSpaceIdNC + "/v" + lSchemaFileDefn.ns_version_id + "\"");
 


### PR DESCRIPTION
LDDTool does not generate the correct namespace for PSA dictionaries.  Make the update to the XML Schema writer.

Resolves #301

