### PR TITLE
Issue-#398 - Resolve references across a partitioned namespace - 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ pom.xml.versionsBackup
 *.javac
 .gwt/
 target/
+model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser_org.java

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -165,6 +165,9 @@ public class DMDocument extends Object {
 	// when true this flag indicates an LDDTool run for a namespace other than pds (i.e., Common)
 	static boolean LDDToolFlag;
 	
+	// misc flags
+	static boolean debugFlag = true;
+	
 	// in an LDDTool run, when true indicates that a mission LDD is being processed
 	// this flag was deprecated with the addition of <dictionary_type> to Ingest_LDD IM V1E00
 	// however this flag is still needed for LDDTool runs with IM Versions prior to 1E00
@@ -275,9 +278,6 @@ public class DMDocument extends Object {
 
 	// class version identifiers (only updated classes; v1.0.0.0 is assumed)
 	static TreeMap <String, String> classVersionId;
-	
-	// debug flag	
-	static boolean debugFlag = true;
 	
 	// info, warning, and error messages
 	static int msgOrder = 100000;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -51,7 +51,6 @@ public class GetDOMModel extends Object {
 		
 		PDSOptionalFlag = oflag;
 		
-// 333 - Remove the following after updating the writers.
 		// use the master version 
 		DOMInfoModel.ont_version_id = DMDocument.masterPDSSchemaFileDefn.ont_version_id;
 		DOMInfoModel.lab_version_id = DMDocument.masterPDSSchemaFileDefn.lab_version_id;
@@ -229,7 +228,6 @@ public class GetDOMModel extends Object {
 		}
 		DOMInfoModel.masterDOMRuleArr = new ArrayList <DOMRule> (DOMInfoModel.masterDOMRuleIdMap.values());
 
-// 555 usecases
 		// 006 - get usecases from UpperModel.pins file
 /*		lProtPinsDOMModel.getUseCasesPins ();
 		
@@ -249,6 +247,8 @@ public class GetDOMModel extends Object {
 		
 		// 008 - if this is an LDD Tool run, parse the LDD(s)
 		if (DMDocument.LDDToolFlag) {
+			
+			// phase one - parse the Ingest_LDD
 			for (Iterator <SchemaFileDefn> i = DMDocument.LDDSchemaFileSortArr.iterator(); i.hasNext();) {
 				SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();
 				LDDDOMParser lLDDDOMParser = new LDDDOMParser ();
@@ -257,7 +257,13 @@ public class GetDOMModel extends Object {
 				lLDDDOMParser.gSchemaFileDefn = lSchemaFileDefn;	// the schema definition file for this LDDParser.
 				lLDDDOMParser.getLocalDD();
 			}
-		}		
+			
+			// phase 2 - resolve component references (cross namespace DD_Association references)
+			DMDocument.primaryLDDDOMModel.getLocalDDPhase2 ();
+			
+			// phase 3 - add to master and validate
+			DMDocument.primaryLDDDOMModel.getLocalDDPhase3 ();
+		}
 		
 		// 009 - set the attrParentClass (attributes parent class) from the class name (temp fix)
 		DMDocument.masterDOMInfoModel.setAttrParentClass (true); // LDD run (master run is above)


### PR DESCRIPTION
LDDTool was not resolving references across the separate files, even through both files had the same namespace. 

This issue is a result of the Geometry LDD partitioning task converting the single geom IngestLDD file into two or more IngestLDD files to reduce complexity. The issue was resolved by creating a single global intermediate storage for the defined classes and attributes.

Error message was

 >>> ERROR Class:0001_NASA_PDS_1.cart.Map_Projection_Lander Association:geom.Coordinate_Space_Reference Class:geom.Coordinate_Space_Reference - Missing Component Class
 >>> ERROR Association: geom.Coordinate_Space_Reference - Missing Component - Reference Type: component_of

Resolves #398
Refs CCB-256

