### PR TITLE
Invalid output schema when trying to set an Internal_Refererence reference_type value set

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -997,6 +997,9 @@ public class LDDDOMParser extends Object
 			}
 		}
 		
+		// validate min and max occurrences
+		validateAssociationCardinalities (lMinimumOccurrences, lMaximumOccurrences, lDOMAttrExt.lddLocalIdentifier);
+		
 		// create a new DOMProp for the cloned lDOMAttr
 		DOMProp lDOMPropAttrExt = new DOMProp ();
 		lDOMPropAttrExt.isAttribute = true;
@@ -1109,10 +1112,6 @@ public class LDDDOMParser extends Object
 			System.out.println("debug get_DD_AEC - lDOMClassExt.localIdentifier:" + lDOMClassExt.localIdentifier);
 			System.out.println("debug get_DD_AEC - lDOMClassExt.definition:" + lDOMClassExt.definition); */
 		}
-		
-		// final validation
-//		validateAssociationCardinalities (lMinimumOccurrences, lMaximumOccurrences, lClassLocalIdentifier);
-//		validateAssociationCardinalities (lMinimumOccurrences, lMaximumOccurrences, lAttrLocalIdentifier);
 		return;
 	}	
 		


### PR DESCRIPTION
Invalid output schema when trying to set an Internal_Reference reference_type value set. The following procedure was not being performed to validate and set the values of min and max occurrences.  The procedure is now being performed.

   validateAssociationCardinalities (lMinimumOccurrences, lMaximumOccurrences

Resolves #331
