### PR TITLE
Issue #324 - LDDTool Geometry Partitioning Task - Remove Error

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -177,14 +177,20 @@ public class DMDocument extends Object {
 	static ArrayList <LDDDOMParser> LDDDOMModelArr;
 	
 	// Schemas, Stewards and Namespaces (SchemaFileDefn)
+	
 	// *** initialized from the config file - maybe rename, to be used only during initialization of LDDSchemaFileSortMap ***
 	static TreeMap <String, SchemaFileDefn> masterAllSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();	// all namespaces in config.properties file.
+	
 	// *** deprecate and only use masterPDSSchemaFileDefn, move  ***
 	static TreeMap <String, SchemaFileDefn> masterSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();		// namespaces that will be written to XML Schema, etc (*** One only, since LDDs are not ingested anymore ***)
+	
 	// *** to be use only for LDDs ***
 	static TreeMap <String, SchemaFileDefn> LDDSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();		   
 	static ArrayList <SchemaFileDefn> LDDSchemaFileSortArr;
 	static ArrayList <String> LDDImportNameSpaceIdNCArr = new ArrayList <String> ();
+	
+	// *** to be used to detect issues by namespace
+	static ArrayList <String> nameSpaceIdExtrnFlagArr = new ArrayList <String> ();	// <element_flag> set to true in each namespace
 	
 	// Master Schemas, Stewards and Namespaces (SchemaFileDefn)
 	static SchemaFileDefn masterPDSSchemaFileDefn;
@@ -1674,25 +1680,27 @@ public class DMDocument extends Object {
 	static void registerMessage (String lMessage) {
 		DOMMsgDefn lMessageDefn = new DOMMsgDefn (lMessage);
 		mainMsgArr.add (lMessageDefn);
-//		System.out.println ("");
-//		System.out.println ("debug  registerMessage  lMessage:" + lMessage);
-//		System.out.println ("debug  registerMessage  lMessageDefn.msgOrgText:" + lMessageDefn.msgOrgText);
-//		System.out.println ("debug  registerMessage  lMessageDefn.msgCleanText:" + lMessageDefn.msgCleanText);
 		return;
 	}
 	
+	static void registerMessage (String lNameSpaceIdNCLC, String lMessage) {
+		DOMMsgDefn lMessageDefn = new DOMMsgDefn (lMessage);
+		lMessageDefn.nameSpaceIdNCLC = lNameSpaceIdNCLC;
+		mainMsgArr.add (lMessageDefn);
+		return;
+	}	
+	
 	static void printErrorMessages () {
 		String lPreviousGroupTitle = "";
-//		System.out.println (" ");
-//		System.out.println (">> -- Processing Messages --");
 		
 		// first sort error messages
 		TreeMap <String, DOMMsgDefn> lMainMsgMap = new TreeMap <String, DOMMsgDefn> ();
 		for (Iterator <DOMMsgDefn> i = mainMsgArr.iterator(); i.hasNext();) {
 			DOMMsgDefn lMainMsg = (DOMMsgDefn) i.next();
-//			System.out.println ("debug printErrorMessages -SORT- lMainMsg.msgOrgText:" + lMainMsg.msgOrgText + "   lMainMsg.msgTypeLevel:" + lMainMsg.msgTypeLevel + "   lMainMsg.msgOrder.toString():" + lMainMsg.msgOrder.toString());
-//			System.out.println ("debug printErrorMessages -SORT- lMainMsg.msgTypeLevel.substring(0, 2)):" + lMainMsg.msgTypeLevel.substring(0, 2));
-
+			
+			// eliminate certain messages
+			if (nameSpaceIdExtrnFlagArr.contains(lMainMsg.nameSpaceIdNCLC)) continue;
+			
 			// if debugFlag is false, skip debug messages
 			// 0>info, 0>warning, 0>error
 			if (! debugFlag) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMMsgDefn.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMMsgDefn.java
@@ -47,6 +47,7 @@ public class DOMMsgDefn extends Object {
 	String msgOrgText;
 	String msgCleanText;
 	String msgGroupTitle;
+	String nameSpaceIdNCLC;
 
 	public DOMMsgDefn () {
 		// messageLevelArr is initialized (init()) when masterDOMMsgDefn is created in DMDocument
@@ -59,6 +60,7 @@ public class DOMMsgDefn extends Object {
 		msgOrgText = "TBD_msgOrgText";
 		msgCleanText = "TBD_msgCleanText";
 		msgGroupTitle = "TBD_msgGroupTitle";
+		nameSpaceIdNCLC = "TBD_nameSpaceIdNCLC";
 		
 		int lMessageLength = lMessage.length();
 		if (lMessageLength <= 0) return;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -439,7 +439,7 @@ public class LDDDOMParser extends Object
 		scanRulesForExternalNamespaces (lSchemaFileDefn);
 		DMDocument.registerMessage ("0>info getLocalDD.parseDocument.scanRulesForExternalNamespaces() Done");
 		
-		validateReservedNames();
+		validateReservedNames(lSchemaFileDefn);
 		DMDocument.registerMessage ("0>info getLocalDD.parseDocument.validateReservedNames() Done");
 				
 		validateAttributeUsed();
@@ -1873,7 +1873,7 @@ public class LDDDOMParser extends Object
 		return namespaceArr;
 	}
 	
-	private void validateReservedNames () {
+	private void validateReservedNames (SchemaFileDefn lSchemaFileDefn) {
 //		System.out.println("\ndebug validateReservedNames");
 		
 		boolean hasAtLeastOneElementDefined = false;
@@ -1897,7 +1897,9 @@ public class LDDDOMParser extends Object
 		}
 		
 		if ((! hasAtLeastOneElementDefined) && numClasses > 0) {
-			DMDocument.registerMessage ("2>error Class: " + " - At least one class must be defined as an xs:Element. (<element_flag> set to \"true\")");
+			DMDocument.registerMessage (lSchemaFileDefn.nameSpaceIdNCLC, "2>error NameSpaceId:" + lSchemaFileDefn.nameSpaceId + " - At least one class must be defined as an xs:Element. (<element_flag> set to \"true\")");
+		} else {
+			DMDocument.nameSpaceIdExtrnFlagArr.add(lSchemaFileDefn.nameSpaceIdNCLC);
 		}
 		
 		// scan LDD attributes titles and determine if a reserved name has been used.


### PR DESCRIPTION
LDDTool Geometry Partitioning Task - Remove the reported error "At least one class must be defined as an xs:Element. (<element_flag> set to true)". Since the dictionary is partitoned, only one partition is required to have an <element_flag> set to "true".

Resolves #324 
