### PR TITLE
CCB-329 - Broaden Definition of Attribute aperture

### DIFF
--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Thu Sep 02 18:54:19 EDT 2021
+; Wed Sep 08 12:33:54 EDT 2021
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Thu Sep 02 18:54:18 EDT 2021
+; Wed Sep 08 12:33:54 EDT 2021
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -1200,7 +1200,7 @@
 ;+		(allowed-classes)
 		(create-accessor read-write))
 	(multislot aperture
-;+		(comment "The aperture attribute provides the diameter of an opening, usually circular, that limits the quantity of light that can enter an optical instrument.")
+;+		(comment "The aperture attribute provides a measure of the effective collecting area of the telescope -- its diameter (if single and circular) or its equivalent diameter (if non-circular and/or an array).  For purposes of this definition, aperture efficiency is assumed to be 100 percent.")
 		(type FLOAT)
 		(create-accessor read-write))
 	(multislot property_map_id
@@ -8005,7 +8005,7 @@
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot aperture
-;+		(comment "The aperture attribute provides the diameter of an opening, usually circular, that limits the quantity of light that can enter an optical instrument.")
+;+		(comment "The aperture attribute provides a measure of the effective collecting area of the telescope -- its diameter (if single and circular) or its equivalent diameter (if non-circular and/or an array).  For purposes of this definition, aperture efficiency is assumed to be 100 percent.")
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))

--- a/model-ontology/src/ontology/Data/dd11179.pins
+++ b/model-ontology/src/ontology/Data/dd11179.pins
@@ -1,4 +1,4 @@
-; Thu Jul 15 21:20:55 EDT 2021
+; Wed Sep 08 12:39:13 EDT 2021
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -20155,7 +20155,7 @@
 
 ([DEF.0001_NASA_PDS_1.pds.Telescope.pds.aperture] of  Definition
 
-	(definitionText "The aperture attribute provides the diameter of an opening, usually circular, that limits the quantity of light that can enter an optical instrument.")
+	(definitionText "The aperture attribute provides a measure of the effective collecting area of the telescope -- its diameter %28if single and circular%29 or its equivalent diameter %28if non-circular and%2For an array%29.  For purposes of this definition, aperture efficiency is assumed to be 100 percent.")
 	(isPreferred TRUE))
 
 ([DEF.0001_NASA_PDS_1.pds.Telescope.pds.coordinate_source] of  Definition


### PR DESCRIPTION
CCB-329 - The aperture attribute is defined for optical instruments with circular light collecting openings. Telescopes at radio wavelengths are not necessarily circular and may be arrays. Broadening the definition will make the attribute more useful at all wavelengths.

Change definition of aperture to: "The aperture attribute provides a measure of the effective collecting area of the telescope -- its diameter (if single and circular) or its equivalent diameter (if non-circular and/or an array).  For purposes of this definition, aperture efficiency is assumed to be 100 percent."

Resolves #403
Refs CCB-329

>