### PR TITLE
Issue #378 - IMTool/LDDTool Cleanup - Remove masterSchemaFileSortMap

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -180,7 +180,7 @@ public class DMDocument extends Object {
 	static TreeMap <String, SchemaFileDefn> masterAllSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();	// all namespaces in config.properties file.
 	
 	// *** deprecate and only use masterPDSSchemaFileDefn, move  ***
-	static TreeMap <String, SchemaFileDefn> masterSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();		// namespaces that will be written to XML Schema, etc (*** One only, since LDDs are not ingested anymore ***)
+//	static TreeMap <String, SchemaFileDefn> masterSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();		// namespaces that will be written to XML Schema, etc (*** One only, since LDDs are not ingested anymore ***)
 	
 	// *** to be use only for LDDs ***
 	static TreeMap <String, SchemaFileDefn> LDDSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();		   
@@ -1098,7 +1098,7 @@ public class DMDocument extends Object {
         		
      			if (lSchemaFileDefn.isMaster) {
 //           		   System.out.println("debug setupNameSpaceInfoAll - set masterPDSSchemaFileDefn - lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier);
-           		   masterSchemaFileSortMap.put(lSchemaFileDefn.identifier, lSchemaFileDefn);
+//           		   masterSchemaFileSortMap.put(lSchemaFileDefn.identifier, lSchemaFileDefn);
           		   masterPDSSchemaFileDefn = lSchemaFileDefn;
            		   masterNameSpaceIdNCLC = lSchemaFileDefn.nameSpaceIdNCLC;
            		   lSchemaFileDefn.isActive = true; // 7777 isActive is set here temporarily until DOM is used; isActive is set above for all IngestLDD
@@ -1120,9 +1120,9 @@ public class DMDocument extends Object {
     		if (printNamespaceFlag || debugFlag) registerMessage ("1>info Configured NameSpaceIds:" + lNamespaceIdArr);
  		
     		// update to masterSchemaFileSortMap to process and write the target LDD
-    		if (DMDocument.LDDToolFlag) {	
- 				masterSchemaFileSortMap.put(masterLDDSchemaFileDefn.identifier, masterLDDSchemaFileDefn);
-    		}
+ //   		if (DMDocument.LDDToolFlag) {	
+ //				masterSchemaFileSortMap.put(masterLDDSchemaFileDefn.identifier, masterLDDSchemaFileDefn);
+ //   		}
         }
 
 /**********************************************************************************************************

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModels.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModels.java
@@ -58,39 +58,34 @@ public class ExportModels extends Object {
 			lWriteModelAttrJSONFile.writeJSONFile (DMDocument.masterPDSSchemaFileDefn);
 		}
 		
-		// get the schema file definitions
-		ArrayList <SchemaFileDefn> lSchemaFileDefnArr = new ArrayList <SchemaFileDefn> (DMDocument.masterSchemaFileSortMap.values());
-		
 		//	write the label schema - new version 4		
-		for (Iterator <SchemaFileDefn> i = lSchemaFileDefnArr.iterator(); i.hasNext();) {
-			SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();
-			if (! lSchemaFileDefn.isActive) continue;
-			
-			//	write the label schema			
-			DMDocument.registerMessage ("0>info " + "writeAllArtifacts - XML Schema - lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier + " - Done");
-			XML4LabelSchemaDOM xml4LabelSchemaDOM = new XML4LabelSchemaDOM ();
-			xml4LabelSchemaDOM.writeXMLSchemaFiles (lSchemaFileDefn, DOMInfoModel.masterDOMClassArr);
-			
-			//  write schematron file
-			WriteDOMSchematron writeDOMSchematron = new WriteDOMSchematron ();
-			writeDOMSchematron.writeSchematronFile(lSchemaFileDefn, DOMInfoModel.masterDOMClassMap);
-			DMDocument.registerMessage ("0>info " + "writeAllArtifacts - Schematron - lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier + " - Done");
-			
-			//  write label file for XML Schema and Schematron
-			WriteCoreXMLSchemaLabel writeCoreXMLSchemaLabel = new WriteCoreXMLSchemaLabel ();
-			writeCoreXMLSchemaLabel.writeFile(lSchemaFileDefn);
-			DMDocument.registerMessage ("0>info " + "writeAllArtifacts - Schema Label - lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier + " - Done");
-		}	
+		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - XML Schema - lSchemaFileDefn.identifier:" + DMDocument.masterPDSSchemaFileDefn.identifier + " - Done");
+		XML4LabelSchemaDOM xml4LabelSchemaDOM = new XML4LabelSchemaDOM ();
+		xml4LabelSchemaDOM.writeXMLSchemaFiles (DMDocument.masterPDSSchemaFileDefn, DOMInfoModel.masterDOMClassArr);
+		
+		//  write schematron file
+		WriteDOMSchematron writeDOMSchematron = new WriteDOMSchematron ();
+		writeDOMSchematron.writeSchematronFile(DMDocument.masterPDSSchemaFileDefn, DOMInfoModel.masterDOMClassMap);
+		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - Schematron - lSchemaFileDefn.identifier:" + DMDocument.masterPDSSchemaFileDefn.identifier + " - Done");
+		
+		//  write label file for XML Schema and Schematron
+		WriteCoreXMLSchemaLabel writeCoreXMLSchemaLabel = new WriteCoreXMLSchemaLabel ();
+		writeCoreXMLSchemaLabel.writeFile(DMDocument.masterPDSSchemaFileDefn);
+		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - Schema Label - lSchemaFileDefn.identifier:" + DMDocument.masterPDSSchemaFileDefn.identifier + " - Done");
 		
 	    // write the Doc Book
 		WriteDOMDocBook lWriteDOMDocBook  = new WriteDOMDocBook (); 
 		lWriteDOMDocBook.writeDocBook(DMDocument.masterPDSSchemaFileDefn);
 		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - DD DocBook Done");
 		
-		// write the new xmi file
-		WriteUML25XMIFile lWriteUML25XMIFile = new WriteUML25XMIFile ();
-		lWriteUML25XMIFile.writeXMIFile (DMDocument.sTodaysDate);
-		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - UML 25 XMI File Done");
+		// write the new xmi file *** Deprecated *** -- now call ExportModelsCustom
+//		WriteUML25XMIFile lWriteUML25XMIFile = new WriteUML25XMIFile ();
+//		lWriteUML25XMIFile.writeXMIFile (DMDocument.sTodaysDate);
+//		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - UML 25 XMI File Done");
+
+//		write the custom files
+//		ExportModelsCustom lExportModelsCustom = new ExportModelsCustom ();
+//		lExportModelsCustom.writeArtifacts (DMDocument.LDDToolFlag);
 		
 		// write the new Neo4J file
 //		WriteNeo4J lWriteNeo4J = new WriteNeo4J ();
@@ -135,18 +130,16 @@ public class ExportModels extends Object {
 		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - JSON Done");
 		
 		// write the LOD SKOS file
-		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - SKOS Done");
-		
-		WriteLODSKOSFileDOM writeLODSKOSDOMFile = new WriteLODSKOSFileDOM ();
-		writeLODSKOSDOMFile.writeDOMSKOSFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecSKOSTTL_DOM);
-		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - SKOS Done");
+//		WriteLODSKOSFileDOM writeLODSKOSDOMFile = new WriteLODSKOSFileDOM ();
+//		writeLODSKOSDOMFile.writeDOMSKOSFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecSKOSTTL_DOM);
+//		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - SKOS Done");
 
-		// write the RDF/OWL file
-		if (! DMDocument.LDDToolFlag) {
-				WriteDOMRDFOWLFile writeDOMRDFOWLFile = new WriteDOMRDFOWLFile ();
-				writeDOMRDFOWLFile.writeOWLFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecOWLRDF_DOM);	
-		}
-		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - RDF/OWL Done");
+//		// write the RDF/OWL file
+//		if (! DMDocument.LDDToolFlag) {
+//				WriteDOMRDFOWLFile writeDOMRDFOWLFile = new WriteDOMRDFOWLFile ();
+//				writeDOMRDFOWLFile.writeOWLFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecOWLRDF_DOM);	
+//		}
+//		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - RDF/OWL Done");
 		
 		// write the 11179 DD Data Element Definition XML Files
 		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - Class Defn Done");
@@ -212,51 +205,44 @@ public class ExportModels extends Object {
 			DMDocument.registerMessage ("0>info " + "writeLDDArtifacts - DD DocBook Done");
 		}
 		
-		// write the OWL File
-		if (DMDocument.exportOWLFileFlag) {
-			WriteDOMRDFOWLFile writeDOMRDFOWLFile = new WriteDOMRDFOWLFile ();
-			writeDOMRDFOWLFile.writeOWLFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecOWLRDF_DOM);
-			DMDocument.registerMessage ("0>info " + "writeLDDArtifacts - OWL File Done");
-		}
+		// write the custom files
+//		ExportModelsCustom lExportModelsCustom = new ExportModelsCustom ();
+//		lExportModelsCustom.writeArtifacts (DMDocument.LDDToolFlag);
 		
-		// get the LDD SchemaFileDefn - should be just one; but the Master must be skipped
-		ArrayList <SchemaFileDefn> lSchemaFileDefnArr = new ArrayList <SchemaFileDefn> (DMDocument.masterSchemaFileSortMap.values());
-		for (Iterator <SchemaFileDefn> i = lSchemaFileDefnArr.iterator(); i.hasNext();) {
-			SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();
-			
-			if (! lSchemaFileDefn.isActive) continue;
-			
-			// skip the master for LDD runs
-			if (lSchemaFileDefn.isMaster) continue;
-			
-			//	write the schema - new version 4
-			XML4LabelSchemaDOM xml4LabelSchemaDOM = new XML4LabelSchemaDOM ();
-			xml4LabelSchemaDOM.writeXMLSchemaFiles (lSchemaFileDefn, lLDDDOMClassArr);
-			DMDocument.registerMessage ("0>info " + "writeAllArtifacts - XML Schema - lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier + " - Done");
-			
-			//  write schematron file
-			WriteDOMSchematron writeDOMSchematron = new WriteDOMSchematron ();
-			writeDOMSchematron.writeSchematronFile(lSchemaFileDefn, lLDDDOMClassMap);
-			DMDocument.registerMessage ("0>info " + "writeAllArtifacts - Schematron - lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier + " - Done");
+		// write the OWL File
+//		if (DMDocument.exportOWLFileFlag) {
+//			WriteDOMRDFOWLFile writeDOMRDFOWLFile = new WriteDOMRDFOWLFile ();
+//			writeDOMRDFOWLFile.writeOWLFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecOWLRDF_DOM);
+//			DMDocument.registerMessage ("0>info " + "writeLDDArtifacts - OWL File Done");
+//		}
+		
+		//	write the schema - new version 4
+		XML4LabelSchemaDOM xml4LabelSchemaDOM = new XML4LabelSchemaDOM ();
+		xml4LabelSchemaDOM.writeXMLSchemaFiles (DMDocument.masterLDDSchemaFileDefn, lLDDDOMClassArr);
+		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - XML Schema - lSchemaFileDefn.identifier:" + DMDocument.masterLDDSchemaFileDefn.identifier + " - Done");
+		
+		//  write schematron file
+		WriteDOMSchematron writeDOMSchematron = new WriteDOMSchematron ();
+		writeDOMSchematron.writeSchematronFile(DMDocument.masterLDDSchemaFileDefn, lLDDDOMClassMap);
+		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - Schematron - lSchemaFileDefn.identifier:" + DMDocument.masterLDDSchemaFileDefn.identifier + " - Done");
 
-			//  write label file for XML Schema and Schematron
-			WriteCoreXMLSchemaLabel writeCoreXMLSchemaLabel = new WriteCoreXMLSchemaLabel ();
-			writeCoreXMLSchemaLabel.writeFile(lSchemaFileDefn);
-			DMDocument.registerMessage ("0>info " + "writeAllArtifacts - Schema Label - lSchemaFileDefn.identifier:" + lSchemaFileDefn.identifier + " - Done");
+		//  write label file for XML Schema and Schematron
+		WriteCoreXMLSchemaLabel writeCoreXMLSchemaLabel = new WriteCoreXMLSchemaLabel ();
+		writeCoreXMLSchemaLabel.writeFile(DMDocument.masterLDDSchemaFileDefn);
+		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - Schema Label - lSchemaFileDefn.identifier:" + DMDocument.masterLDDSchemaFileDefn.identifier + " - Done");
 
-			// write the 11179 JSON file
-			if (DMDocument.exportJSONFileFlag || DMDocument.exportJSONFileAllFlag) {
-				WriteDOMDDJSONFile writeDOMDDJSONFile = new WriteDOMDDJSONFile ();
-				writeDOMDDJSONFile.writeJSONFile ();
-				DMDocument.registerMessage ("0>info " + "writeAllArtifacts - JSON Done");
-			}
+		// write the 11179 JSON file
+		if (DMDocument.exportJSONFileFlag || DMDocument.exportJSONFileAllFlag) {
+			WriteDOMDDJSONFile writeDOMDDJSONFile = new WriteDOMDDJSONFile ();
+			writeDOMDDJSONFile.writeJSONFile ();
+			DMDocument.registerMessage ("0>info " + "writeAllArtifacts - JSON Done");
+		}
 
-			// write the Info Spec file 
-			if (DMDocument.exportSpecFileFlag) {
-				WriteDOMSpecification writeDOMSpecification = new WriteDOMSpecification (DMDocument.docInfo, PDSOptionalFlag); 
-				writeDOMSpecification.printArtifacts();
-				DMDocument.registerMessage ("0>info " + "writeLDDArtifacts - Info Model Spec Done");
-			}
+		// write the Info Spec file 
+		if (DMDocument.exportSpecFileFlag) {
+			WriteDOMSpecification writeDOMSpecification = new WriteDOMSpecification (DMDocument.docInfo, PDSOptionalFlag); 
+			writeDOMSpecification.printArtifacts();
+			DMDocument.registerMessage ("0>info " + "writeLDDArtifacts - Info Model Spec Done");
 		}
 		return;
 	}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GenDOMRules.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GenDOMRules.java
@@ -45,14 +45,24 @@ class GenDOMRules extends Object {
 	
 //	generate schematron rules
 	public void genSchematronRules () throws java.io.IOException {
-		// for each namespace, generate the schematron rules
-		ArrayList <SchemaFileDefn> lSchemaFileDefnArr = new ArrayList <SchemaFileDefn> (DMDocument.masterSchemaFileSortMap.values());
-		for (Iterator <SchemaFileDefn> i = lSchemaFileDefnArr.iterator(); i.hasNext();) {
-			SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();
-			genSchematronRule(lSchemaFileDefn, DOMInfoModel.masterDOMClassMap);
+		// generate the schematron rules for both the common and the master LDD
+		genSchematronRule(DMDocument.masterPDSSchemaFileDefn, DOMInfoModel.masterDOMClassMap);
+		if (DMDocument.LDDToolFlag) {
+			genSchematronRule(DMDocument.masterLDDSchemaFileDefn, DOMInfoModel.masterDOMClassMap);
 		}
 		return;
 	}
+	
+	//	generate schematron rules
+//	public void genSchematronRules () throws java.io.IOException {
+		// for each namespace, generate the schematron rules
+//		ArrayList <SchemaFileDefn> lSchemaFileDefnArr = new ArrayList <SchemaFileDefn> (DMDocument.masterSchemaFileSortMap.values());
+//		for (Iterator <SchemaFileDefn> i = lSchemaFileDefnArr.iterator(); i.hasNext();) {
+//			SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();
+//			genSchematronRule(lSchemaFileDefn, DOMInfoModel.masterDOMClassMap);
+//		}
+//		return;
+//	}
 		
 //	write the schematron rules
 	public void genSchematronRule (SchemaFileDefn lSchemaFileDefn, TreeMap <String, DOMClass> lMasterDOMClassMap) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -412,36 +412,31 @@ public class GetDOMModel extends Object {
 		
 		// 040 - set isActive flag
 		// initialize masterNameSpaceHasMemberArr; used to determine if a file needs to be written.
-		ArrayList <SchemaFileDefn> lSchemaFileDefnArr = new ArrayList <SchemaFileDefn> (DMDocument.masterSchemaFileSortMap.values());
 		ArrayList <String> lNameSpaceHasMemberArr = new ArrayList <String> ();
-		for (Iterator <SchemaFileDefn> i = lSchemaFileDefnArr.iterator(); i.hasNext();) {
-			SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();
-			boolean foundObject = false;
-			for (Iterator <DOMClass> j = DOMInfoModel.masterDOMClassArr.iterator(); j.hasNext();) {
-				DOMClass lSelectedClass = (DOMClass) j.next();
-				if (lSchemaFileDefn.nameSpaceIdNC.compareTo(lSelectedClass.nameSpaceIdNC) == 0) foundObject = true;
-			}
-			for (Iterator <DOMAttr> j = DOMInfoModel.masterDOMAttrArr.iterator(); j.hasNext();) {
-				DOMAttr lSelectedAttr = (DOMAttr) j.next();
-				if (lSchemaFileDefn.nameSpaceIdNC.compareTo(lSelectedAttr.nameSpaceIdNC) == 0) foundObject = true;
-			}
-			for (Iterator <DOMDataType> j = DOMInfoModel.masterDOMDataTypeArr.iterator(); j.hasNext();) {
-				DOMDataType lSelectedDataType = (DOMDataType) j.next();
-				if (lSchemaFileDefn.nameSpaceIdNC.compareTo(lSelectedDataType.nameSpaceIdNC) == 0) foundObject = true;
-			}
-			for (Iterator <DOMUnit> j = DOMInfoModel.masterDOMUnitArr.iterator(); j.hasNext();) {
-				DOMUnit lSelectedUnit = (DOMUnit) j.next();
-				if (lSchemaFileDefn.nameSpaceIdNC.compareTo(lSelectedUnit.nameSpaceIdNC) == 0) foundObject = true;
-			}
-			for (Iterator <PropertyMapsDefn> j = DOMInfoModel.masterPropertyMapsArr.iterator(); j.hasNext();) {
-				PropertyMapsDefn lSelectedPropMap = (PropertyMapsDefn) j.next();
-				if (lSchemaFileDefn.nameSpaceIdNC.compareTo(lSelectedPropMap.namespace_id) == 0) foundObject = true;
-			}
-			
-			if (foundObject) {
-				lSchemaFileDefn.isActive = true;
-				lNameSpaceHasMemberArr.add(lSchemaFileDefn.nameSpaceIdNC);
-			}
+		boolean foundObject = false;
+		for (Iterator <DOMClass> j = DOMInfoModel.masterDOMClassArr.iterator(); j.hasNext();) {
+			DOMClass lSelectedClass = (DOMClass) j.next();
+			if (DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC.compareTo(lSelectedClass.nameSpaceIdNC) == 0) foundObject = true;
+		}
+		for (Iterator <DOMAttr> j = DOMInfoModel.masterDOMAttrArr.iterator(); j.hasNext();) {
+			DOMAttr lSelectedAttr = (DOMAttr) j.next();
+			if (DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC.compareTo(lSelectedAttr.nameSpaceIdNC) == 0) foundObject = true;
+		}
+		for (Iterator <DOMDataType> j = DOMInfoModel.masterDOMDataTypeArr.iterator(); j.hasNext();) {
+			DOMDataType lSelectedDataType = (DOMDataType) j.next();
+			if (DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC.compareTo(lSelectedDataType.nameSpaceIdNC) == 0) foundObject = true;
+		}
+		for (Iterator <DOMUnit> j = DOMInfoModel.masterDOMUnitArr.iterator(); j.hasNext();) {
+			DOMUnit lSelectedUnit = (DOMUnit) j.next();
+			if (DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC.compareTo(lSelectedUnit.nameSpaceIdNC) == 0) foundObject = true;
+		}
+		for (Iterator <PropertyMapsDefn> j = DOMInfoModel.masterPropertyMapsArr.iterator(); j.hasNext();) {
+			PropertyMapsDefn lSelectedPropMap = (PropertyMapsDefn) j.next();
+			if (DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC.compareTo(lSelectedPropMap.namespace_id) == 0) foundObject = true;
+		}
+		if (foundObject) {
+			DMDocument.masterPDSSchemaFileDefn.isActive = true;
+			lNameSpaceHasMemberArr.add(DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC);
 		}
 		
 		if (DMDocument.debugFlag) {		

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFile.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFile.java
@@ -464,14 +464,9 @@ class WriteDOM11179DDPinsFile extends Object{
 		prDDPins.println("	(contact [PDS_Standards_Coordinator])");
 		prDDPins.println("	(organization [" + DMDocument.registeredByValue + "]))");
 		
-		ArrayList <SchemaFileDefn> lSchemaFileDefnArr = new ArrayList <SchemaFileDefn> (DMDocument.masterSchemaFileSortMap.values());		
-		for (Iterator <SchemaFileDefn> i = lSchemaFileDefnArr.iterator(); i.hasNext();) {
-			SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();
-			prDDPins.println("([" + lSchemaFileDefn.identifier + "] of Steward");
-			prDDPins.println("	(contact [PDS_Standards_Coordinator])");
-			prDDPins.println("	(organization [" + DMDocument.registeredByValue + "]))");
-
-		}
+		prDDPins.println("([" + DMDocument.masterPDSSchemaFileDefn.identifier + "] of Steward");
+		prDDPins.println("	(contact [PDS_Standards_Coordinator])");
+		prDDPins.println("	(organization [" + DMDocument.registeredByValue + "]))");
 		
 		// ops is not included as a defined namespace in the SchemaFileDefn array
 		prDDPins.println("([ops] of Steward");

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java
@@ -47,35 +47,14 @@ class WriteDOMDDJSONFile extends Object{
 
 	// write the JSON file
 	public void writeJSONFile () throws java.io.IOException {	
-		// if IMTool, then write separate JSON files for "all", i.e., each namespace
-		// *** modify - only Common should be written; "all" was only used when LDDs were merged into the Common dictionary ***
 		if (! DMDocument.LDDToolFlag) {
-/*			// write one JSON file for all IM content
-			// PDS4_ALL_JSON_1910_DOM
-			String lFileName = DMDocument.masterPDSSchemaFileDefn.relativeFileSpecDOMModelJSON;
-			lFileName = DMDocument.replaceString (lFileName, "PDS_JSON", "ALL_JSON");
-			PrintWriter prDDPins = new PrintWriter(new OutputStreamWriter (new FileOutputStream(new File(lFileName)), "UTF-8"));
-			printPDDPHdr(prDDPins);
-			printPDDPBody ("all", prDDPins);
-			printPDDPFtr(prDDPins);
-			prDDPins.close(); */
-			
-			//	now write a JSON file for each namespace
-			ArrayList <SchemaFileDefn> lSchemaFileDefnArr = new ArrayList <SchemaFileDefn> (DMDocument.masterSchemaFileSortMap.values());
-			
-			//	write a JSON file for each namespace
-			for (Iterator <SchemaFileDefn> i = lSchemaFileDefnArr.iterator(); i.hasNext();) {
-				SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();
-				if (! lSchemaFileDefn.isActive) continue;
-				
-				// PDS4_PDS_JSON_1910_DOM
-				String lFileName2 = lSchemaFileDefn.relativeFileSpecDOMModelJSON;
-				PrintWriter prDDPins2 = new PrintWriter(new OutputStreamWriter (new FileOutputStream(new File(lFileName2)), "UTF-8"));
-				printPDDPHdr(lSchemaFileDefn, prDDPins2);
-				printPDDPBody (lSchemaFileDefn.nameSpaceIdNC, prDDPins2);
-				printPDDPFtr(prDDPins2);
-				prDDPins2.close();
-			}
+			// PDS4_PDS_JSON_1910_DOM
+			String lFileName2 = DMDocument.masterPDSSchemaFileDefn.relativeFileSpecDOMModelJSON;
+			PrintWriter prDDPins2 = new PrintWriter(new OutputStreamWriter (new FileOutputStream(new File(lFileName2)), "UTF-8"));
+			printPDDPHdr(DMDocument.masterPDSSchemaFileDefn, prDDPins2);
+			printPDDPBody (DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC, prDDPins2);
+			printPDDPFtr(prDDPins2);
+			prDDPins2.close();
 		} else {
 			// write the JSON file for the LDD
 			String lFileName = DMDocument.masterLDDSchemaFileDefn.relativeFileSpecDOMModelJSON;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
@@ -57,18 +57,18 @@ class WriteDOMDocBook extends Object {
 		// get the current namespaces and initialize classification maps
 		if (! DMDocument.LDDToolFlag) {
 			// only the common dictionary (pds)
-			lSchemaFileDefnToWriteArr = new ArrayList <SchemaFileDefn> (DMDocument.masterSchemaFileSortMap.values());
+			lSchemaFileDefnToWriteArr = new ArrayList <SchemaFileDefn> ();
+			lSchemaFileDefnToWriteArr.add(DMDocument.masterPDSSchemaFileDefn);
 		} else {
 			// intialize array to capture namespaces to be written
 			ArrayList <String> lDDNamespaceArr = new ArrayList <String> ();
 			lSchemaFileDefnToWriteArr = new ArrayList <SchemaFileDefn> ();
 			
 			// first get the common dictionary
-			ArrayList <SchemaFileDefn> tempSchemaFileDefnToWriteArr = new ArrayList <SchemaFileDefn> (DMDocument.masterSchemaFileSortMap.values());
-            for(SchemaFileDefn lSchemaFileDefn : tempSchemaFileDefnToWriteArr) {
-    			lSchemaFileDefnToWriteArr.add(lSchemaFileDefn);
-    			lDDNamespaceArr.add(lSchemaFileDefn.nameSpaceIdNC);
-            }
+			ArrayList <SchemaFileDefn> tempSchemaFileDefnToWriteArr = new ArrayList <SchemaFileDefn> ();
+			tempSchemaFileDefnToWriteArr.add(DMDocument.masterPDSSchemaFileDefn);
+    		lSchemaFileDefnToWriteArr.add(DMDocument.masterPDSSchemaFileDefn);
+    		lDDNamespaceArr.add(DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC);
             
 			// now add all the LDDs that are stacked for this run
             tempSchemaFileDefnToWriteArr = new ArrayList <SchemaFileDefn> (DMDocument.LDDSchemaFileSortMap.values());


### PR DESCRIPTION
IMTool/LDDTool Cleanup - Remove masterSchemaFileSortMap

IMTool/LDDTool still attempts to process dLDD ingested into Protege. The masterSchemaFileSortMap was used to capture dLDDs that were ingested into the IM Protege DB. Since dLDDs are no longer ingested, the map can be replaced by masterPDSSchemaFileDefn.

Resolves #378
