### PR TITLE
#418 - Inconsistent naming of JSON schema files

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -1506,7 +1506,7 @@ public class DMDocument extends Object {
                 .type(Boolean.class)
                 .nargs(1)
                 .action(Arguments.storeTrue())
-                .help("This option has no effect starting with PDS4 IM Version 1.14.0.0. See the LDDTool User's Manual for more information on how to provide this information.");
+                .help("This option has no effect starting with PDS4 IM Version 1.14.0.0. See the LDDTool Usage document for more information on how to provide this information.");
         
         parser.addArgument("-n", "--nuance")
                 .dest("n")

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/SchemaFileDefn.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/SchemaFileDefn.java
@@ -251,7 +251,7 @@ public class SchemaFileDefn {
 			relativeFileNameXMLSchema2 = DMDocument.mastModelId + "_" + nameSpaceIdNCUC + "_" + lLabelVersionId + "_" + lab_version_id + ".xsd";
 			relativeFileNameSchematron = DMDocument.mastModelId + "_" + nameSpaceIdNCUC + "_" + lab_version_id + ".sch";
 			relativeFileSpecXMLLabel = DMDocument.outputDirPath + "SchemaXML4/" + DMDocument.mastModelId + "_" + nameSpaceIdNCUC + "_" + lab_version_id + ".xml";
-			relativeFileSpecDOMModelJSON = DMDocument.outputDirPath + "export/JSON/" + DMDocument.mastModelId + "_" + nameSpaceIdNCUC + "_" + "JSON" + "_" + lab_version_id + ".JSON";	
+			relativeFileSpecDOMModelJSON = DMDocument.outputDirPath + "export/JSON/" + DMDocument.mastModelId + "_" + nameSpaceIdNCUC + "_" + lab_version_id + ".JSON";	
 			relativeFileSpecDDCSV = DMDocument.outputDirPath + "export/csv/" + DMDocument.mastModelId + "_" + nameSpaceIdNCUC + "_" + lab_version_id;			
 			relativeFileSpecCCSDSCSV = DMDocument.outputDirPath + "export/csv/" + DMDocument.mastModelId + "_" + nameSpaceIdNCUC + "_CCSDS"  + "_" + lab_version_id;			
 		} else {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java
@@ -78,7 +78,7 @@ class WriteDOMDDJSONFile extends Object{
 		prDDPins.println("      " + formValue("Title") + ": " + formValue("PDS4 Data Dictionary") + " ,");
 		prDDPins.println("      " + formValue("IM Version") + ": " +  formValue(DMDocument.masterPDSSchemaFileDefn.ont_version_id) + " ,");
 		prDDPins.println("      " + formValue("LDD Version") + ": " +  formValue(lSchemaFileDefn2.ont_version_id) + " ,");
-		prDDPins.println("      " + formValue("Date") + ": " +  formValue(DMDocument.sTodaysDate) + " ,");
+		prDDPins.println("      " + formValue("Date") + ": " +  formValue(DMDocument.masterTodaysDateTimeUTCwT) + " ,");
 		prDDPins.println("      " + formValue("Description") + ": " + formValue("This document is a dump of the contents of the PDS4 Data Dictionary") + " ,");
 		String lNSList = formValue("pds:");
 		String del = ", ";


### PR DESCRIPTION
#418 - Inconsistent naming of JSON schema files

The file name formation rule for the JSON file is not consistent with the rule for other LDDTool generated operational files, for example the XML Schema file, PDS4_PDS_1H00.xsd.

Change the JSON file name from  PDS4_PDS_JSON_1G00.JSON to  PDS4_PDS_1G00.JSON.

Additional minor changes included are:
1) Changed the date format in the JSON file header.
2) Updated the -help description for the -M command line option

Resolves #418

