### PR TITLE
Issue #361 - LDDTool - Query Model LDD for SKOS Related Values

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMAttr.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMAttr.java
@@ -44,6 +44,7 @@ public class DOMAttr extends ISOClassOAIS11179 {
 	String classNameSpaceIdNC;
 	String submitter;								// submitter for attribute
 	String parentClassTitle;						// class that this attribute is a member of
+	String extrnTitleQM;							// title of external class for query model
 	DOMClass attrParentClass; 						// class instance that this attribute is a member of
 													// *** deprecate *** moved to DOMProp
 	String classConcept;							// for DEC
@@ -145,6 +146,7 @@ public class DOMAttr extends ISOClassOAIS11179 {
 		classWord = "TBD_classWord"; 
 		lddLocalIdentifier = "TBD_lddLocalIdentifier";
 		lddUserAttribute = null;
+		extrnTitleQM = "TBD_extrnTitleQM";
 
 		xmlBaseDataType = "TBD_XML_Base_Data_Type";
 		protValType = "TBD_Protege_Value_type";

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMClass.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMClass.java
@@ -43,6 +43,7 @@ public class DOMClass extends ISOClassOAIS11179 {
 	String baseClassName;							// Fundamental structure class title
 	String localIdentifier;							// used temporarily for ingest of LDD
 	String used;									// MDPTNConfig used flag - Y, N, or I - Inactive
+	String extrnTitleQM;							// title of external class for query model
 	
 	int subClassLevel;
 	boolean isUSERClass;							// The class of all classes
@@ -64,6 +65,7 @@ public class DOMClass extends ISOClassOAIS11179 {
 	boolean isReferencedFromLDD;				// is a class in the master that is referenced from an LDD
 	boolean isExposed;							// the class is to be exposed in XML Schema - i.e., defined using xs:Element
 	boolean isAssociatedExternalClass;			// the class was defined using DD_Associate_External_Class
+	boolean isQueryModel;						// this class was defined DD_Associate_External_Class is a query model 
 
 	DOMProp hasDOMPropInverse;					// the owning DOMProp of this Class 
 	ArrayList <DOMProtAttr> hasDOMProtAttr;		// the protege attributes to be converted to DOMProp and either DOMAttr or DOMClass
@@ -97,6 +99,7 @@ public class DOMClass extends ISOClassOAIS11179 {
 		baseClassName = "TBD_base_class_name";
 		localIdentifier = "TBD_localIdentifier";
 		used = "TBD_used";
+		extrnTitleQM = "TBD_extrnTitleQM";
 		subClassLevel = 0;
 		isUSERClass = false;
 //		isUsedInClass = false;
@@ -117,6 +120,7 @@ public class DOMClass extends ISOClassOAIS11179 {
 		isFromLDD = false;
 		isReferencedFromLDD = false;
 		isAssociatedExternalClass = false;			// the class was defined using DD_Associate_External_Class
+		isQueryModel = false;
 		
 		hasDOMPropInverse = null;
 		hasDOMProtAttr = new ArrayList <DOMProtAttr> ();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISOClassOAIS11179.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISOClassOAIS11179.java
@@ -39,7 +39,7 @@ public class ISOClassOAIS11179 extends ISOClassOAIS {
 	String steward;									// steward
 	String nameSpaceId;								// namespace id - assigned namespace id with colon
 	String nameSpaceIdNC;							// namespace id - assigned namespace id No Colon
-
+	String lddTitle;								// class and attribute title from LDD processing  - DD_Associate_External_Class
 	String anchorString;							// "class_" + lClass.nameSpaceIdNC + "_" + lClass.title
 	
 	boolean isUsedInModel;
@@ -56,7 +56,6 @@ public class ISOClassOAIS11179 extends ISOClassOAIS {
 		steward = "TBD_steward";
 		nameSpaceId = "TBD_namespaceid";
 		nameSpaceIdNC = "TBD_namespaceidNC";
-		
 		anchorString = "TBD_anchorString";
 		
 		isUsedInModel = false;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
@@ -83,12 +83,8 @@ class WriteDOMDocBook extends Object {
 //		System.out.println("");
 		for (Iterator <SchemaFileDefn> i = lSchemaFileDefnToWriteArr.iterator(); i.hasNext();) {
 			SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();
-//			classClassificationMap.put(lSchemaFileDefn.identifier, new ClassClassificationDefnDOM (lSchemaFileDefn.identifier));
-//			attrClassificationMap.put(lSchemaFileDefn.identifier, new AttrClassificationDefnDOM (lSchemaFileDefn.identifier));
 			classClassificationMap.put(lSchemaFileDefn.nameSpaceIdNC, new ClassClassificationDefnDOM (lSchemaFileDefn.nameSpaceIdNC));
 			attrClassificationMap.put(lSchemaFileDefn.nameSpaceIdNC, new AttrClassificationDefnDOM (lSchemaFileDefn.nameSpaceIdNC));
-//			System.out.println("debug WriteDOMDocBook lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier);
-//			System.out.println("                      lSchemaFileDefn.nameSpaceIdNC:" + lSchemaFileDefn.nameSpaceIdNC);
 		}
 		
 		classClassificationMap.put("pds.product", new ClassClassificationDefnDOM ("pds.product"));


### PR DESCRIPTION
Prototype a discipline LDD for SKOS Related Permissible Value Query Models.

The QM_SKOS_Related_Elements Local Data Dictionary (LDD - namespace: “qmsre”) was defined to allow similar permissible (standard) values to be related formally using SKOS relations.

For each PDS4 attribute for which permissible values are to be related, a <DD_Class> is created. Each class in turn uses <DD_Associate_External_Class> to reference a target PDS4 attribute and its PDS4 class. Within the attribute’s <DD_Permissible_Value> the targeted attribute’s value is specified. Each value to be related is then included in a <Terminological_Entry>.  The attribute’s original value is also included in a “preferred” terminological entry.

See attached IngestLDD and output JSON file (files extensions changed to .txt.)

[QM_SKOS_Related_Elements_IngestLDD_XML.txt](https://github.com/NASA-PDS/pds4-information-model/files/6511259/QM_SKOS_Related_Elements_IngestLDD_XML.txt)

[PDS4_QMSRE_1G00_00100_JSON.txt](https://github.com/NASA-PDS/pds4-information-model/files/6511261/PDS4_QMSRE_1G00_00100_JSON.txt)



Resolves #361

