### PR TITLE
Issue #369 - Remove Body_Identification_Base from SCH File

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMRule.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMRule.java
@@ -44,6 +44,8 @@ public class DOMRule  extends ISOClassOAIS11179 {
 	String classSteward;
 	boolean alwaysInclude;		// the rule is to always be included in the schematron file
 	boolean isMissionOnly;		// the rule is to be included in an LDDTool generated .sch file at the mission level
+	boolean isAssociatedExternalClass;			// the class was defined using DD_Associate_External_Class
+	
 	ArrayList <String> letAssignArr;
 	ArrayList <String> letAssignPatternArr;
 	ArrayList <DOMAssert> assertArr;
@@ -60,6 +62,7 @@ public class DOMRule  extends ISOClassOAIS11179 {
 		classSteward = "TBD_classSteward";
 		alwaysInclude = false;
 		isMissionOnly = false;
+		isAssociatedExternalClass = false;
 		
 		letAssignArr = new ArrayList <String>();
 		letAssignPatternArr = new ArrayList <String>();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
@@ -200,19 +200,19 @@ class WriteDOMSchematron extends Object {
 				if (lAssert.assertType.compareTo("RAW") == 0) {	
 					if (lAssert.assertMsg.indexOf("TBD") == 0) {
 						prSchematron.println("      <sch:assert test=\"" + lAssert.assertStmt + "\"/>");						
-						prSchematron.println("        <title>" + lRule.identifier + "/" + lAssert.identifier + "</title>");						
+						prSchematron.println("        <title>" + getRuleTitle (lRule, lAssert) + "</title>");						
 					} else {
 						prSchematron.println("      <sch:assert test=\"" + lAssert.assertStmt + "\">");
-						prSchematron.println("        <title>" + lRule.identifier + "/" + lAssert.identifier + "</title>");						
+						prSchematron.println("        <title>" + getRuleTitle (lRule, lAssert) + "</title>");						
 						prSchematron.println("        " + lAssert.assertMsg + "</sch:assert>");
 					}
 				} else if (lAssert.assertType.compareTo("REPORT") == 0) {
 					if (lAssert.assertMsg.indexOf("TBD") == 0) {
 						prSchematron.println("      <sch:report test=\"" + lAssert.assertStmt + "\"/>");						
-						prSchematron.println("        <title>" + lRule.identifier + "/" + lAssert.identifier + "</title>");						
+						prSchematron.println("        <title>" + getRuleTitle (lRule, lAssert) + "</title>");						
 					} else {
 						prSchematron.println("      <sch:report test=\"" + lAssert.assertStmt + "\">");
-						prSchematron.println("        <title>" + lRule.identifier + "/" + lAssert.identifier + "</title>");						
+						prSchematron.println("        <title>" + getRuleTitle (lRule, lAssert) + "</title>");						
 						prSchematron.println("        " + lAssert.assertMsg + "</sch:assert>");
 					}
 				} else if (lAssert.assertType.compareTo("EVERY") == 0) {
@@ -225,7 +225,7 @@ class WriteDOMSchematron extends Object {
 					}
 					prSchematron.print(lTestValueString);
 					prSchematron.println(")\">");
-					prSchematron.println("        <title>" + lRule.identifier + "/" + lAssert.identifier + "</title>");						
+					prSchematron.println("        <title>" + getRuleTitle (lRule, lAssert) + "</title>");						
 					// print message
 					prSchematron.println("        The attribute " + lRule.attrTitle + lAssert.assertMsg + lTestValueString + ".</sch:assert>");
 				} else if (lAssert.assertType.compareTo("IF") == 0) {
@@ -238,7 +238,7 @@ class WriteDOMSchematron extends Object {
 					}
 					prSchematron.print(lTestValueString);
 					prSchematron.println(") else true ()\">");
-					prSchematron.println("        <title>" + lRule.identifier + "/" + lAssert.identifier + "</title>");						
+					prSchematron.println("        <title>" + getRuleTitle (lRule, lAssert) + "</title>");						
 					// print message
 					prSchematron.println("        The attribute " + lRule.attrTitle + lAssert.assertMsg + lTestValueString + ".</sch:assert>");					
 				}
@@ -246,7 +246,16 @@ class WriteDOMSchematron extends Object {
 			prSchematron.println("    </sch:rule>");
 			prSchematron.println("  </sch:pattern>");
 		} 
-	}	
+	}
+	
+//	get the rule title
+	public String getRuleTitle (DOMRule lRule, DOMAssert lAssert) {
+		String lTitle = lRule.identifier + "/" + lAssert.identifier;
+		if (lRule.isAssociatedExternalClass) {
+			lTitle = lRule.identifier;
+		}
+		return lTitle;
+	}
 	
 //	write the schematron file header
 	public void printSchematronFileHdr (SchemaFileDefn lSchemaFileDefn, PrintWriter prSchematron) {


### PR DESCRIPTION
When using the DD_Associate_External_Class to create an Abstract class, a rule should not be created to validate any attribute of the abstract class. A rule will be created for the attributes of the subclass of the abstract class.

Resolves #369
Refs CCB-256

**Summary***
Removed the code that included Schematron rules for the abstract classes Body_Identification_Base and Frame_Identification_Base. 

**Related Issues**
Continue to debug the new code using DD_Associate_External_Class for the Geometry LDD Partitioning task. The attached includes the Geometry LDD partitioned into two parts, the run command, and before and after schematron files.

[RemoveAbstractClassIssueIssue369.zip](https://github.com/NASA-PDS/pds4-information-model/files/6736956/RemoveAbstractClassIssueIssue369.zip)
