### PR TITLE
LDDTool Geometry Partitioning - Prepend Inherited-By class to XPath

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -1634,6 +1634,7 @@ public class LDDDOMParser extends Object
 //							if (! isChoiceOrAny) {
 							lDOMProp.valArr.add(lDOMClassComponent.title);
 							lDOMProp.hasDOMObject = lDOMClassComponent;
+							lDOMClassComponent.hasDOMPropInverse = lDOMProp;
 							
 							// get all block headers and components
 							if (lDOMProp.groupName.indexOf("XSChoice#") == 0 || lDOMProp.groupName.indexOf("XSAny#") == 0) {


### PR DESCRIPTION
 Modify the LDDTool schematron rule generator to prepend the title of all inherited-by classes to the xpath of the inherited class.

Resolves #367
Refs CCB-256
