### PR TITLE
Issue #239 - Refactor Class information from config to Data Dictionary Protege ontology - Phase 1

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -68,7 +68,8 @@ public class DMDocument extends Object {
 	static final String upperModelFileName  = "UpperModel.pont";
 	
 	// variables for the class %3ACLIPS_TOP_LEVEL_SLOT_CLASS
-	static final String TopLevelAttrClassName  = "%3ACLIPS_TOP_LEVEL_SLOT_CLASS";
+	static final String TopLevelAttrClassName = "%3ACLIPS_TOP_LEVEL_SLOT_CLASS";
+	static final String ANAME = "%3ANAME";
 	
 	// process state for used flags, files, and directories
 	static DMProcessState dmProcessState;
@@ -140,7 +141,9 @@ public class DMDocument extends Object {
 //	static boolean LDDClassElementFlag = false;			// if true, write XML elements for classes
 	static boolean LDDAttrElementFlag = false;			// if true, write  XML elements for attributes
 	static boolean LDDNuanceFlag = false;				//
-
+	static boolean overWriteClass = false;				// use dd11179.pins to provide class disp information; also deprecation flags.
+	static boolean useMDPTNConfig = true;				// use MDPTNConfigClassDisp in protPont class parsing
+	
 	// alternate IM Version
 	// if no option "V" is provided on the command line, then the default is the current IM version.
 	static boolean alternateIMVersionFlag = false;
@@ -952,49 +955,6 @@ public class DMDocument extends Object {
 		  }
 		  return buf.toString();
 		}
-	
-	/**
-	 *   get the disposition of a class (from Protege)
-	 */
-	static public DOMClass getDOMClassDisposition (DOMClass lClass, String lClassName, boolean isFromProtege) {
-		// get disposition identifier - if isFromProtege, then the identifier is set else it is not since it is from an LDD.
-		String lDispId = lClass.subModelId + "." + registrationAuthorityIdentifierValue + "." + lClassName;
-		if (! isFromProtege) lDispId = "LDD_" + lDispId;
-		DispDefn lDispDefn = masterClassDispoMap2.get(lDispId);
-		if (lDispDefn != null) {
-			lClass.used = lDispDefn.used;
-			lClass.section = lDispDefn.section;
-			String lDisp = lDispDefn.disposition;
-			lClass.steward = lDispDefn.intSteward;
-			String lClassNameSpaceIdNC = lDispDefn.intNSId;
-			lClass.nameSpaceIdNC = lClassNameSpaceIdNC;
-			lClass.nameSpaceId = lClassNameSpaceIdNC + ":";
-			
-			// if from protege, the identifier needs to be set; if from LDD it cannot be set here.
-			if (isFromProtege) lClass.identifier = DOMInfoModel.getClassIdentifier(lClassNameSpaceIdNC, lClassName);
-			lClass.isMasterClass = true;
-			if (lDisp.indexOf("V") > -1) {
-				lClass.isVacuous = true;
-			}
-			if (lDisp.indexOf("S") > -1) {
-				lClass.isSchema1Class = true;
-			}
-			if (lDisp.indexOf("R") > -1) {
-				lClass.isRegistryClass = true;
-			}
-			if (lDisp.indexOf("T") > -1) {
-				lClass.isTDO = true;
-			}
-			if (lDisp.indexOf("d") > -1) {
-				lClass.isDataType = true;
-			}
-			if (lDisp.indexOf("u") > -1) {
-				lClass.isUnitOfMeasure = true;
-			}
-			return lClass;
-		}
-		return null;
-	}		
 	
 /**********************************************************************************************************
 	set object flags, e.g., deprecated

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMClass.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMClass.java
@@ -90,6 +90,19 @@ public class DOMClass extends ISOClassOAIS11179 {
 
 	ArrayList <DOMAttr> allEnumAttrArr;						// all enumerated attributes, this.class and all superclasses
 	
+	String dataIdentifier; 						// data identifier
+	String ocDataIdentifier;					// object class
+	String desDataIdentifier;					// designation 
+	String defDataIdentifier;					// definition
+	String teDataIdentifier;					// terminological entry
+	String administrationRecordValue;
+	String registeredByValue;
+//	
+//  **** move registeredByValue to ISOClassOAIS11179
+//	**** deprecate registrationAuthorityIdentifierValue and use ISOClassOAIS11179.regAuthId
+//  **** add both to DOMProtAttr ???
+// 	String registrationAuthorityIdentifierValue;
+	
 	public DOMClass () {
 		section = "TBD_section";
 		role = "TBD_role";
@@ -145,6 +158,13 @@ public class DOMClass extends ISOClassOAIS11179 {
 		ownedPropNSTitleMap = new TreeMap <String, DOMProp> ();
 		ownedAttrAssocNSTitleMap = new TreeMap <String, DOMAttr> ();
 		allEnumAttrArr = new ArrayList <DOMAttr> ();
+		
+		ocDataIdentifier = "TBD_ocDataIdentifier";				// data element 
+		desDataIdentifier = "TBD_desDataIdentifier";			// designation 
+		defDataIdentifier = "TBD_defDataIdentifier";			// definition
+		teDataIdentifier = "TBD_teDataIdentifier";				// terminlogical entry			
+		administrationRecordValue = "TBD_administrationRecordValue";                                                               
+		registeredByValue = "TBD_registeredByValue";                   
 	}
 	
 	public String getSection() {
@@ -168,12 +188,16 @@ public class DOMClass extends ISOClassOAIS11179 {
 			this.section = lDispDefn.section;
 			String lDisp = lDispDefn.disposition;
 			this.steward = lDispDefn.intSteward;
-			String lClassNameSpaceIdNC = lDispDefn.intNSId;
+			String lClassNameSpaceIdNC = lDispDefn.intNSId; // needed below for identifier
 			this.nameSpaceIdNC = lClassNameSpaceIdNC;
 			this.nameSpaceId = lClassNameSpaceIdNC + ":";
 			
 			// if from protege, the identifier needs to be set; if from LDD it cannot be set here.
-			if (isFromProtege) this.identifier = DOMInfoModel.getClassIdentifier(lClassNameSpaceIdNC, this.title);
+			if (isFromProtege) {
+				this.identifier = DOMInfoModel.getClassIdentifier(lClassNameSpaceIdNC, this.title);
+				set11179Attr (this.identifier);
+//				System.out.println("debug getDOMClassDisposition this.identifier:" + this.identifier);
+			}
 			this.isMasterClass = true;
 			if (lDisp.indexOf("V") > -1) {
 				this.isVacuous = true;
@@ -196,5 +220,59 @@ public class DOMClass extends ISOClassOAIS11179 {
 			return true;
 		}
 		return false;
+	}
+	
+	/**
+	 *   get the disposition of a class (from Protege)
+	 */
+	public boolean getDOMClassDisposition2 () {
+		if (this.title.compareTo(DMDocument.TopLevelAttrClassName) != 0)
+			this.nameSpaceIdNC = DMDocument.masterNameSpaceIdNCLC;
+		else 
+			this.nameSpaceIdNC = "tbd";  // %3ACLIPS_TOP_LEVEL_SLOT_CLASS is not in the Common namespace
+		this.nameSpaceId = this.nameSpaceIdNC + ":";
+		this.identifier = DOMInfoModel.getClassIdentifier(this.nameSpaceIdNC, this.title);
+		set11179Attr (this.identifier);
+		System.out.println("debug getDOMClassDisposition2 this.identifier:" + this.identifier);
+		return true;
+	}	
+	
+	public void set11179Attr (String lIdentifier) {
+		// object class identifiers	
+		dataIdentifier = lIdentifier;
+		ocDataIdentifier = "OC." + lIdentifier;				// data element
+		desDataIdentifier = "DES." + lIdentifier;			// designation 
+		defDataIdentifier = "DEF." + lIdentifier;			// definition
+		teDataIdentifier = "TE." + lIdentifier;				// terminological entry		
+	}
+	
+	static ArrayList <DOMClass> sortDOMClass (ArrayList <DOMClass> ISOArr) {
+		TreeMap <String, DOMClass> lISOMap = new TreeMap <String, DOMClass> ();
+		for (Iterator<DOMClass> i = ISOArr.iterator(); i.hasNext();) {
+			DOMClass lISO = (DOMClass) i.next();
+			lISOMap.put(lISO.identifier, lISO);
+		}
+		ArrayList <DOMClass> lISOArr = new ArrayList <DOMClass> (lISOMap.values());
+		return lISOArr;
+	}
+	
+	static ArrayList <DOMAttr> sortDOMAttr (ArrayList <DOMAttr> ISOArr) {
+		TreeMap <String, DOMAttr> lISOMap = new TreeMap <String, DOMAttr> ();
+		for (Iterator<DOMAttr> i = ISOArr.iterator(); i.hasNext();) {
+			DOMAttr lISO = (DOMAttr) i.next();
+			lISOMap.put(lISO.identifier, lISO);
+		}
+		ArrayList <DOMAttr> lISOArr = new ArrayList <DOMAttr> (lISOMap.values());
+		return lISOArr;
+	}
+	
+	static ArrayList <DOMProp> sortDOMProp (ArrayList <DOMProp> ISOArr) {
+		TreeMap <String, DOMProp> lISOMap = new TreeMap <String, DOMProp> ();
+		for (Iterator<DOMProp> i = ISOArr.iterator(); i.hasNext();) {
+			DOMProp lISO = (DOMProp) i.next();
+			lISOMap.put(lISO.identifier, lISO);
+		}
+		ArrayList <DOMProp> lISOArr = new ArrayList <DOMProp> (lISOMap.values());
+		return lISOArr;
 	}
 }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
@@ -147,7 +147,6 @@ public abstract class DOMInfoModel extends Object {
 	static TreeMap <String, PermValueDefn> masterValueMeaningMap;
 	
 //  Parsed Classes, Props, and Attributes
-	static ArrayList <DOMClass> parsedClassArr;
 	static TreeMap <String, DOMClass> parsedClassMap;
 	
 	static ArrayList <DOMProtAttr> parsedProtAttrArr;
@@ -360,6 +359,30 @@ public abstract class DOMInfoModel extends Object {
 		texSectionFormats.add("\\subsubsection");
 	}
 
+/**********************************************************************************************************
+		getters and setters
+***********************************************************************************************************/
+	
+	static public ArrayList <DOMClass> getMasterDOMClassArr () {
+		return masterDOMClassArr;
+	}	
+	
+	static public ArrayList <DOMProp> getMasterDOMPropArr () {
+		return new ArrayList <DOMProp> (masterDOMPropIdMap.values());
+	}
+	
+	static public ArrayList <DOMAttr> getMasterDOMAttrArr () {
+		return masterDOMAttrArr;
+	}
+	
+	static public ArrayList <DOMDataType> getMasterDOMDataTypeArr () {
+		return masterDOMDataTypeArr;
+	}
+	
+	static public ArrayList <DOMUnit> getMasterDOMUnitArr () {
+		return masterDOMUnitArr;
+	}
+	
 /**********************************************************************************************************
 		miscellaneous routines
 ***********************************************************************************************************/
@@ -920,7 +943,7 @@ public abstract class DOMInfoModel extends Object {
 		return lRefTypeArr;
 	}
 	
-	// clone an attribute 
+	// clone an attribute *** Move to GetCSVMetadataFile and remove here ***
 	static public DOMAttr cloneDOMAttr (String lClassNameSpaceIdNC, String lClassTitle, String lAttrNameSpaceIdNC, String lAttrTitle, DOMAttr lOrgAttr) {
 		DOMAttr lNewAttr = new DOMAttr ();				              					              
 //		lNewAttr.uid = lOrgAttr.uid;										              
@@ -1102,6 +1125,8 @@ public abstract class DOMInfoModel extends Object {
 		TreeMap <String, DOMProp> lDOMPropMap = new TreeMap <String, DOMProp>();
 		for (Iterator<DOMProp> i = DOMInfoModel.masterDOMPropArr.iterator(); i.hasNext();) {
 			DOMProp lDOMProp = (DOMProp) i.next();
+			if (lDOMProp.isInactive) continue;
+			if (lDOMProp.title.compareTo("%3ANAME") == 0) continue;
 			lDOMPropMap.put(lDOMProp.sortKeyIMSPec, lDOMProp);
 		}
 		ArrayList <DOMProp> lDOMPropArr = new ArrayList <DOMProp>(lDOMPropMap.values());	

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GenDOMRules.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GenDOMRules.java
@@ -105,6 +105,7 @@ class GenDOMRules extends Object {
 			DOMClass lClass = (DOMClass) i.next();
 			if ((lClass == null) || (! ((lSchemaFileDefn.nameSpaceIdNC.compareTo(lClass.nameSpaceIdNC) == 0) && lSchemaFileDefn.stewardArr.contains(lClass.steward)))) continue;
 			if (lClass.isUSERClass || lClass.isUnitOfMeasure || lClass.isDataType || lClass.isVacuous) continue;
+			if (lClass.isInactive) continue;
 			if (lClass.allEnumAttrArr == null || lClass.allEnumAttrArr.isEmpty()) continue;
 			
 			// discipline facet and facet group schema rules are hard coded elsewhere.

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -296,10 +296,15 @@ public class GetDOMModel extends Object {
 		// 016 - set the attribute isUsedInClass flag				
 		DMDocument.masterDOMInfoModel.setMasterAttrisUsedInClassFlag ();
 		
-		// 017 - overwrite master attributes from the 11179 DD
+		// 017a - overwrite master attributes from the 11179 DD
 		//     - either import from JSON 11179 file or overwrite from 11179 dictionary
 		//		Overwrite is needed to set classes and attribute defined in protege but not in JSON11179 ???		
 		lISO11179DOMMDR.OverwriteFrom11179DataDict();
+		
+		// 017b - overwrite master classes from the 11179 DD
+		//     - either import from JSON 11179 file or overwrite from 11179 dictionary
+		//		Overwrite is needed to set classes and attribute defined in protege but not in JSON11179 ???
+		if (DMDocument.overWriteClass) lISO11179DOMMDR.OverwriteClassFrom11179DataDict();
 		
 		// 018 - overwrite any LDD attributes from the cloned USER attributes
 		//       this is not really needed since the definitions are in the external class
@@ -313,6 +318,9 @@ public class GetDOMModel extends Object {
 		}
 		
 		// ******* overwrite completed - start final cleanup *******
+		
+		// 018.5 - propagate the class.inactive flag; these are classes with "I" (Ignore) or "N" (not used) use flags.
+		DMDocument.masterDOMInfoModel.setInactiveFlag ();
 		
 		// 019 - general master attribute fixup
 		// anchorString; sort_identifier; sort attribute.valArr
@@ -412,7 +420,7 @@ public class GetDOMModel extends Object {
 			if (lAttr != null) lAttr.isExposed = true;
 		}
 		
-		// 040 - set isActive flag
+		// 040 - set isActive flag for masterPDSSchemaFileDefn
 		// initialize masterNameSpaceHasMemberArr; used to determine if a file needs to be written.
 		ArrayList <String> lNameSpaceHasMemberArr = new ArrayList <String> ();
 		boolean foundObject = false;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISO11179DOMMDR.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISO11179DOMMDR.java
@@ -242,6 +242,110 @@ class ISO11179DOMMDR extends Object {
 		}
 	}
 	
+//	scan through the master class list and overwrite with the latest from the 11179 DD database.
+	public void OverwriteClassFrom11179DataDict () {
+		HashMap <String, ArrayList<String>> lInstMap = new HashMap <String, ArrayList<String>> ();
+		String lSuffix;
+		String lInstId;
+		String lVal;
+		boolean lDebugFlag = false;	
+		
+		// iterate through the master attribute array
+		for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
+			DOMClass lDOMClass = (DOMClass) i.next();
+			if (lDOMClass.isFromLDD) continue;			
+			lSuffix = DOMInfoModel.getClassIdentifier (lDOMClass.nameSpaceIdNC, lDOMClass.title);
+			lInstId = "ObjectClass" + "." + "OC" + "." + lSuffix;		
+			InstDefn lOCInst = DOMInfoModel.master11179DataDict.get(lInstId);
+			if (lOCInst != null) {
+				lInstMap = lOCInst.genSlotMap;
+
+				// update used
+				lVal = ProtPinsDOM11179DD.getStringValueUpdate (false, lInstMap, "used", lDOMClass.used);                        
+				if (lVal != null) {
+					if (lDebugFlag) { System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId + " - updating Class.steward:" + lDOMClass.used + "  - with lVal:" + lVal); }
+					lDOMClass.used = lVal;
+				}
+
+				// update section
+				lVal = ProtPinsDOM11179DD.getStringValueUpdate (false, lInstMap, "section", lDOMClass.section);                        
+				if (lVal != null) {
+					if (lDebugFlag) { System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId + " - updating Class.steward:" + lDOMClass.section + "  - with lVal:" + lVal); }
+					lDOMClass.section = lVal;
+				}
+
+				// update steward
+				lVal = ProtPinsDOM11179DD.getStringValueUpdate (false, lInstMap, "steward", lDOMClass.steward);                        
+				if (lVal != null) {
+					if (lDebugFlag) { System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId + " - updating Class.steward:" + lDOMClass.steward + "  - with lVal:" + lVal); }
+					lDOMClass.steward = lVal;
+				}
+
+				// update nameSpaceIdNC
+				lVal = ProtPinsDOM11179DD.getStringValueUpdate (false, lInstMap, "nameSpaceIdNC", lDOMClass.nameSpaceIdNC);                        
+				if (lVal != null) {
+					if (lDebugFlag) { System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId + " - updating Class.steward:" + lDOMClass.nameSpaceIdNC + "  - with lVal:" + lVal); }
+					lDOMClass.nameSpaceIdNC = lVal;
+				}
+
+				// update isVacuous
+				lVal = ProtPinsDOM11179DD.getStringValueUpdate (false, lInstMap, "isVacuous", "false");                        
+				if (lVal != null && lVal.compareTo("true") == 0) {
+					if (lDebugFlag) { System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId + " - updating Class.steward:" + lDOMClass.isVacuous + "  - with lVal:" + lVal); }
+					lDOMClass.isVacuous = true;
+				}
+
+				// update isSchema1Class
+				lVal = ProtPinsDOM11179DD.getStringValueUpdate (false, lInstMap, "isSchema1Class", "false");                        
+				if (lVal != null && lVal.compareTo("true") == 0) {
+					if (lDebugFlag) { System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId + " - updating Class.steward:" + lDOMClass.isSchema1Class + "  - with lVal:" + lVal); }
+					lDOMClass.isSchema1Class = true;
+				}
+
+				// update isRegistryClass
+				lVal = ProtPinsDOM11179DD.getStringValueUpdate (false, lInstMap, "isRegistryClass", "false");                        
+				if (lVal != null && lVal.compareTo("true") == 0) {
+					if (lDebugFlag) { System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId + " - updating Class.steward:" + lDOMClass.isRegistryClass + "  - with lVal:" + lVal); }
+					lDOMClass.isRegistryClass = true;
+				}
+
+				// update isTDO
+				lVal = ProtPinsDOM11179DD.getStringValueUpdate (false, lInstMap, "isTDO", "false");                        
+				if (lVal != null && lVal.compareTo("true") == 0) {
+					if (lDebugFlag) { System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId + " - updating Class.steward:" + lDOMClass.isTDO + "  - with lVal:" + lVal); }
+					lDOMClass.isTDO = true;
+				}
+
+				// update isDataType
+				lVal = ProtPinsDOM11179DD.getStringValueUpdate (false, lInstMap, "isDataType", "false");                        
+				if (lVal != null && lVal.compareTo("true") == 0) {
+					if (lDebugFlag) { System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId + " - updating Class.steward:" + lDOMClass.isDataType + "  - with lVal:" + lVal); }
+					lDOMClass.isDataType = true;
+				}
+
+				// update isUnitOfMeasure
+				lVal = ProtPinsDOM11179DD.getStringValueUpdate (false, lInstMap, "isUnitOfMeasure", "false");                        
+				if (lVal != null && lVal.compareTo("true") == 0) {
+					if (lDebugFlag) { System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId + " - updating Class.steward:" + lDOMClass.isUnitOfMeasure + "  - with lVal:" + lVal); }
+					lDOMClass.isUnitOfMeasure = true;
+				}
+
+				// update versionIdentifier
+				lVal = ProtPinsDOM11179DD.getStringValueUpdate (false, lInstMap, "versionIdentifier", lDOMClass.versionId);                        
+				if (lVal != null) {
+					if (lDebugFlag) { System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId + " - updating Class.steward:" + lDOMClass.versionId + "  - with lVal:" + lVal); }
+					lDOMClass.versionId = lVal;
+				}			
+
+			} else {
+//				DMDocument.registerMessage ("1>error " + "11179 data dictionary class is missing for overwrite - Identifier:" + lInstId);
+				if (lDOMClass.title.compareTo("USER") != 0) {
+					DMDocument.registerMessage ("1>error " + "11179 data dictionary class is missing for overwrite - Identifier:" + lInstId);
+				}
+			}
+		}
+	}	
+	
 //	Get class order
 	public void getClassOrder () {
 		// iterate through the associations

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/PermValueDefn.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/PermValueDefn.java
@@ -29,7 +29,6 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 package gov.nasa.pds.model.plugin; 
-
 public class PermValueDefn {
 	String identifier;		// identifier from raw value meaning files - e.g. 0001_NASA_PDS_1.Table_Delimited.record_delimiter_Value_1
 	String searchKey;		// identifier from raw value meaning files - e.g. 0001_NASA_PDS_1.Table_Delimited.record_delimiter_Value_1
@@ -38,6 +37,7 @@ public class PermValueDefn {
 	String value_meaning;	// the meaning of the value
 	String value_begin_date;	// the value begin date
 	String value_end_date;		// the value end date
+	boolean isDeprecated;		// class is deprecated
 	
 	public PermValueDefn (String lId, String lValue, String lValueMeaning) {
 		identifier = lId; 
@@ -47,6 +47,7 @@ public class PermValueDefn {
 		value_meaning = lValueMeaning;
 		value_begin_date = "TBD_value_begin_date";
 		value_end_date = "TBD_value_end_date";
+		isDeprecated = false;
 	} 
 	
 	public PermValueDefn (String lId, String lValue) {
@@ -57,5 +58,6 @@ public class PermValueDefn {
 		value_meaning = "TBD_value_meaning";
 		value_begin_date = "TBD_value_begin_date";
 		value_end_date = "TBD_value_end_date";
+		isDeprecated = false;
 	} 	
 }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFile.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFile.java
@@ -226,42 +226,12 @@ class WriteDOM11179DDPinsFile extends Object{
 
 	// Print the the Protege Pins Properties
 	public  void printPDDPPR (PrintWriter prDDPins) {
-		
-// 888 Comparison Change
-//		ArrayList <String> lUsedIdentifiers = new ArrayList <String> ();
-//		String lPrevDOMPropId = "TBD_lPrevDOMPropId";
-		
 		ArrayList <DOMProp> lSortedAssocArr = new ArrayList <DOMProp> (DOMInfoModel.masterDOMPropIdMap.values());
 		for (Iterator<DOMProp> i = lSortedAssocArr.iterator(); i.hasNext();) {
 			DOMProp lDOMProp = (DOMProp) i.next();
-			
-// 888 Comparison Change
+			if (lDOMProp.isInactive) continue;
+			if (lDOMProp.identifier.indexOf(DMDocument.ANAME) > -1) continue;  // %3ANAME for protege attribute name; e.g., Schematron_Rule
 			String prDataIdentifier = "PR." + lDOMProp.identifier;
-			
-/* for Comparing MOF and DOM Pins Files.
-			String lDOMPropId = lDOMProp.identifier;
-			System.out.println("\ndebug printPDDPPR lDOMPropId:" + lDOMPropId);
-	        int count = 0;        
-	        for(int k = 0; k < lDOMPropId.length(); k++) {    
-	            if(lDOMPropId.charAt(k) == '.')    
-	                count++;    
-	        }
-			System.out.println("                  count:" + count);
-	        if (count > 4) {
-	        	int offset = lDOMPropId.lastIndexOf(".");
-				System.out.println("                  offset:" + offset);
-	        	lDOMPropId = lDOMPropId.substring(0, offset);
-				System.out.println("                  lDOMPropId:" + lDOMPropId);
-	        }
-        	String prDataIdentifier = "PR." + lDOMPropId;
-        	if (lUsedIdentifiers.contains(prDataIdentifier)) {
-				System.out.println("                  Previous lDOMProp.identifier:" + lPrevDOMPropId);
-				System.out.println("                           lDOMProp.identifier:" + lDOMProp.identifier);
-        		continue;
-        	}
-        	lUsedIdentifiers.add(prDataIdentifier);
-        	lPrevDOMPropId = lDOMProp.identifier; */
-			
 			prDDPins.println("([" + prDataIdentifier + "] of Property");
 			prDDPins.println("  (administrationRecord [" + DMDocument.administrationRecordValue + "])");
 			prDDPins.println("  (dataIdentifier \"" + prDataIdentifier + "\")");
@@ -297,9 +267,9 @@ class WriteDOM11179DDPinsFile extends Object{
 
 			lfc = "";
 			prDDPins.println("  (representing2 ");
-//			for (Iterator<AttrDefn> j = lIndex.identifier1Arr.iterator(); j.hasNext();) {
 			for (Iterator<DOMAttr> j = lIndex.getSortedIdentifier1Arr().iterator(); j.hasNext();) {
 				DOMAttr lAttr = (DOMAttr) j.next();
+				if (lAttr.isInactive) continue;
 				prDDPins.print(lfc);
 				if (lAttr.isEnumerated) {
 					prDDPins.print("    [" + lAttr.evdDataIdentifier + "]");
@@ -345,9 +315,9 @@ class WriteDOM11179DDPinsFile extends Object{
 
 			String lfc = "";
 			prDDPins.println("  (expressing ");
-//			for (Iterator<AttrDefn> j = lIndex.identifier1Arr.iterator(); j.hasNext();) {
 			for (Iterator<DOMAttr> j = lIndex.getSortedIdentifier1Arr().iterator(); j.hasNext();) {
 				DOMAttr lAttr = (DOMAttr) j.next();
+				if (lAttr.isInactive) continue;
 				prDDPins.print(lfc);
 				prDDPins.print("    [" + lAttr.deDataIdentifier + "]");
 				lfc = "\n";
@@ -391,17 +361,10 @@ class WriteDOM11179DDPinsFile extends Object{
 	// Print the the Protege Pins TE
 	public  void printPDDPTE (PrintWriter prDDPins) {
 		
-		for (Iterator<DOMAttr> i = DOMInfoModel.masterDOMAttrArr.iterator(); i.hasNext();) {
-			DOMAttr lDOMAttr= (DOMAttr) i.next();
-			if (lDOMAttr.isUsedInClass && lDOMAttr.isAttribute) {
-//	            System.out.println("debug printPDDPTE lDOMAttr.identifier:" + lDOMAttr.identifier);
-//	            System.out.println("debug printPDDPTE lDOMAttr.definition:" + lDOMAttr.definition);
-			}
-		}
-		
 		// print the Terminological Entry
 		for (Iterator<DOMAttr> i = DOMInfoModel.masterDOMAttrArr.iterator(); i.hasNext();) {
 			DOMAttr lDOMAttr= (DOMAttr) i.next();
+			if (lDOMAttr.isInactive) continue;
 			if (lDOMAttr.isUsedInClass && lDOMAttr.isAttribute) {
 				// print TE section
 				prDDPins.println("([" + lDOMAttr.teDataIdentifier + "] of TerminologicalEntry");
@@ -564,6 +527,7 @@ class WriteDOM11179DDPinsFile extends Object{
 		TreeMap <String, DOMAttr> lTreeMap = new TreeMap <String, DOMAttr>();
 		for (Iterator<DOMAttr> i = DOMInfoModel.masterDOMAttrArr.iterator(); i.hasNext();) {
 			DOMAttr lAttr = (DOMAttr) i.next();
+			if (lAttr.isInactive) continue;
 			if (lAttr.isUsedInClass && lAttr.isAttribute) {
 				String sortKey = lAttr.title + ":" + lAttr.steward + "." + lAttr.parentClassTitle + ":" + lAttr.classSteward;
 				sortKey = sortKey.toUpperCase();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
@@ -230,7 +230,7 @@ class XML4LabelSchemaDOM extends Object {
 			DOMClass lClass = (DOMClass) i.next();
 			lClass.includeInThisSchemaFile = false;
 			if ((lSchemaFileDefn.nameSpaceIdNC.compareTo(lClass.nameSpaceIdNC) == 0) && lSchemaFileDefn.stewardArr.contains(lClass.steward)) {				
-				if (! (lClass.isUSERClass || lClass.isUnitOfMeasure || lClass.isDataType || lClass.isVacuous)) {
+				if (! (lClass.isUSERClass || lClass.isUnitOfMeasure || lClass.isDataType || lClass.isVacuous || lClass.isInactive)) {
 					lClass.includeInThisSchemaFile = true;
 					classCount++;
 					lClassMap.put(lClass.identifier, lClass);


### PR DESCRIPTION
Refactor Class information from config to Data Dictionary Protege ontology - Phase 1 - Add Class attributes to dd11179.pins.

The refactoring task focuses on moving the IM class disposition information from an XML configuration file, MDPTNConfigClassDisp.xml, to the IM Protege  metadata registry, dd11179.pins. The class, attribute, and permissible value deprecation information is also being moved from the DMDocument file to dd11179.pins.

Phase 1 of this task simply uploads the updated code to the repository without activating the code. Further testing and a Protege file update will follow.

Resolves #239

