### PR TITLE
An LDD developer desires to inherit a class defined in an external namespace

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMClass.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMClass.java
@@ -63,6 +63,7 @@ public class DOMClass extends ISOClassOAIS11179 {
 	boolean isFromLDD;								// has been ingested from Ingest_LDD
 	boolean isReferencedFromLDD;				// is a class in the master that is referenced from an LDD
 	boolean isExposed;							// the class is to be exposed in XML Schema - i.e., defined using xs:Element
+	boolean isAssociatedExternalClass;			// the class was defined using DD_Associate_External_Class
 
 	DOMProp hasDOMPropInverse;					// the owning DOMProp of this Class 
 	ArrayList <DOMProtAttr> hasDOMProtAttr;		// the protege attributes to be converted to DOMProp and either DOMAttr or DOMClass
@@ -115,6 +116,7 @@ public class DOMClass extends ISOClassOAIS11179 {
 		includeInThisSchemaFile = false;
 		isFromLDD = false;
 		isReferencedFromLDD = false;
+		isAssociatedExternalClass = false;			// the class was defined using DD_Associate_External_Class
 		
 		hasDOMPropInverse = null;
 		hasDOMProtAttr = new ArrayList <DOMProtAttr> ();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
@@ -1269,23 +1269,28 @@ public abstract class DOMInfoModel extends Object {
 
 		prDOMWriter.println("\n=========================   Attributes  =========================");		
         
-		prDOMWriter.println("-------------------------  ownedAttribute  --------------------------");
+		prDOMWriter.println("\n-------------------------  ownedAttribute  --------------------------");
 		lSortDOMPropArr = sortDOMProp (objClass.ownedAttrArr);
 		for (Iterator <DOMProp> i = lSortDOMPropArr.iterator(); i.hasNext();) {
 			DOMProp lDOMProp = (DOMProp) i.next();
+			prDOMWriter.println("\n    ownedAttrArr prop:" + lDOMProp.identifier);
+			prDOMWriter.println("                 prop:" + lDOMProp.rdfIdentifier);
 			if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMAttr) {
 				DOMAttr lDOMAttr = (DOMAttr) lDOMProp.hasDOMObject;
 				DOMAttrWriter(lDOMAttr, prDOMWriter);
 			}
 		}
 		
-		prDOMWriter.println("-------------------------  ownedAssociation (Class Identifiers) -----");
+		prDOMWriter.println("\n-------------------------  ownedAssociation (Class Identifiers) -----");
 		lSortDOMPropArr = sortDOMProp (objClass.ownedAssocArr);
 		for (Iterator <DOMProp> i = lSortDOMPropArr.iterator(); i.hasNext();) {
 			DOMProp lDOMProp = (DOMProp) i.next();
+			prDOMWriter.println("\n    ownedAssocArr prop:" + lDOMProp.identifier);
+			prDOMWriter.println("                  prop:" + lDOMProp.rdfIdentifier);
 			if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMClass) {
 				DOMClass lDOMClass = (DOMClass) lDOMProp.hasDOMObject;
-				prDOMWriter.println("    ownedAssocArr :" + lDOMClass.identifier);
+				prDOMWriter.println("                 class:" + lDOMClass.identifier);
+				prDOMWriter.println("                 class:" + lDOMClass.rdfIdentifier);
 			}	
 		}
 	}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GenDOMRules.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GenDOMRules.java
@@ -98,7 +98,7 @@ class GenDOMRules extends Object {
 			if ((lClass == null) || (! ((lSchemaFileDefn.nameSpaceIdNC.compareTo(lClass.nameSpaceIdNC) == 0) && lSchemaFileDefn.stewardArr.contains(lClass.steward)))) continue;
 			if (lClass.isUSERClass || lClass.isUnitOfMeasure || lClass.isDataType || lClass.isVacuous) continue;
 			if (lClass.allEnumAttrArr == null || lClass.allEnumAttrArr.isEmpty()) continue;
-
+			
 			// discipline facet and facet group schema rules are hard coded elsewhere.
 			if (lClass.title.compareTo("Discipline_Facets") == 0 || lClass.title.compareTo("Group_Facet1") == 0 || lClass.title.compareTo("Group_Facet2") == 0) continue;
 			
@@ -120,7 +120,7 @@ class GenDOMRules extends Object {
 	public void addClassSchematronRuleEnumerated (String lClassNameSpaceIdNC, String lClassTitle, String lClassSteward, String lDeprecatedClassIdentifier, ArrayList <DOMAttr> lAttrArr) {	
 		for (Iterator <DOMAttr> j = lAttrArr.iterator(); j.hasNext();) {
 			DOMAttr lAttr = (DOMAttr) j.next();
-			String lRuleId = lClassNameSpaceIdNC + ":" + lClassTitle  + "/" + lAttr.nameSpaceIdNC + ":" + lAttr.title;;
+			String lRuleId = lClassNameSpaceIdNC + ":" + lClassTitle  + "/" + lAttr.nameSpaceIdNC + ":" + lAttr.title;
 			DOMRule lRule = DOMInfoModel.masterDOMRuleIdMap.get(lRuleId);
 			if (lRule == null) {
 				lRule = new DOMRule(lRuleId);


### PR DESCRIPTION
LDDTool needs to allow class/attributes defined using DD_Associate_External_Class to be inherited. The class and attribute defined using DD_Associate_External_Class must be defined within context (e.g., xpath) in order to be inherited by one or more sub classes.

Resolves #324
