### PR TITLE
#170 - LDDTool: DocBook generation does not work from any location

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -56,9 +56,6 @@ import net.sourceforge.argparse4j.inf.Namespace;
  */ 
 public class DMDocument extends Object {
 	
-// change markers
-// 444 - Rules moved to .pins file
-	
 	// environment variables
 	static String lPARENT_DIR;
 	static String lSCRIPT_DIR;
@@ -76,6 +73,8 @@ public class DMDocument extends Object {
 	// process state for used flags, files, and directories
 	static DMProcessState dmProcessState;
 	
+	// set by -p flag; needs to remain however is deprecated for any processing; 
+	// use mastModelId=PDS4 set in config.properties file
 	static boolean PDSOptionalFlag;
 	
 	// configuration file variables
@@ -137,8 +136,7 @@ public class DMDocument extends Object {
 	static String buildIMVersionId = "1.17.0.0";
 	static String buildIMVersionFolderId = "1H00";
 	static String classVersionIdDefault = "1.0.0.0";
-//	static String LDDToolGeometry = "Geometry";
-	static boolean PDS4MergeFlag  = false;				// *** Deprecate ***
+	static boolean PDS4MergeFlag  = false;				// create protege output; not currently used
 //	static boolean LDDClassElementFlag = false;			// if true, write XML elements for classes
 	static boolean LDDAttrElementFlag = false;			// if true, write  XML elements for attributes
 	static boolean LDDNuanceFlag = false;				//
@@ -157,7 +155,7 @@ public class DMDocument extends Object {
 	static boolean exportDDFileFlag = false;
 	static boolean importJSONAttrFlag = false;			// non PDS processing - not currently used
 	static boolean exportOWLFileFlag = false;
-	static boolean pds4ModelFlag = true;
+	static boolean pds4ModelFlag = false;				// set in config.properties files (read by WriteDOMDocBook to exclude PDS3 from generated DD)
 	static boolean printNamespaceFlag = false;			// print the configured namespaces to the log
 	static boolean disciplineMissionFlag = false;		//  set by -d; Omit the term "mission" from the namespace of a Mission dictionary
 	static int writeDOMCount = 0;						// *** Deprecate *** LDDParser DOM Error write count; if exportDOMFlag=true then DOM code is executed and so error/warning messages are duplicated in log and txt file.
@@ -190,9 +188,6 @@ public class DMDocument extends Object {
 	
 	// *** initialized from the config file - maybe rename, to be used only during initialization of LDDSchemaFileSortMap ***
 	static TreeMap <String, SchemaFileDefn> masterAllSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();	// all namespaces in config.properties file.
-	
-	// *** deprecate and only use masterPDSSchemaFileDefn, move  ***
-//	static TreeMap <String, SchemaFileDefn> masterSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();		// namespaces that will be written to XML Schema, etc (*** One only, since LDDs are not ingested anymore ***)
 	
 	// *** to be use only for LDDs ***
 	static TreeMap <String, SchemaFileDefn> LDDSchemaFileSortMap = new TreeMap <String, SchemaFileDefn> ();		   
@@ -294,11 +289,7 @@ public class DMDocument extends Object {
 	static ArrayList <String> propertyMapFileName = new ArrayList <String> ();
 	
 	// command line argument parser
-	static ArgumentParser parser;		
-	
-	// need a place to store the LDD schema file definition until it is created.
-//	static String LDDToolSchemaFileVersionId;
-
+	static ArgumentParser parser;
 
 /**********************************************************************************************************
 	main
@@ -580,18 +571,16 @@ public class DMDocument extends Object {
 		setObjectDeprecatedFlag();
 		
 		// get the 11179 Attribute Dictionary - .pins file
-//		ProtPins11179DD protPins11179DD  = new ProtPins11179DD ();
-//		protPins11179DD.getProtPins11179DD(DMDocument.registrationAuthorityIdentifierValue, DMDocument.dataDirPath + "dd11179.pins");
 		ProtPinsDOM11179DD lProtPinsDOM11179DD  = new ProtPinsDOM11179DD ();
 		lProtPinsDOM11179DD.getProtPins11179DD(DMDocument.registrationAuthorityIdentifierValue, DMDocument.dataDirPath + "dd11179.pins");
 		
 		// get the models
 		GetDOMModelDoc lGetDOMModelDoc = new GetDOMModelDoc();
-		lGetDOMModelDoc.getModels (PDSOptionalFlag, docFileName + ".pins");
+		lGetDOMModelDoc.getModels (docFileName + ".pins");
 		
 		// get the DOM Model
 		GetDOMModel lGetDOMModel = new GetDOMModel();
-		lGetDOMModel.getDOMModel (PDSOptionalFlag, docFileName + ".pins");
+		lGetDOMModel.getDOMModel (docFileName + ".pins");
 		if (debugFlag) DOMInfoModel.domWriter(DOMInfoModel.masterDOMClassArr, "DOMModelListPerm.txt");
 		
 		// export the models
@@ -832,7 +821,6 @@ public class DMDocument extends Object {
         		} else{
         			registerMessage ("3>error Missing schema config item: "+ stewardArrKey);
         		}
-//        		lSchemaFileDefn.setVersionIds();
         		
           		String commentKey = SCHEMA_LITERAL+nameSpaceId + ".comment";
         	    value = prop.getProperty(commentKey);
@@ -934,11 +922,6 @@ public class DMDocument extends Object {
     		}
     		
     		if (printNamespaceFlag || debugFlag) registerMessage ("1>info Configured NameSpaceIds:" + lNamespaceIdArr);
- 		
-    		// update to masterSchemaFileSortMap to process and write the target LDD
- //   		if (DMDocument.LDDToolFlag) {	
- //				masterSchemaFileSortMap.put(masterLDDSchemaFileDefn.identifier, masterLDDSchemaFileDefn);
- //   		}
         }
 
 /**********************************************************************************************************
@@ -1694,16 +1677,6 @@ public class DMDocument extends Object {
 				alternateIMVersionFlag = true;
 			}
 		}
-		
-/*		registerMessage ("1>info " + "The configured IM Versions are:" + alternateIMVersionArr);
-		if (alternateIMVersionArr.contains(lArg)) {
-			alternateIMVersion = lArg;
-			registerMessage ("1>info " + "The provided IM Version " + lArg + " is valid");
-		} else {
-			registerMessage ("3>error " + "The provided IM Version " + lArg + " is not valid");
-			printErrorMessages();
-			System.exit(1);
-		} */
 		return;
 	}
 	

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMProcessState.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMProcessState.java
@@ -342,37 +342,37 @@ public class DMProcessState {
 	
 	public void setRelativeFileSpecModelSpec_DOM (SchemaFileDefn lSchemaFileDefn) {
 		writtenFilesMap.put(lSchemaFileDefn.relativeFileSpecModelSpec_DOM, 1020);
-//		if (lSchemaFileDefn.isLDD) DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/xxx/");
+		// checkCreateDirectory not needed, file is in root directory
 		return;
 	}
 	
 	public void setRelativeFileSpecXMLSchema (SchemaFileDefn lSchemaFileDefn) {
 		writtenFilesMap.put(lSchemaFileDefn.relativeFileSpecXMLSchema, 1030);
-//		if (lSchemaFileDefn.isLDD) DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/xxx/");
+		// checkCreateDirectory not needed, file is in root directory
 		return;
 	}
 	
 	public void setRelativeFileSpecSchematron (SchemaFileDefn lSchemaFileDefn) {
 		writtenFilesMap.put(lSchemaFileDefn.relativeFileSpecSchematron, 1040);
-//		if (lSchemaFileDefn.isLDD) DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/xxx/");
+		// checkCreateDirectory not needed, file is in root directory
 		return;
 	}
 	
 	public void setRelativeFileSpecXMLLabel (SchemaFileDefn lSchemaFileDefn) {
 		writtenFilesMap.put(lSchemaFileDefn.relativeFileSpecXMLLabel, 1080);
-//		if (lSchemaFileDefn.isLDD) DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/xxx/");
+		// checkCreateDirectory not needed, file is in root directory
 		return;
 	}
 	
 	public void setRelativeFileSpecDOMModelJSON (SchemaFileDefn lSchemaFileDefn) {
 		writtenFilesMap.put(lSchemaFileDefn.relativeFileSpecDOMModelJSON, 1100);
-//		if (lSchemaFileDefn.isLDD) DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/xxx/");
+		// checkCreateDirectory not needed, file is in root directory
 		return;
 	}
 	
 	public void setRelativeFileSpecDDCSV (SchemaFileDefn lSchemaFileDefn) {
 		writtenFilesMap.put(lSchemaFileDefn.relativeFileSpecDDCSV, 1110);
-//		if (lSchemaFileDefn.isLDD) DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/xxx/");
+		// checkCreateDirectory not needed, file is in root directory
 		return;
 	}
 	
@@ -384,13 +384,13 @@ public class DMProcessState {
 	
 	public void setRelativeFileSpecLDDPontMerge (SchemaFileDefn lSchemaFileDefn) {
 		writtenFilesMap.put(lSchemaFileDefn.relativeFileSpecLDDPontMerge, 1130);
-//		if (lSchemaFileDefn.isLDD) DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/xxx/");
+		// checkCreateDirectory not needed, file is in root directory
 		return;
 	}
 	
 	public void setRelativeFileSpecReportTXT (SchemaFileDefn lSchemaFileDefn) {
 		writtenFilesMap.put(lSchemaFileDefn.relativeFileSpecReportTXT, 1140);
-//		if (lSchemaFileDefn.isLDD) DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/xxx/");
+		// checkCreateDirectory not needed, file is in root directory
 		return;
 	}
 	
@@ -402,13 +402,13 @@ public class DMProcessState {
 	
 	public void setRelativeFileSpecDDProtPins (SchemaFileDefn lSchemaFileDefn) {
 		writtenFilesMap.put(lSchemaFileDefn.relativeFileSpecDDProtPins, 1160);
-//		if (lSchemaFileDefn.isLDD) DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/xxx/");
+		// checkCreateDirectory not needed, file is in root directory
 		return;
 	}
 	
 	public void setRelativeFileSpecDDProtPinsSN (SchemaFileDefn lSchemaFileDefn) {
 		writtenFilesMap.put(lSchemaFileDefn.relativeFileSpecDDProtPinsSN, 1170);
-//		if (lSchemaFileDefn.isLDD) DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/xxx/");
+		// checkCreateDirectory not needed, file is in root directory
 		return;
 	}
 	

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModels.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModels.java
@@ -36,7 +36,6 @@ import java.util.*;
  *
  */
 public class ExportModels extends Object {
-	boolean PDSOptionalFlag = false;
 	
 	public ExportModels () {
 				
@@ -46,13 +45,17 @@ public class ExportModels extends Object {
 		write the various documents and files
 ***********************************************************************************************************/
 
-	public void writeAllArtifacts () throws java.io.IOException {	    
+	public void writeAllArtifacts () throws java.io.IOException {
+		
+		// check if the export/ directory exists; if not create it
+		DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/");
+		
 	    // write the model specification
 		DMDocument.dmProcessState.setRelativeFileSpecModelSpec_DOM (DMDocument.masterPDSSchemaFileDefn);
-		WriteDOMSpecification writeDOMSpecification = new WriteDOMSpecification(DMDocument.docInfo, PDSOptionalFlag);
+		WriteDOMSpecification writeDOMSpecification = new WriteDOMSpecification(DMDocument.docInfo);
 		writeDOMSpecification.printArtifacts();
 		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - Specification Done");
-		
+				
 		//	write the label schema - new version 4		
 		DMDocument.dmProcessState.setRelativeFileSpecXMLSchema (DMDocument.masterPDSSchemaFileDefn);
 		XML4LabelSchemaDOM xml4LabelSchemaDOM = new XML4LabelSchemaDOM ();
@@ -158,6 +161,10 @@ public class ExportModels extends Object {
 	}
 
 	public void writeLDDArtifacts () throws java.io.IOException {
+		
+		// check if the export directory exists; if not create it
+		DMDocument.checkCreateDirectory (DMDocument.outputDirPath + "export/");
+		
 		// DOM
 		ArrayList <DOMClass> lLDDDOMClassArr = new ArrayList <DOMClass> ();
 		TreeMap <String, DOMClass> lLDDDOMClassMap = new TreeMap <String, DOMClass> ();
@@ -215,7 +222,7 @@ public class ExportModels extends Object {
 		// write the Info Spec file 
 		if (DMDocument.exportSpecFileFlag) {
 			DMDocument.dmProcessState.setRelativeFileSpecModelSpec_DOM (DMDocument.masterLDDSchemaFileDefn);
-			WriteDOMSpecification writeDOMSpecification = new WriteDOMSpecification (DMDocument.docInfo, PDSOptionalFlag); 
+			WriteDOMSpecification writeDOMSpecification = new WriteDOMSpecification (DMDocument.docInfo); 
 			writeDOMSpecification.printArtifacts();
 			DMDocument.registerMessage ("0>info " + "writeLDDArtifacts - Info Model Spec Done");
 		}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -33,10 +33,7 @@ import java.util.*;
 
 public class GetDOMModel extends Object {
 
-//	ISO11179MDR ISO79MDR;
 	ISO11179DOMMDR lISO11179DOMMDR;
-	
-	boolean PDSOptionalFlag = false;
 	
 	public GetDOMModel () {
 	}
@@ -47,9 +44,7 @@ public class GetDOMModel extends Object {
 	  * the document, glossary, etc are handled in GetDOMModelDoc
 ***********************************************************************************************************/
 	
-	public void getDOMModel (boolean oflag, String docFileName)  throws Throwable {
-		
-		PDSOptionalFlag = oflag;
+	public void getDOMModel (String docFileName)  throws Throwable {
 		
 		// use the master version 
 		DOMInfoModel.ont_version_id = DMDocument.masterPDSSchemaFileDefn.ont_version_id;
@@ -238,7 +233,8 @@ public class GetDOMModel extends Object {
 			DOMInfoModel.masterDOMUseCaseMap.put(lUseCase.rdfIdentifier, lUseCase);
 			DOMInfoModel.masterDOMUseCaseIdMap.put(lUseCase.identifier, lUseCase);
 		}
-		DOMInfoModel.masterDOMUseCaseArr = new ArrayList <DOMUseCase> (DOMInfoModel.masterDOMUseCaseIdMap.values()); */
+		DOMInfoModel.masterDOMUseCaseArr = new ArrayList <DOMUseCase> (DOMInfoModel.masterDOMUseCaseIdMap.values());
+*/
 		
 		// 007 - get list of USER attributes (owned attributes)
 		//        This must be done before LDD parsing since it needs the USER attributes

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModelDoc.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModelDoc.java
@@ -44,8 +44,6 @@ public class GetDOMModelDoc extends Object {
 	
 	ArrayList <String> texSectionFormats;
 	
-	boolean PDSOptionalFlag = false;
-	
 	public GetDOMModelDoc () {
 		
 		//	set up the Tex markers *** delete the following. ***
@@ -59,9 +57,7 @@ public class GetDOMModelDoc extends Object {
 	  initialize the models (document, information, data dictionaries) and master dictionaries (attribute and class)
 ***********************************************************************************************************/
 	
-	public void getModels (boolean oflag, String docFileName)  throws Throwable {
-
-		PDSOptionalFlag = oflag;
+	public void getModels (String docFileName)  throws Throwable {
 
 		// get the Spec Document Information from the Protege DMDocuemt Pins file
 		ProtPins protPinsInst = new ProtPins();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSpecification.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSpecification.java
@@ -44,7 +44,7 @@ public class WriteDOMSpecification extends Object {
 	ArrayList <String> emwfHTML;
 	
 	boolean includeAllAttrFlag = false;
-	boolean PDSOptionalFlag = false;
+	boolean PDSOptionalFlag = false;		// to be deprecated in WriteDOMSpecification
 	boolean lDebugPrint = false;
 	int figNum;
 	Date rTodaysDate;
@@ -53,9 +53,8 @@ public class WriteDOMSpecification extends Object {
 	
 	PrintWriter prhtml;
 	
-	public WriteDOMSpecification (DocDefn lDocInfo, boolean lflag) {
+	public WriteDOMSpecification (DocDefn lDocInfo) {
 		docInfo = lDocInfo;
-		PDSOptionalFlag = lflag;
 		
 		//	set up the HTML Headers
 		begSectionFormats = new ArrayList <String>();


### PR DESCRIPTION
Issue #170 - LDDTool: DocBook generation does not work from any file system location - redux

Looks like lddtool must be run specifically from /path/to/lddtool-11.2.2 in order to generate a DocBook. Lddtool still requires the existence of export/, i.e. it fails if there is no subdirectory export/ in the directory you're running from.
LDDTool now ensures that the directory export/ exists.

Resolves #170

