### PR TITLE
 Issue #428 - IMTool Refactoring - Phase 2

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -141,8 +141,11 @@ public class DMDocument extends Object {
 //	static boolean LDDClassElementFlag = false;			// if true, write XML elements for classes
 	static boolean LDDAttrElementFlag = false;			// if true, write  XML elements for attributes
 	static boolean LDDNuanceFlag = false;				//
-	static boolean overWriteClass = false;				// use dd11179.pins to provide class disp information; also deprecation flags.
-	static boolean useMDPTNConfig = true;				// use MDPTNConfigClassDisp in protPont class parsing
+	
+	// refactor into Protege switches
+	static boolean overWriteClass = true;				// use dd11179.pins class disp, isDeprecated, and versionId to overwrite Master DOMClasses, DOMAttrs, and DOMPermvalues
+	static boolean useMDPTNConfig = true;				// ProtPontDOMModel; get disposition for the class from MDPTNConfigClassDisp
+	static boolean overWriteDeprecated = false;			// use dd11179.pins isDeprecated to overwrite DMDocument.deprecatedObjects2
 	
 	// alternate IM Version
 	// if no option "V" is provided on the command line, then the default is the current IM version.
@@ -262,16 +265,12 @@ public class DMDocument extends Object {
 		
 	// the set of deprecated classes, attributes, and values	
 	static ArrayList <DeprecatedDefn> deprecatedObjects2;
-	static ArrayList <String> deprecatedAttrValueArr;
 	static String Literal_DEPRECATED = " *Deprecated*";
 	static boolean deprecatedAdded;
 	static boolean deprecatedAddedDOM;
 	
 	// the set of classes and attributes that will be externalized (defined as xs:Element)	
 	static ArrayList <String> exposedElementArr;
-
-	// class version identifiers (only updated classes; v1.0.0.0 is assumed)
-	static TreeMap <String, String> classVersionId;
 	
 	// info, warning, and error messages
 	static int msgOrder = 100000;
@@ -404,10 +403,7 @@ public class DMDocument extends Object {
 		
 		// set exposed elements 
 		setexposedElementFlag ();
-		
-		// set classVersionId
-		setClassVersionIdFlag ();
-		
+				
 		// get the command line arguments using argparse4j
 		Namespace argparse4jNamespace = getArgumentParserNamespace(args);
 		
@@ -1003,64 +999,6 @@ public class DMDocument extends Object {
 	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type", "pds", "Instrument", "pds", "type", "", false));                            
 	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.subtype", "pds", "Instrument", "pds", "subtype", "", false));                            
 
-/*
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Accelerometer", "pds", "Instrument", "pds", "type", "Accelerometer", false));                            
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Alpha Particle Detector", "pds", "Instrument", "pds", "type", "Alpha Particle Detector", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Alpha Particle X-Ray Spectrometer", "pds", "Instrument", "pds", "type", "Alpha Particle X-Ray Spectrometer", false));
-//	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Altimeter", "pds", "Instrument", "pds", "type", "Altimeter", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Anemometer", "pds", "Instrument", "pds", "type", "Anemometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Atomic Force Microscope", "pds", "Instrument", "pds", "type", "Atomic Force Microscope", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Barometer", "pds", "Instrument", "pds", "type", "Barometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Biology Experiments", "pds", "Instrument", "pds", "type", "Biology Experiments", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Bolometer", "pds", "Instrument", "pds", "type", "Bolometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Camera", "pds", "Instrument", "pds", "type", "Camera", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Cosmic Ray Detector", "pds", "Instrument", "pds", "type", "Cosmic Ray Detector", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Drilling Tool", "pds", "Instrument", "pds", "type", "Drilling Tool", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Dust Detector", "pds", "Instrument", "pds", "type", "Dust Detector", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Electrical Probe", "pds", "Instrument", "pds", "type", "Electrical Probe", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Energetic Particle Detector", "pds", "Instrument", "pds", "type", "Energetic Particle Detector", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Gamma Ray Detector", "pds", "Instrument", "pds", "type", "Gamma Ray Detector", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Gas Analyzer", "pds", "Instrument", "pds", "type", "Gas Analyzer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Grinding Tool", "pds", "Instrument", "pds", "type", "Grinding Tool", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Hygrometer", "pds", "Instrument", "pds", "type", "Hygrometer", false));
-//	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Imager", "pds", "Instrument", "pds", "type", "Imager", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Imaging Spectrometer", "pds", "Instrument", "pds", "type", "Imaging Spectrometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Inertial Measurement Unit", "pds", "Instrument", "pds", "type", "Inertial Measurement Unit", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Infrared Spectrometer", "pds", "Instrument", "pds", "type", "Infrared Spectrometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Laser Induced Breakdown Spectrometer", "pds", "Instrument", "pds", "type", "Laser Induced Breakdown Spectrometer", false));
-//	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Magnetometer", "pds", "Instrument", "pds", "type", "Magnetometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Mass Spectrometer", "pds", "Instrument", "pds", "type", "Mass Spectrometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Microwave Spectrometer", "pds", "Instrument", "pds", "type", "Microwave Spectrometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Moessbauer Spectrometer", "pds", "Instrument", "pds", "type", "Moessbauer Spectrometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Naked Eye", "pds", "Instrument", "pds", "type", "Naked Eye", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Neutral Particle Detector", "pds", "Instrument", "pds", "type", "Neutral Particle Detector", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Neutron Detector", "pds", "Instrument", "pds", "type", "Neutron Detector", false));
-//	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Photometer", "pds", "Instrument", "pds", "type", "Photometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Plasma Analyzer", "pds", "Instrument", "pds", "type", "Plasma Analyzer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Plasma Detector", "pds", "Instrument", "pds", "type", "Plasma Detector", false));
-//	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Plasma Wave Spectrometer", "pds", "Instrument", "pds", "type", "Plasma Wave Spectrometer", false));
-//	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Polarimeter", "pds", "Instrument", "pds", "type", "Polarimeter", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Radar", "pds", "Instrument", "pds", "type", "Radar", false));
-//		Undeprecate Radio Science as per CCB-247
-//	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Radio Science", "pds", "Instrument", "pds", "type", "Radio Science", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Radio Spectrometer", "pds", "Instrument", "pds", "type", "Radio Spectrometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Radio Telescope", "pds", "Instrument", "pds", "type", "Radio Telescope", false));
-//	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Radiometer", "pds", "Instrument", "pds", "type", "Radiometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Reflectometer", "pds", "Instrument", "pds", "type", "Reflectometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Robotic Arm", "pds", "Instrument", "pds", "type", "Robotic Arm", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Spectrograph Imager", "pds", "Instrument", "pds", "type", "Spectrograph Imager", false));
-//	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Spectrometer", "pds", "Instrument", "pds", "type", "Spectrometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Thermal Imager", "pds", "Instrument", "pds", "type", "Thermal Imager", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Thermal Probe", "pds", "Instrument", "pds", "type", "Thermal Probe", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Thermometer", "pds", "Instrument", "pds", "type", "Thermometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Ultraviolet Spectrometer", "pds", "Instrument", "pds", "type", "Ultraviolet Spectrometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Weather Station", "pds", "Instrument", "pds", "type", "Weather Station", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.Wet Chemistry Laboratory", "pds", "Instrument", "pds", "type", "Wet Chemistry Laboratory", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.X-ray Detector", "pds", "Instrument", "pds", "type", "X-ray Detector", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.X-ray Diffraction Spectrometer", "pds", "Instrument", "pds", "type", "X-ray Diffraction Spectrometer", false));
-	    deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type.X-ray Fluorescence Spectrometer", "pds", "Instrument", "pds", "type", "X-ray Fluorescence Spectrometer", false));
-*/
-
 	    deprecatedObjects2.add(new DeprecatedDefn ("Target_Identification.type", "pds", "Target_Identification", "pds", "type", "Calibration", false));
 	    deprecatedObjects2.add(new DeprecatedDefn ("Target_Identification.type", "pds", "Target_Identification", "pds", "type", "Open Cluster", false));
 	    deprecatedObjects2.add(new DeprecatedDefn ("Target_Identification.type", "pds", "Target_Identification", "pds", "type", "Globular Cluster", false));
@@ -1129,31 +1067,6 @@ public class DMDocument extends Object {
 		deprecatedObjects2.add(new DeprecatedDefn ("Inventory.field_delimiter", "pds", "Inventory", "pds", "field_delimiter", "vertical bar", false));
 
 //		deprecatedObjects2.add(new DeprecatedDefn ("Update.Update_Entry", "pds", "Update_Entry", "", "", "", false));
-
-/*		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Aerial survey - North American (1983) datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Adindan datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Australian datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Campo Inchauspe (Argentina) datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Cape (South Africa) datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Corregio Alegre (Brazil) datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - datum unknown", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - European 1979 datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - European datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - GRS 80 datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Hermannskogel datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Indian datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - La Canoa (Venezuela) datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - New Zealand datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - North American (1927) datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Old Hawaiian datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Ordnance Survey of Great Britain (1936) datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Ordnance Survey of Great Britain (SN) 1980 datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Potsdam datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Puerto Rican (1940) datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - South American datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - Tokyo datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Geodetic - WGS 84 datum", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.coordinate_source", "pds", "Telescope", "pds", "coordinate_source", "Satellite determined - datum unknown", false)); */
 		
 		deprecatedObjects2.add(new DeprecatedDefn ("Telescope.altitude", "pds", "Telescope", "pds", "altitude", "", false));
 
@@ -1210,24 +1123,13 @@ public class DMDocument extends Object {
 		deprecatedObjects2.add(new DeprecatedDefn ("Vector_Cartesian_3", "pds", "Vector_Cartesian_3", "", "", "", false));
 		deprecatedObjects2.add(new DeprecatedDefn ("Vector_Cartesian_3_Acceleration", "pds", "Vector_Cartesian_3_Acceleration", "", "", "", false));
 		deprecatedObjects2.add(new DeprecatedDefn ("Vector_Cartesian_3_Position", "pds", "Vector_Cartesian_3_Position", "", "", "", false));
-		deprecatedObjects2.add(new DeprecatedDefn ("Vector_Cartesian_3_Velocity", "pds", "Vector_Cartesian_3_Velocity", "", "", "", false));		
-		
-		// get ArrayList for *** testing only ***
-		deprecatedAttrValueArr = new ArrayList <String> ();
-		for (Iterator <DeprecatedDefn> i = deprecatedObjects2.iterator(); i.hasNext();) {
-			DeprecatedDefn lObject = (DeprecatedDefn) i.next();
-			if (lObject.value.compareTo("") != 0) {
-				String lIdentifier = lObject.classNameSpaceIdNC + "." + lObject.className + "." + lObject.attrName + "." + lObject.value;			
-				deprecatedAttrValueArr.add(lIdentifier);
-				continue;
-			}
-			if (lObject.attrName.compareTo("") != 0) {
-				String lIdentifier = lObject.classNameSpaceIdNC + "." + lObject.className + "." + lObject.attrName;
-				deprecatedAttrValueArr.add(lIdentifier);
-				continue;
-			}
-			String lIdentifier = lObject.classNameSpaceIdNC + "." + lObject.className;
-			deprecatedAttrValueArr.add(lIdentifier);
+		deprecatedObjects2.add(new DeprecatedDefn ("Vector_Cartesian_3_Velocity", "pds", "Vector_Cartesian_3_Velocity", "", "", "", false));
+	}
+	
+	static void Dump333DeprecatedObjects2 (String title, ArrayList <DeprecatedDefn> lDeprecatedObjectsArr) {
+		System.out.println("\n debug Dump333DeprecatedObjects2 - " + title);
+		for (DeprecatedDefn lDep : lDeprecatedObjectsArr) {
+			System.out.println("debug lDep.title:" + lDep.title + " |  lDep.classNameSpaceIdNC:" + lDep.classNameSpaceIdNC + " |  lDep.className:" + lDep.className + " |  lDep.attrNameSpaceIdNC:" + lDep.attrNameSpaceIdNC + " |  lDep.attrName:" + lDep.attrName + " |  lDep.value:" + lDep.value + " |  lDep.isValue:" + lDep.isValue + " |  lDep.isAttribute:" + lDep.isAttribute + " |  lDep.isUnitId:" + lDep.isUnitId);
 		}
 	}
 	
@@ -1299,97 +1201,6 @@ public class DMDocument extends Object {
 		registryAttr.add("stop_date");
 		registryAttr.add("logical_identifier"); 
 		registryAttr.add("version_id");
-	}
-	
-	static void setClassVersionIdFlag () {
-		// class version ids
-		classVersionId = new TreeMap <String, String> ();
-		classVersionId.put("Array", "2.0.0.0");
-		classVersionId.put("Array_2D_Image", "1.1.0.0");
-		classVersionId.put("Axis_Array", "1.3.0.0");
-		classVersionId.put("Bundle_Member_Entry", "1.1.0.0");
-		classVersionId.put("Checksum_Manifest", "1.1.0.0");
-		classVersionId.put("Citation_Information", "1.2.0.0");
-		classVersionId.put("Data_Set_PDS3", "1.1.0.0");
-		classVersionId.put("DD_Association", "1.2.0.0");
-		classVersionId.put("DD_Association_External", "1.1.0.0");
-		classVersionId.put("DD_Permissible_Value", "1.1.0.0");
-		classVersionId.put("Display_Settings", "1.1.0.0");
-		classVersionId.put("Document", "2.0.0.0");
-		classVersionId.put("Document_File", "1.4.0.0");
-		classVersionId.put("Encoded_Binary", "1.1.0.0");
-		classVersionId.put("Encoded_Telemetry", "1.1.0.0");
-		classVersionId.put("Field", "1.1.0.0");
-		classVersionId.put("File", "1.1.0.0");
-		classVersionId.put("File_Area_Browse", "1.1.0.0");
-		classVersionId.put("File_Area_Ancillary", "1.1.0.0");
-		classVersionId.put("File_Area_Browse", "1.2.0.0");
-		classVersionId.put("File_Area_Observational", "1.3.0.0");
-		classVersionId.put("File_Area_Observational_Supplemental", "1.3.0.0");
-		classVersionId.put("File_Area_Update", "1.1.0.0");
-		classVersionId.put("Group", "1.1.0.0");
-		classVersionId.put("Group_Field_Binary", "1.1.0.0");
-		classVersionId.put("Group_Field_Character", "1.1.0.0");
-		classVersionId.put("Header", "1.1.0.0");
-		classVersionId.put("Identification_Area", "1.4.0.0");
-		classVersionId.put("Ingest_LDD", "1.1.0.0");
-		classVersionId.put("Instrument", "1.3.0.0");
-		classVersionId.put("Instrument_Host", "1.3.0.0");
-		classVersionId.put("Internal_Reference", "1.1.0.0");
-		classVersionId.put("Inventory", "1.2.0.0");
-//		classVersionId.put("NOT Spice_Kernel", "");
-		classVersionId.put("Observing_System_Component", "1.1.0.0"); 
-		classVersionId.put("Primary_Result_Summary", "2.3.0.0");
-
-		classVersionId.put("Product_Document", "2.1.0.0");
-		classVersionId.put("Investigation_Area", "1.1.0.0");        //  <Internal_Reference.reference_type>
-		classVersionId.put("Product_Bundle", "1.1.0.0");         		//  <Internal_Reference.reference_type>
-		classVersionId.put("Product_Collection", "1.1.0.0");        //  <Internal_Reference.reference_type>
-		classVersionId.put("Product_Context", "1.1.0.0");         	//  <Internal_Reference.reference_type>
-		classVersionId.put("Product_Observational", "1.7.0.0");      //  <Internal_Reference.reference_type>
-		classVersionId.put("Product_Native", "1.2.0.0");
-		classVersionId.put("Product_Service", "1.1.0.0");
-		classVersionId.put("Product_XML_Schema", "1.2.0.0");
-		classVersionId.put("Product_SIP_Deep_Archive", "1.1.0.0");
-
-		classVersionId.put("Record_Character", "1.1.0.0");
-		classVersionId.put("Special_Constants", "1.1.0.0");
-		classVersionId.put("Spectral_Radiance", "1.1.0.0");
-		classVersionId.put("Spectral_Irradiance", "1.1.0.0");
-		classVersionId.put("Table_Binary", "1.1.0.0");
-		classVersionId.put("Target", "1.3.0.0");
-		classVersionId.put("Target_Identification", "1.4.0.0");
-		classVersionId.put("Telescope", "1.3.0.0");
-		classVersionId.put("Terminological_Entry", "1.1.0.0");
-		classVersionId.put("Transfer_Manifest", "1.1.0.0");
-		classVersionId.put("Uniformly_Sampled", "1.1.0.0");
-		classVersionId.put("Unit_Of_Measure", "1.1.0.0");
-		classVersionId.put("Units_of_Current", "1.1.0.0");
-		classVersionId.put("Units_of_Radiance", "1.1.0.0");
-		classVersionId.put("XML_Schema", "1.2.0.0");
-
-		classVersionId.put("ASCII_Date", "1.1.0.0");
-		classVersionId.put("ASCII_DOI", "1.1.0.0");
-		classVersionId.put("ASCII_Date_Time", "1.1.0.0");
-		classVersionId.put("ASCII_Date_Time_DOY", "1.2.0.0");
-		classVersionId.put("ASCII_Date_Time_UTC", "1.3.0.0");
-		classVersionId.put("ASCII_Date_Time_YMD", "1.1.0.0");
-		classVersionId.put("ASCII_Date_YMD", "1.1.0.0");
-		classVersionId.put("ASCII_Integer", "1.1.0.0");
-		classVersionId.put("ASCII_MD5_Checksum", "1.1.0.0");
-		classVersionId.put("ASCII_Numeric_Base2", "1.2.0.0");
-		classVersionId.put("ASCII_Numeric_Base8", "1.2.0.0");
-		classVersionId.put("ASCII_Time", "1.1.0.0");
-		classVersionId.put("ASCII_VID", "1.1.0.0");
-		classVersionId.put("ASCII_Directory_Path_Name", "1.1.0.0");
-		classVersionId.put("ASCII_File_Name", "1.1.0.0");
-		classVersionId.put("ASCII_File_Specification_Name", "1.1.0.0");
-		classVersionId.put("ASCII_LID", "1.1.0.0");
-		classVersionId.put("ASCII_LIDVID", "1.1.0.0");
-		classVersionId.put("ASCII_LIDVID_LID", "1.1.0.0");
-		classVersionId.put("ASCII_MD5_Checksum", "1.1.0.0");
-		classVersionId.put("ASCII_Time", "1.1.0.0");
-		classVersionId.put("ASCII_VID", "1.1.0.0");
 	}
 	
 	static void registerMessage (String lMessage) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
@@ -1166,6 +1166,7 @@ public abstract class DOMInfoModel extends Object {
 		prDOMWriter.println("  title:" + objClass.title);
 		prDOMWriter.println("  definition:" + objClass.definition);
 		prDOMWriter.println("  registrationStatus:" + objClass.registrationStatus);
+		prDOMWriter.println("  isInactive:" + objClass.isInactive);
 		prDOMWriter.println("  isDeprecated:" + objClass.isDeprecated);
 		
 		prDOMWriter.println("  isDigital:" + objClass.isDigital);
@@ -1332,6 +1333,7 @@ public abstract class DOMInfoModel extends Object {
         prDOMWriter.println("        attr.title:" + attr.title);
         prDOMWriter.println("        attr.definition:" + attr.definition);
         prDOMWriter.println("        attr.registrationStatus:" + attr.registrationStatus);
+		prDOMWriter.println("        attr.isInactive:" + attr.isInactive);
         prDOMWriter.println("        attr.isDeprecated:" + attr.isDeprecated);
 
         prDOMWriter.println("        attr.isDigital:" + attr.isDigital);
@@ -1412,7 +1414,7 @@ public abstract class DOMInfoModel extends Object {
 				DOMProp lDOMProp = (DOMProp) j.next();
 				if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMPermValDefn) {
 					DOMPermValDefn lDOMPermVal = (DOMPermValDefn) lDOMProp.hasDOMObject;
-					prDOMWriter.println("          lDOMPermVal.value:" + lDOMPermVal.value + "  lDOMPermVal.registrationStatus:" + lDOMPermVal.registrationStatus + "  lDOMPermVal.value_meaning:" + lDOMPermVal.value_meaning);
+					prDOMWriter.println("          lDOMPermVal.value:" + lDOMPermVal.value + "  lDOMPermVal.isInactive:" + lDOMPermVal.isInactive + "  lDOMPermVal.isDeprecated:" + lDOMPermVal.isDeprecated + "  lDOMPermVal.registrationStatus:" + lDOMPermVal.registrationStatus + "  lDOMPermVal.value_meaning:" + lDOMPermVal.value_meaning);
 				}
 			}
 		} else {
@@ -1430,6 +1432,7 @@ public abstract class DOMInfoModel extends Object {
 		prDOMWriter.println("        lProp.title:" + lProp.title);
 		prDOMWriter.println("        lProp.definition:" + lProp.definition);
 		prDOMWriter.println("        lProp.registrationStatus:" + lProp.registrationStatus);
+		prDOMWriter.println("        lProp.isInactive:" + lProp.isInactive);
 		prDOMWriter.println("        lProp.isDeprecated:" + lProp.isDeprecated);
 		
 		prDOMWriter.println("        lProp.isDigital:" + lProp.isDigital);

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModels.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModels.java
@@ -109,10 +109,16 @@ public class ExportModels extends Object {
 //		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - CCSDS CSV Done");
 		
 		// write the 11179 DD pins file
-		WriteDOM11179DDPinsFile lWriteDOM11179DDPinsFile = new WriteDOM11179DDPinsFile ();
-		lWriteDOM11179DDPinsFile.writePINSFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecDDProtPins);	
-		lWriteDOM11179DDPinsFile.writePINSFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecDDProtPinsSN);	
-		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - DD Pins File Done");
+//		WriteDOM11179DDPinsFile lWriteDOM11179DDPinsFile = new WriteDOM11179DDPinsFile ();
+//		lWriteDOM11179DDPinsFile.writePINSFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecDDProtPins);	
+//		lWriteDOM11179DDPinsFile.writePINSFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecDDProtPinsSN);	
+//		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - DD Pins File Done");
+
+		// write the 11179 DD pins file - Plus Class Version
+		WriteDOM11179DDPinsFilePClass lWriteDOM11179DDPinsFilePClass = new WriteDOM11179DDPinsFilePClass ();
+		lWriteDOM11179DDPinsFilePClass.writePINSFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecDDProtPins);	
+		lWriteDOM11179DDPinsFilePClass.writePINSFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecDDProtPinsSN);	
+		DMDocument.registerMessage ("0>info " + "writeAllArtifacts - DD Pins *** plus class *** File Done");
 		
 		// write the 11179 DOM JSON file - requires DOMInfoModel to be executed
 		DMDocument.dmProcessState.setRelativeFileSpecDOMModelJSON (DMDocument.masterPDSSchemaFileDefn);

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -304,7 +304,7 @@ public class GetDOMModel extends Object {
 		// 017b - overwrite master classes from the 11179 DD
 		//     - either import from JSON 11179 file or overwrite from 11179 dictionary
 		//		Overwrite is needed to set classes and attribute defined in protege but not in JSON11179 ???
-		if (DMDocument.overWriteClass) lISO11179DOMMDR.OverwriteClassFrom11179DataDict();
+		lISO11179DOMMDR.OverwriteClassFrom11179DataDict();
 		
 		// 018 - overwrite any LDD attributes from the cloned USER attributes
 		//       this is not really needed since the definitions are in the external class
@@ -321,6 +321,10 @@ public class GetDOMModel extends Object {
 		
 		// 018.5 - propagate the class.inactive flag; these are classes with "I" (Ignore) or "N" (not used) use flags.
 		DMDocument.masterDOMInfoModel.setInactiveFlag ();
+
+		// 333
+		// 018.7 - get the Deprecated Objects array
+//		DMDocument.deprecatedObjects2 = DMDocument.masterDOMInfoModel.getDeprecatedObjectsArr();
 		
 		// 019 - general master attribute fixup
 		// anchorString; sort_identifier; sort attribute.valArr
@@ -334,9 +338,14 @@ public class GetDOMModel extends Object {
 		
 		// 022 - set the registration status
 		DMDocument.masterDOMInfoModel.setRegistrationStatus ();
+
+		// 018.7 - get the Deprecated Objects array
+// 333	
+		if (DMDocument.overWriteDeprecated) DMDocument.deprecatedObjects2 = DMDocument.masterDOMInfoModel.getDeprecatedObjectsArr();
 		
-		// 023 - set the class version identifiers (stop gap until class are stored in OWL) (was 038)
-		DMDocument.masterDOMInfoModel.setClassVersionIds ();
+// 333		DMDocument.Dump333DeprecatedObjects2 ("DMDocument", DMDocument.deprecatedObjects2);
+
+// 333		DMDocument.Dump333DeprecatedObjects2 ("DD11179", DMDocument.masterDOMInfoModel.getDeprecatedObjectsArr());
 		
 		// 024 - set up master data types - the data type map
 		DMDocument.masterDOMInfoModel.setMasterDataType2 ();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/InstDefn.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/InstDefn.java
@@ -56,5 +56,20 @@ public class InstDefn extends Object {
 		description = "TBD_description";
 		
 		genSlotMap = new HashMap <String, ArrayList<String>> ();
-	}  	
+	}
+	
+	// get a singleton slot value given a keyName (Protege dd11179 attribute)
+	public String getSlotValueSingleton (String keyName) {
+		ArrayList <String> lValArr = getSlotValueArr (keyName);
+		if (lValArr == null) return null;
+		String lValue = lValArr.get(0);
+		if (lValue == null) return null;
+		return lValue;
+	}	
+
+	// get the slot value array given a keyName (Protege dd11179 attribute)
+	public ArrayList <String> getSlotValueArr (String keyName) {
+		ArrayList <String> lValArr = genSlotMap.get(keyName);
+		return lValArr;
+	}
 } 	

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
@@ -138,7 +138,7 @@ class ProtPontDOMModel extends DOMInfoModel{
 							// class is "hidden" ignore it and do not print warning
 
 							// *** added ***
-						/*	if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue;   // omit %3ACLIPS_TOP_LEVEL_SLOT_CLASS
+							if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue;   // omit %3ACLIPS_TOP_LEVEL_SLOT_CLASS
 							lClass.isInactive = true;
 							classNameSpaceIdNC = lClass.nameSpaceIdNC;  // global needed for parser
 							parsedClassMap.put(lClass.rdfIdentifier, lClass);
@@ -146,7 +146,7 @@ class ProtPontDOMModel extends DOMInfoModel{
 							String token1 = (String) tokenIter.next();
 							if (token1.compareTo("(") != 0) {
 								lClass.definition = DOMInfoModel.unEscapeProtegeString(token1);
-							} */
+							}
 							// *** end of added ***
 						
 						} else {	// disposition exists but not clear why, print warning 
@@ -154,14 +154,14 @@ class ProtPontDOMModel extends DOMInfoModel{
 								DMDocument.registerMessage ("1>warning " + "Class omitted from build - Class Identifier:" + lClass.identifier);
 							}
 
-						/*  lClass.isInactive = true;
+						  lClass.isInactive = true;
 							classNameSpaceIdNC = lClass.nameSpaceIdNC;  // global needed for parser
 							parsedClassMap.put(lClass.rdfIdentifier, lClass);
 							isInParsedClassMap = true;
 							String token1 = (String) tokenIter.next();
 							if (token1.compareTo("(") != 0) {
 								lClass.definition = DOMInfoModel.unEscapeProtegeString(token1);
-							} */
+							}
 							// *** end of added ***
 
 						}
@@ -175,7 +175,8 @@ class ProtPontDOMModel extends DOMInfoModel{
 				
 				// get disposition for the class from dd11179
 //				if (DMDocument.overWriteClass) {
-				if (false) {
+//				if (false) {
+				if (true) {
 					lClass.getDOMClassDisposition2 ();
 					if (! isInParsedClassMap) {
 					parsedClassMap.put(lClass.rdfIdentifier, lClass);

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFilePClass.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFilePClass.java
@@ -1,0 +1,550 @@
+// Copyright 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+// * Neither the name of Caltech nor its operating division, the Jet Propulsion
+// Laboratory, nor the names of its contributors may be used to endorse or
+// promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package gov.nasa.pds.model.plugin; 
+import java.io.*;
+import java.util.*;
+
+/**
+ * Writes the Protege .pins (protege instance) file compliant with 11179 - DOM version
+ *   
+ */
+
+class WriteDOM11179DDPinsFilePClass extends Object{
+	
+	PrintWriter prDDPins;
+
+	public WriteDOM11179DDPinsFilePClass () {
+		return;
+	}
+
+	// write the PINS file
+	public void writePINSFile (String lFileName) throws java.io.IOException {
+		String lNewFileName = DOMInfoModel.replaceString (lFileName, "dd11179_Gen", "dd11179_GenPClass");
+		prDDPins = new PrintWriter(new OutputStreamWriter (new FileOutputStream(new File(lNewFileName)), "UTF-8"));		
+		
+	    printPDDPHdr();
+		printPDDPBody ();
+		printPDDPFtr();
+		prDDPins.close();
+	}	
+	
+	// Print the Protege Pins Header
+	private void printPDDPHdr () {
+		prDDPins.println("	; Tue Jan 26 07:52:47 PST 2010"); // protege write resets date
+//		prDDPins.println("	; " + DMDocument.masterTodaysDateTimeUTCwT);
+		prDDPins.println("	; ");
+		prDDPins.println("	;+ (version \"3.3.1\")");
+		prDDPins.println("	;+ (build \"Build 430\")");
+		prDDPins.println("");
+	}
+	
+	// Print the Protege Pins Footer
+	private  void printPDDPFtr () {
+		prDDPins.println("");
+	}
+	
+//	print the body
+	private  void printPDDPBody () {
+		// print the data elements
+		 printPDDPOC (prDDPins);
+		 printPDDPDE (prDDPins);
+		 printPDDPVD (prDDPins);
+		 printPDDPPR (prDDPins);
+		 printPDDPCD (prDDPins);
+		 printPDDPDEC (prDDPins);
+		 printPDDPTEDE (prDDPins); // TE for Data Elements
+		 printPDDPTEOC (prDDPins); // TE for Object Classes
+		 printPDDPMISC (prDDPins);
+	}
+	
+	// Print the the Protege Pins Object Class (OC)
+	private  void printPDDPOC (PrintWriter prDDPins) {
+		for (DOMClass lDOMClass : DOMInfoModel.getMasterDOMClassArr ()) {
+			if (lDOMClass.ocDataIdentifier.compareTo("TBD_ocDataIdentifier") == 0) {
+				continue;
+			}
+			prDDPins.println("([" + lDOMClass.ocDataIdentifier + "] of ObjectClass");
+			prDDPins.println("  (administrationRecord [" + DMDocument.administrationRecordValue + "])");
+			prDDPins.println("  (dataIdentifier \"" + lDOMClass.ocDataIdentifier + "\")");
+			prDDPins.println("  (registeredBy [" + lDOMClass.registeredByValue + "])");
+			prDDPins.println("  (registrationAuthorityIdentifier [" + lDOMClass.regAuthId + "])");
+			prDDPins.println("  (steward [" + lDOMClass.steward + "])");
+			prDDPins.println("  (terminologicalEntry [" + lDOMClass.teDataIdentifier + "])");
+			
+			prDDPins.println("  (isInactive \"" + lDOMClass.isInactive + "\")");
+			prDDPins.println("  (isDeprecated \"" + lDOMClass.isDeprecated + "\")");
+			prDDPins.println("  (used \"" + lDOMClass.used + "\")");  // Ignore, Yes, No
+			prDDPins.println("  (section \"" + lDOMClass.section + "\")");
+			prDDPins.println("  (steward \"" + lDOMClass.steward + "\")");
+			prDDPins.println("  (nameSpaceIdNC \"" + lDOMClass.nameSpaceIdNC + "\")");
+//			prDDPins.println("  (nameSpaceId \"" + lDOMClass.nameSpaceId + "\")");
+			prDDPins.println("  (isVacuous \"" + lDOMClass.isVacuous + "\")");
+			prDDPins.println("  (isSchema1Class \"" + lDOMClass.isSchema1Class + "\")");
+			prDDPins.println("  (isRegistryClass \"" + lDOMClass.isRegistryClass + "\")");
+			prDDPins.println("  (isTDO \"" + lDOMClass.isTDO + "\")");
+			prDDPins.println("  (isDataType \"" + lDOMClass.isDataType + "\")");
+			prDDPins.println("  (isUnitOfMeasure \"" + lDOMClass.isUnitOfMeasure + "\")");			
+			prDDPins.println("  (versionIdentifier \"" + lDOMClass.versionId + "\"))");
+		}
+	}
+		
+	// Print the the Protege Pins DE
+	private  void printPDDPDE (PrintWriter prDDPins) {
+		// print the data elements
+		ArrayList <DOMAttr> lSortedAttrArr = getSortedAttrs ();
+		for (Iterator<DOMAttr> i = lSortedAttrArr.iterator(); i.hasNext();) {
+			DOMAttr lAttr = (DOMAttr) i.next();
+			prDDPins.println("([" + lAttr.deDataIdentifier + "] of DataElement");
+			prDDPins.println("  (administrationRecord [" + DMDocument.administrationRecordValue + "])");
+			prDDPins.println("  (dataIdentifier \"" + lAttr.deDataIdentifier + "\")");
+			prDDPins.println("  (expressedBy ");
+			prDDPins.println("    [DEC_" + lAttr.classConcept + "])");
+			prDDPins.println("  (registeredBy [" + lAttr.registeredByValue+ "])");
+			prDDPins.println("  (registrationAuthorityIdentifier [" + lAttr.registrationAuthorityIdentifierValue + "])");
+			prDDPins.println("  (representing ");
+			if (lAttr.isEnumerated) {
+				prDDPins.println("    [" + lAttr.evdDataIdentifier + "])");
+			} else {
+				prDDPins.println("    [" + lAttr.nevdDataIdentifier + "])");				
+			}
+// propagated			prDDPins.println("  (isInactive \"" + lAttr.isInactive + "\")");
+			prDDPins.println("  (isDeprecated \"" + lAttr.isDeprecated + "\")");
+			prDDPins.println("  (isNillable \"" + lAttr.isNilable + "\")");
+			prDDPins.println("  (steward [" + lAttr.steward + "])");
+			prDDPins.println("  (submitter [" + lAttr.submitter + "])");
+			prDDPins.println("  (terminologicalEntry [" + lAttr.teDataIdentifier + "])");
+			prDDPins.println("  (versionIdentifier \"" + lAttr.versionIdentifierValue + "\"))");
+		}
+	}
+	
+	// Print the the Protege Pins VD
+	private  void printPDDPVD (PrintWriter prDDPins) {
+		// print the value domain
+
+		ArrayList <DOMAttr> lSortedAttrArr = getSortedAttrs ();
+		for (Iterator<DOMAttr> i = lSortedAttrArr.iterator(); i.hasNext();) {
+			DOMAttr lDOMAttr = (DOMAttr) i.next();
+			if (lDOMAttr.isEnumerated) {
+				prDDPins.println("([" + lDOMAttr.evdDataIdentifier + "] of EnumeratedValueDomain");
+			} else {
+				prDDPins.println("([" + lDOMAttr.nevdDataIdentifier  + "] of NonEnumeratedValueDomain");	
+			}
+			prDDPins.println("  (administrationRecord [" + DMDocument.administrationRecordValue + "])");
+			if (lDOMAttr.isEnumerated) {
+				if ( ! (lDOMAttr.domPermValueArr == null || lDOMAttr.domPermValueArr.isEmpty())) {
+					boolean isNewLine = false;
+					prDDPins.println("  (containedIn1 ");
+					// get the permissible value instance identifiers	
+					for (Iterator<DOMProp> j = lDOMAttr.domPermValueArr.iterator(); j.hasNext();) {
+						DOMProp lDOMProp = (DOMProp) j.next();
+						if ( ! (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMPermValDefn)) continue;
+						DOMPermValDefn lDOMPermValDefn = (DOMPermValDefn) lDOMProp.hasDOMObject;
+						if (isNewLine) prDDPins.println("");
+						if (lDOMPermValDefn != null) {
+				 			int lHashCodeI = lDOMPermValDefn.value.hashCode();
+							String lHashCodeS = Integer.toString(lHashCodeI);
+							String pvIdentifier =  "pv." + lDOMAttr.dataIdentifier + "." + lHashCodeS;	// permissible value
+							prDDPins.print("    [" + pvIdentifier  + "]");
+						}
+						isNewLine = true;
+					}
+					prDDPins.println(")");
+				}
+				prDDPins.println("  (dataIdentifier \"" + lDOMAttr.evdDataIdentifier  + "\")");
+			} else {
+				prDDPins.println("  (dataIdentifier \"" + lDOMAttr.nevdDataIdentifier  + "\")");				
+			}
+			prDDPins.println("  (datatype [" + lDOMAttr.valueType + "])");
+			prDDPins.println("  (maximumCharacterQuantity \"" + lDOMAttr.maximum_characters + "\")");
+			prDDPins.println("  (minimumCharacterQuantity \"" + lDOMAttr.minimum_characters + "\")");
+			prDDPins.println("  (maximumValue \"" + lDOMAttr.maximum_value + "\")");
+			prDDPins.println("  (minimumValue \"" + lDOMAttr.minimum_value + "\")");
+			prDDPins.println("  (pattern \"" + DOMInfoModel.escapeProtegePatterns(lDOMAttr.pattern) + "\")");
+			prDDPins.println("  (valueDomainFormat \"" + DOMInfoModel.escapeProtegePatterns(lDOMAttr.format) + "\")");
+			prDDPins.println("  (registeredBy " + lDOMAttr.registeredByValue+ ")");
+			prDDPins.println("  (registrationAuthorityIdentifier [" + lDOMAttr.registrationAuthorityIdentifierValue + "])");
+			prDDPins.println("  (representedBy" + " [" + lDOMAttr.deDataIdentifier + "])");
+			prDDPins.println("  (representedBy2" + " [" + "CD_" + lDOMAttr.dataConcept + "])");
+			prDDPins.println("  (steward [" + "Steward_PDS" + "])");
+			prDDPins.println("  (submitter [" + lDOMAttr.submitter + "])");
+			prDDPins.println("  (unitOfMeasure [" + lDOMAttr.unit_of_measure_type + "])");			
+			prDDPins.println("  (defaultUnitId \"" + lDOMAttr.default_unit_id + "\")");
+			
+			int allowedUnitIdLmt = lDOMAttr.allowedUnitId.size();
+			if (allowedUnitIdLmt > 0) {
+				int allowedUnitIdInd = 1;
+				prDDPins.println("  (allowedUnitId");
+				boolean isNewLine = true;				
+				for (Iterator<String> j = lDOMAttr.allowedUnitId.iterator(); j.hasNext();) {
+					String lUnitId = (String) j.next();
+					if (allowedUnitIdInd == allowedUnitIdLmt) isNewLine = false;
+					if (isNewLine) prDDPins.println("    \"" + lUnitId + "\"");
+					else           prDDPins.print("    \"" + lUnitId + "\"");
+				}
+				prDDPins.println(")");
+			}
+			
+			prDDPins.println("  (versionIdentifier \"" + lDOMAttr.versionIdentifierValue + "\"))");
+			
+			if (lDOMAttr.isEnumerated) {				
+				for (Iterator<DOMProp> j = lDOMAttr.domPermValueArr.iterator(); j.hasNext();) {
+					DOMProp lDOMProp = (DOMProp) j.next();
+					if ( ! (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMPermValDefn)) continue;
+					DOMPermValDefn lDOMPermValDefn = (DOMPermValDefn) lDOMProp.hasDOMObject;
+					if (lDOMPermValDefn != null) {
+			 			int lHashCodeI = lDOMPermValDefn.value.hashCode();
+						String lHashCodeS = Integer.toString(lHashCodeI);
+						String pvIdentifier =  "pv." + lDOMAttr.dataIdentifier + "." + lHashCodeS;	// permissible value
+						String vmIdentifier =  "vm." + lDOMAttr.dataIdentifier + "." + lHashCodeS;
+						prDDPins.println("([" + pvIdentifier + "] of PermissibleValue");
+						prDDPins.println("  (beginDate \"" + DMDocument.beginDatePDS4Value + "\")");
+						prDDPins.println("  (containing1 [" + lDOMAttr.evdDataIdentifier + "])");
+						prDDPins.println("  (endDate \"" + DMDocument.endDateValue + "\")");
+// propagated			prDDPins.println("  (isInactive \"" + lDOMPermValDefn.isInactive + "\")");
+						prDDPins.println("  (isDeprecated \"" + lDOMPermValDefn.isDeprecated + "\")");
+						prDDPins.println("  (usedIn [" + vmIdentifier + "])");
+						prDDPins.println("  (value \"" + DOMInfoModel.escapeProtegeString(lDOMPermValDefn.value) + "\"))");
+						prDDPins.println(" ");
+						prDDPins.println("([" + vmIdentifier + "] of ValueMeaning");
+						prDDPins.println("  (beginDate \"" + DMDocument.beginDatePDS4Value + "\")");
+						prDDPins.println("  (containing1 [" + lDOMAttr.evdDataIdentifier + "])");
+						prDDPins.println("  (endDate \"" + DMDocument.endDateValue + "\")");
+						prDDPins.println("  (description \"" + DOMInfoModel.escapeProtegeString(lDOMPermValDefn.value_meaning) + "\"))");
+						prDDPins.println(" ");
+					}
+				}
+			}
+		}
+	}
+
+	// Print the the Protege Pins Properties
+	private  void printPDDPPR (PrintWriter prDDPins) {
+		for (DOMProp lDOMProp : DOMInfoModel.getMasterDOMPropArr()) {
+			String prDataIdentifier = "PR." + lDOMProp.identifier;
+			prDDPins.println("([" + prDataIdentifier + "] of Property");
+			prDDPins.println("  (administrationRecord [" + DMDocument.administrationRecordValue + "])");
+			prDDPins.println("  (dataIdentifier \"" + prDataIdentifier + "\")");
+			prDDPins.println("  (registeredBy [" + DMDocument.registeredByValue + "])");
+			prDDPins.println("  (registrationAuthorityIdentifier [" + DMDocument.registrationAuthorityIdentifierValue + "])");						
+			prDDPins.println("  (classOrder \"" + lDOMProp.classOrder + "\")");
+			prDDPins.println("  (versionIdentifier \"" + DMDocument.versionIdentifierValue + "\"))");
+		}
+	}
+
+	// Print the the Protege Pins CD
+	private  void printPDDPCD (PrintWriter prDDPins) {
+		ArrayList <DOMIndexDefn> lCDAttrArr = new ArrayList <DOMIndexDefn> (DOMInfoModel.cdDOMAttrMap.values());
+		for (Iterator<DOMIndexDefn> i = lCDAttrArr.iterator(); i.hasNext();) {
+			DOMIndexDefn lIndex = (DOMIndexDefn) i.next();
+			String gIdentifier = lIndex.identifier;
+			String dbIdentifier = "CD_" + gIdentifier;
+			prDDPins.println("([" + dbIdentifier  + "] of ConceptualDomain");
+			prDDPins.println("	(administrationRecord [" + DMDocument.administrationRecordValue + "])");
+			prDDPins.println("	(dataIdentifier \"" + dbIdentifier  + "\")");
+
+			boolean isNewLine = false;
+			prDDPins.println("  (having ");
+			for (Iterator<String> j = lIndex.getSortedIdentifier2Arr().iterator(); j.hasNext();) {
+				String lDEC = (String) j.next();
+				if (isNewLine) prDDPins.println("");
+				prDDPins.print("    [" + "DEC_" + lDEC + "]");
+				isNewLine = true;
+			}
+			prDDPins.println(")");
+			prDDPins.println(" 	(registeredBy [" + DMDocument.registeredByValue+ "])");
+			prDDPins.println(" 	(registrationAuthorityIdentifier [" + DMDocument.registrationAuthorityIdentifierValue + "])");
+
+			isNewLine = false;
+			prDDPins.println("  (representing2 ");
+			for (Iterator<DOMAttr> j = lIndex.getSortedIdentifier1Arr().iterator(); j.hasNext();) {
+				DOMAttr lAttr = (DOMAttr) j.next();
+				if (isNewLine) prDDPins.println("");
+				if (lAttr.isEnumerated) {
+					prDDPins.print("    [" + lAttr.evdDataIdentifier + "]");
+				} else {
+					prDDPins.print("    [" + lAttr.nevdDataIdentifier + "]");
+				}
+				isNewLine = true;
+			}
+			prDDPins.println(")");
+			prDDPins.println(" 	(steward [" + DMDocument.stewardValue + "])");
+			prDDPins.println(" 	(submitter [" + DMDocument.submitterValue + "])");
+			prDDPins.println(" 	(terminologicalEntry [" + "TE." + gIdentifier + "])");
+			prDDPins.println(" 	(versionIdentifier \"" + DMDocument.versionIdentifierValue + "\"))");
+		
+			// write terminological entry
+			String teIdentifier = "TE." + gIdentifier;
+			String defIdentifier = "DEF." + gIdentifier;
+			String desIdentifier = "DES." + gIdentifier;
+			prDDPins.println("([" + teIdentifier + "] of TerminologicalEntry");
+			prDDPins.println(" (administeredItemContext [NASA_PDS])");
+			prDDPins.println(" (definition [" + defIdentifier + "])");
+			prDDPins.println(" (designation [" + desIdentifier + "])");
+			prDDPins.println(" (sectionLanguage [LI_English]))");
+			prDDPins.println("([" + defIdentifier + "] of Definition");
+			prDDPins.println(" (definitionText \"TBD_DEC_Definition\")");
+			prDDPins.println(" (isPreferred \"TRUE\"))");
+			prDDPins.println("([" + desIdentifier + "] of Designation");
+			prDDPins.println(" (designationName \"" + gIdentifier + "\")");
+			prDDPins.println(" (isPreferred \"TRUE\"))");
+		}
+	}
+	
+	// Print the the Protege Pins DEC
+	private  void printPDDPDEC (PrintWriter prDDPins) {
+		ArrayList <DOMIndexDefn> lDECAttrArr = new ArrayList <DOMIndexDefn> (DOMInfoModel.decDOMAttrMap.values());
+		for (Iterator<DOMIndexDefn> i = lDECAttrArr.iterator(); i.hasNext();) {
+			DOMIndexDefn lIndex = (DOMIndexDefn) i.next();
+			String gIdentifier = lIndex.identifier;
+			String dbIdentifier = "DEC_" + gIdentifier;
+			prDDPins.println("([" + dbIdentifier  + "] of DataElementConcept");
+			prDDPins.println("	(administrationRecord [" + DMDocument.administrationRecordValue + "])");
+			prDDPins.println("	(dataIdentifier \"" + dbIdentifier  + "\")");
+
+			boolean isNewLine = false;
+			prDDPins.println("  (expressing ");
+			for (Iterator<DOMAttr> j = lIndex.getSortedIdentifier1Arr().iterator(); j.hasNext();) {
+				DOMAttr lAttr = (DOMAttr) j.next();
+				if (isNewLine) prDDPins.println("");
+				prDDPins.print("    [" + lAttr.deDataIdentifier + "]");
+				isNewLine = true;
+			}
+			prDDPins.println(")");
+			prDDPins.println(" 	(registeredBy [" + DMDocument.registeredByValue+ "])");
+			prDDPins.println(" 	(registrationAuthorityIdentifier [" + DMDocument.registrationAuthorityIdentifierValue + "])");
+			isNewLine = false;
+			prDDPins.println("  (specifying ");
+			for (Iterator<String> j = lIndex.getSortedIdentifier2Arr().iterator(); j.hasNext();) {
+				String lCD = (String) j.next();
+				if (isNewLine) prDDPins.println("");
+				prDDPins.print("    [" + "CD_" + lCD + "]");
+				isNewLine = true;
+			}
+			prDDPins.println(")");
+			prDDPins.println(" 	(steward [" + DMDocument.stewardValue + "])");
+			prDDPins.println(" 	(submitter [" + DMDocument.submitterValue + "])");
+			prDDPins.println(" 	(terminologicalEntry [" + "TE." + gIdentifier + "])");
+			prDDPins.println(" 	(versionIdentifier \"" + DMDocument.versionIdentifierValue + "\"))");
+			
+			// write the terminological entry
+			
+			String teIdentifier = "TE." + gIdentifier;
+			String defIdentifier = "DEF." + gIdentifier;
+			String desIdentifier = "DES." + gIdentifier;
+			prDDPins.println("([" + teIdentifier + "] of TerminologicalEntry");
+			prDDPins.println(" (administeredItemContext [NASA_PDS])");
+			prDDPins.println(" (definition [" + defIdentifier + "])");
+			prDDPins.println(" (designation [" + desIdentifier + "])");
+			prDDPins.println(" (sectionLanguage [LI_English]))");
+			prDDPins.println("([" + defIdentifier + "] of Definition");
+			prDDPins.println(" (definitionText \"TBD_DEC_Definition\")");
+			prDDPins.println(" (isPreferred \"TRUE\"))");
+			prDDPins.println("([" + desIdentifier + "] of Designation");
+			prDDPins.println(" (designationName \"" + gIdentifier + "\")");
+			prDDPins.println(" (isPreferred \"TRUE\"))");
+		}
+	}
+	
+	// Print the the Protege Pins TE for Data Elements
+	private  void printPDDPTEDE (PrintWriter prDDPins) {
+		
+		// print the Terminological Entry
+		for (DOMAttr lDOMAttr : DOMInfoModel.getMasterDOMAttrArr()) {
+			if (lDOMAttr.isUsedInClass && lDOMAttr.isAttribute) {
+				// print TE section
+				prDDPins.println("([" + lDOMAttr.teDataIdentifier + "] of TerminologicalEntry");
+				prDDPins.println("  (administeredItemContext [NASA_PDS])");
+				prDDPins.println("  (definition ["  + lDOMAttr.defDataIdentifier + "])");
+				prDDPins.println("  (designation [" + lDOMAttr.desDataIdentifier + "])");
+				prDDPins.println("  (sectionLanguage [" + "LI_English" + "]))");
+		
+				// print definition section
+				prDDPins.println("([" + lDOMAttr.defDataIdentifier + "] of Definition");
+				prDDPins.println("  (definitionText \"" + DOMInfoModel.escapeProtegeString(lDOMAttr.definition) + "\")");
+				prDDPins.println("  (isPreferred \"" + "TRUE" + "\"))");
+				
+				// print designation section
+				prDDPins.println("([" + lDOMAttr.desDataIdentifier + "] of Designation");
+				prDDPins.println("  (designationName \"" + lDOMAttr.title + "\")");
+				prDDPins.println("  (isPreferred \"" + "TRUE" + "\"))");
+			}
+		}
+	}	
+	
+	// Print the the Protege Pins TE for Object Classes
+	private  void printPDDPTEOC (PrintWriter prDDPins) {
+		
+		// print the Terminological Entry
+		for (DOMClass lDOMClass : DOMInfoModel.getMasterDOMClassArr()) {
+			if (lDOMClass.title.compareTo(lDOMClass.title) == 0) { // always true
+				// print TE section
+				prDDPins.println("([" + lDOMClass.teDataIdentifier + "] of TerminologicalEntry");
+				prDDPins.println("  (administeredItemContext [NASA_PDS])");
+				prDDPins.println("  (definition ["  + lDOMClass.defDataIdentifier + "])");
+				prDDPins.println("  (designation [" + lDOMClass.desDataIdentifier + "])");
+				prDDPins.println("  (sectionLanguage [" + "LI_English" + "]))");
+		
+				// print definition section
+				prDDPins.println("([" + lDOMClass.defDataIdentifier + "] of Definition");
+				prDDPins.println("  (definitionText \"" + DOMInfoModel.escapeProtegeString(lDOMClass.definition) + "\")");
+				prDDPins.println("  (isPreferred \"" + "TRUE" + "\"))");
+				
+				// print designation section
+				prDDPins.println("([" + lDOMClass.desDataIdentifier + "] of Designation");
+				prDDPins.println("  (designationName \"" + lDOMClass.title + "\")");
+				prDDPins.println("  (isPreferred \"" + "TRUE" + "\"))");
+			}
+		}
+	}	
+
+	// Print the the Protege Pins Misc
+	private  void printPDDPMISC (PrintWriter prDDPins) {
+		// print the Miscellaneous records
+		prDDPins.println("([" + DMDocument.administrationRecordValue + "] of AdministrationRecord");
+		prDDPins.println("	(administrativeNote \"This is a test load of the PDS4 Data Dictionary from the PDS4 Information Model.\")");
+		prDDPins.println("	(administrativeStatus Final)");
+		prDDPins.println("	(changeDescription \"PSDD content has been merged into the model.\")");
+		prDDPins.println("	(creationDate \"2010-03-10\")");
+		prDDPins.println("	(effectiveDate \"2010-03-10\")");
+		prDDPins.println("	(explanatoryComment \"This test load is a merge of the PDS4 Information Model and the Planetary Science Data Dictionary (PSDD).\")");
+		prDDPins.println("	(lastChangeDate \"2010-03-10\")");
+		prDDPins.println("	(origin \"Planetary Data System\")");
+		prDDPins.println("	(registrationStatus Preferred)");
+		prDDPins.println("	(unresolvedIssue \"Issues still being determined.\")");
+		prDDPins.println("	(untilDate \"" + DMDocument.endDateValue + "\"))");
+		
+		prDDPins.println("([" + DMDocument.registrationAuthorityIdentifierValue + "] of RegistrationAuthorityIdentifier");
+		prDDPins.println("	(internationalCodeDesignator \"0001\")");
+		prDDPins.println("	(opiSource \"1\")");
+		prDDPins.println("	(organizationIdentifier \"National Aeronautics and Space Administration\")");
+		prDDPins.println("	(organizationPartIdentifier \"Planetary Data System\"))");
+
+		prDDPins.println("([" + DMDocument.registeredByValue + "] of RegistrationAuthority");
+		prDDPins.println("	(documentationLanguageIdentifier [LI_English])");
+		prDDPins.println("	(languageUsed [LI_English])");
+		prDDPins.println("	(organizationMailingAddress \"4800 Oak Grove Drive\")");
+		prDDPins.println("	(organizationName \"NASA Planetary Data System\")");
+		prDDPins.println("	(registrar [PDS_Registrar])");
+		prDDPins.println("	(registrationAuthorityIdentifier_v [" + DMDocument.registrationAuthorityIdentifierValue + "]))");
+	
+		prDDPins.println("([NASA_PDS] of Context");
+		prDDPins.println("	(dataIdentifier  \"NASA_PDS\"))");
+		
+		prDDPins.println("([PDS_Registrar] of  Registrar");
+		prDDPins.println("	(contact [PDS_Standards_Coordinator])");
+		prDDPins.println("	(registrarIdentifier \"PDS_Registrar\"))");
+		
+		prDDPins.println("([Steward_PDS] of Steward");
+		prDDPins.println("	(contact [PDS_Standards_Coordinator])");
+		prDDPins.println("	(organization [" + DMDocument.registeredByValue + "]))");
+		
+		prDDPins.println("([" + DMDocument.masterPDSSchemaFileDefn.identifier + "] of Steward");
+		prDDPins.println("	(contact [PDS_Standards_Coordinator])");
+		prDDPins.println("	(organization [" + DMDocument.registeredByValue + "]))");
+		
+		// ops is not included as a defined namespace in the SchemaFileDefn array
+		prDDPins.println("([ops] of Steward");
+		prDDPins.println("	(contact [PDS_Standards_Coordinator])");
+		prDDPins.println("	(organization [" + DMDocument.registeredByValue + "]))");
+		
+		prDDPins.println("([Submitter_PDS] of Submitter");
+		prDDPins.println("	(contact [DataDesignWorkingGroup])");
+		prDDPins.println("	(organization [" + DMDocument.registeredByValue + "]))");
+		
+		prDDPins.println("([PDS_Standards_Coordinator] of Contact");
+		prDDPins.println("	(contactTitle \"PDS_Standards_Coordinator\")");
+		prDDPins.println("	(contactMailingAddress \"4800 Oak Grove Dr, Pasadena, CA 91109\")");
+		prDDPins.println("	(contactEmailAddress \"Elizabeth.Rye@jpl.nasa.gov\")");
+		prDDPins.println("	(contactInformation \"Jet Propulsion Laboratory\")");
+		prDDPins.println("	(contactPhone \"818.354.6135\")");
+		prDDPins.println("	(contactName \"Elizabeth Rye\"))");
+		
+		prDDPins.println("([DataDesignWorkingGroup] of Contact");
+		prDDPins.println("	(contactEmailAddress \"Steve.Hughes@jpl.nasa.gov\")");
+		prDDPins.println("	(contactInformation \"Jet Propulsion Laboratory\")");
+		prDDPins.println("	(contactPhone \"818.354.9338\")");
+		prDDPins.println("	(contactName \"J. Steven Hughes\"))");
+		
+		prDDPins.println("([LI_English] of LanguageIdentification");
+		prDDPins.println("  (countryIdentifier \"USA\")");
+		prDDPins.println("  (languageIdentifier \"English\"))");
+			
+		// write the unitOfMeasure
+		for (DOMUnit lDOMUnit : DOMInfoModel.getMasterDOMUnitArr()) {	
+			prDDPins.println("([" + lDOMUnit.title + "] of UnitOfMeasure");
+			prDDPins.println("	(measureName \"" + lDOMUnit.title + "\")");
+			prDDPins.println("	(defaultUnitId \"" + DOMInfoModel.escapeProtegeString(lDOMUnit.default_unit_id) + "\")");
+			prDDPins.println("	(precision \"" + "TBD_precision" + "\")");
+			if (! lDOMUnit.unit_id.isEmpty() )
+			{
+				String lSpace = "";
+				prDDPins.print("	(unitId ");
+				// set the units
+				for (Iterator<String> j = lDOMUnit.unit_id.iterator(); j.hasNext();) {
+					String lVal = (String) j.next();
+					prDDPins.print(lSpace + "\"" + DOMInfoModel.escapeProtegeString(lVal) + "\"");
+					lSpace = " ";
+				}
+				prDDPins.println("))");
+			}
+		}
+		
+		// write the TBD_unitOfMeasure		
+		prDDPins.println("([" + "TBD_unit_of_measure_type" + "] of UnitOfMeasure");
+		prDDPins.println("	(measureName \"" + "TBD_unit_of_measure_type" + "\")");
+		prDDPins.println("	(defaultUnitId \"" + "defaultUnitId" + "\")");
+		prDDPins.println("	(precision \"" + "TBD_precision" + "\")");
+		prDDPins.println("	(unitId \"" + "TBD_unitId" + "\"))");
+		
+		// print data types
+		for (DOMDataType lDOMDataType : DOMInfoModel.getMasterDOMDataTypeArr()) {
+			prDDPins.println("([" + lDOMDataType.title + "] of DataType");
+			prDDPins.println("  (dataTypeName \"" + lDOMDataType.title + "\")");
+			prDDPins.println("  (dataTypeSchemaReference \"TBD_dataTypeSchemaReference\"))");
+		}
+	}
+	
+	/**
+	*  sort attributes by class and namespaces
+	*/
+	private ArrayList <DOMAttr> getSortedAttrs () {
+		TreeMap <String, DOMAttr> lTreeMap = new TreeMap <String, DOMAttr>();
+		for (DOMAttr lDOMAttr : DOMInfoModel.getMasterDOMAttrArr()) {
+			if (lDOMAttr.isUsedInClass && lDOMAttr.isAttribute) {
+				String sortKey = lDOMAttr.title + ":" + lDOMAttr.steward + "." + lDOMAttr.parentClassTitle + ":" + lDOMAttr.classSteward;
+				sortKey = sortKey.toUpperCase();
+				lTreeMap.put(sortKey, lDOMAttr);
+			}
+		}
+		ArrayList <DOMAttr> lSortedAttrArr = new ArrayList <DOMAttr> (lTreeMap.values());		
+		return lSortedAttrArr; 
+	}
+}	

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java
@@ -122,6 +122,7 @@ class WriteDOMDDJSONFile extends Object{
 		ArrayList <DOMClass> lSelectedClassArr = new ArrayList <DOMClass> ();
 		for (Iterator <DOMClass> j = DOMInfoModel.masterDOMClassArr.iterator(); j.hasNext();) {
 			DOMClass lSelectedClass = (DOMClass) j.next();
+			if (lSelectedClass.isInactive) continue;
 			if (isAllFlag || lNameSpaceIdNC.compareTo(lSelectedClass.nameSpaceIdNC) == 0) {
 				lSelectedClassArr.add(lSelectedClass);
 			}
@@ -139,6 +140,7 @@ class WriteDOMDDJSONFile extends Object{
 		ArrayList <DOMAttr> lSelectedAttrArr = new ArrayList <DOMAttr> ();
 		for (Iterator <DOMAttr> j = DOMInfoModel.masterDOMAttrArr.iterator(); j.hasNext();) {
 			DOMAttr lSelectedAttr = (DOMAttr) j.next();
+			if (lSelectedAttr.isInactive) continue;
 			if (isAllFlag || lNameSpaceIdNC.compareTo(lSelectedAttr.classNameSpaceIdNC) == 0) {
 				lSelectedAttrArr.add(lSelectedAttr);
 			}
@@ -153,6 +155,7 @@ class WriteDOMDDJSONFile extends Object{
 		ArrayList <DOMDataType> lSelectedDataTypeArr = new ArrayList <DOMDataType> ();
 		for (Iterator <DOMDataType> j = DOMInfoModel.masterDOMDataTypeArr.iterator(); j.hasNext();) {
 			DOMDataType lSelectedDataType = (DOMDataType) j.next();
+			if (lSelectedDataType.isInactive) continue;
 			if (isAllFlag || lNameSpaceIdNC.compareTo(lSelectedDataType.nameSpaceIdNC) == 0) {
 				lSelectedDataTypeArr.add(lSelectedDataType);
 			}
@@ -167,6 +170,7 @@ class WriteDOMDDJSONFile extends Object{
 		ArrayList <DOMUnit> lSelectedUnitArr = new ArrayList <DOMUnit> ();
 		for (Iterator <DOMUnit> j = DOMInfoModel.masterDOMUnitArr.iterator(); j.hasNext();) {
 			DOMUnit lSelectedUnit = (DOMUnit) j.next();
+			if (lSelectedUnit.isInactive) continue;
 			if (isAllFlag || lNameSpaceIdNC.compareTo(lSelectedUnit.nameSpaceIdNC) == 0) {
 				lSelectedUnitArr.add(lSelectedUnit);
 			}
@@ -195,6 +199,7 @@ class WriteDOMDDJSONFile extends Object{
 		ArrayList <DOMClass> lSelectedTEClassArr = new ArrayList <DOMClass> ();
 		for (Iterator <DOMClass> j = DOMInfoModel.masterDOMClassArr.iterator(); j.hasNext();) {
 			DOMClass lDOMClass = (DOMClass) j.next();
+			if (lDOMClass.isInactive) continue;
 			if (! lDOMClass.isQueryModel) continue;
 			lSelectedTEClassArr.add(lDOMClass);
 		}
@@ -207,7 +212,6 @@ class WriteDOMDDJSONFile extends Object{
 	// Print the classes
 	public  void printClass (ArrayList <DOMClass> lSelectedClassArr, PrintWriter prDDPins) {
 		String delimiter1 = "  ";
-//		ArrayList <DOMClass> lClassArr = new ArrayList <DOMClass> (DOMInfoModel.masterDOMClassIdMap.values());
 		for (Iterator<DOMClass> i = lSelectedClassArr.iterator(); i.hasNext();) {
 			DOMClass lClass = (DOMClass) i.next();
 			if (lClass.title.indexOf("PDS3") > -1) continue;
@@ -278,15 +282,15 @@ class WriteDOMDDJSONFile extends Object{
 				prDDPins.println("                " + formValue("minimumCardinality") + ": " + formValue(lDOMProp.cardMin) + " ,");	
 				prDDPins.println("                " + formValue("maximumCardinality") + ": " + formValue(lDOMProp.cardMax) + " ,");	
 				prDDPins.println("                " + formValue("classOrder") + ": " + formValue(lDOMProp.classOrder) + " ,");	
-				prDDPins.println("                " + formValue("attributeId") + ": [");				
-				String delimiter2 = "";				
+				prDDPins.println("                " + formValue("attributeId") + ": [");
+				boolean isNewLine = false;
 				for (Iterator<ISOClassOAIS11179> j = lDOMPropGroup2.domObjectArr.iterator(); j.hasNext();) {
 					ISOClassOAIS11179 lISOClass = (ISOClassOAIS11179) j.next();
 					if (lISOClass instanceof DOMAttr) {
 						DOMAttr lDOMAttr = (DOMAttr) lISOClass;	
-						prDDPins.print(delimiter2);
+						if (isNewLine) prDDPins.println(",");
 						prDDPins.print("                  " + formValue(lDOMAttr.identifier));	
-						delimiter2 = ",\n";
+						isNewLine = true;
 					}
 				}
 				prDDPins.println("");
@@ -307,14 +311,14 @@ class WriteDOMDDJSONFile extends Object{
 				prDDPins.println("                " + formValue("maximumCardinality") + ": " + formValue(lDOMProp.cardMax) + " ,");	
 				prDDPins.println("                " + formValue("classOrder") + ": " + formValue(lDOMProp.classOrder) + " ,");	
 				prDDPins.println("                " + formValue("classId") + ": [");	
-				String delimiter2 = "";
+				boolean isNewLine = false;
 				for (Iterator<ISOClassOAIS11179> j = lDOMPropGroup2.domObjectArr.iterator(); j.hasNext();) {
 					ISOClassOAIS11179 lISOClass = (ISOClassOAIS11179) j.next();
 					if (lISOClass instanceof DOMClass) {
 						DOMClass lDOMAttr = (DOMClass) lISOClass;	
-						prDDPins.print(delimiter2);
+						if (isNewLine) prDDPins.println(",");
 						prDDPins.print("                  " + formValue(lDOMAttr.identifier));	
-						delimiter2 = ",\n";
+						isNewLine = true;
 					}
 				}
 				prDDPins.println("");
@@ -654,6 +658,7 @@ class WriteDOMDDJSONFile extends Object{
 		ArrayList <DOMProp> lSortedAssocArr = new ArrayList <DOMProp> (DOMInfoModel.masterDOMPropIdMap.values());
 		for (Iterator<DOMProp> i = lSortedAssocArr.iterator(); i.hasNext();) {
 			DOMProp lAssoc = (DOMProp) i.next();
+			if (lAssoc.isInactive) continue;
 			String prDataIdentifier = "PR." + lAssoc.identifier;
 			prDDPins.println("([" + prDataIdentifier + "] of Property");
 			prDDPins.println("  (administrationRecord [" + DMDocument.administrationRecordValue + "])");
@@ -676,31 +681,31 @@ class WriteDOMDDJSONFile extends Object{
 			prDDPins.println("	(administrationRecord [" + DMDocument.administrationRecordValue + "])");
 			prDDPins.println("	(dataIdentifier \"" + dbIdentifier  + "\")");
 
-			String lfc = "";
 			prDDPins.println("  (having ");
+			boolean isNewLine = false;
 			for (Iterator<String> j = lIndex.getSortedIdentifier2Arr().iterator(); j.hasNext();) {
 				String lDEC = (String) j.next();
-				prDDPins.print(lfc);
+				if (isNewLine) prDDPins.println("");
 				prDDPins.print("    [" + "DEC_" + lDEC + "]");
-				lfc = "\n";
+				isNewLine = true;
 			}
-			prDDPins.print(")\n");
+			prDDPins.println(")");
 			prDDPins.println(" 	(registeredBy [" + DMDocument.registeredByValue+ "])");
 			prDDPins.println(" 	(registrationAuthorityIdentifier [" + DMDocument.registrationAuthorityIdentifierValue + "])");
 
-			lfc = "";
 			prDDPins.println("  (representing2 ");
+			isNewLine = false;
 			for (Iterator<DOMAttr> j = lIndex.getSortedIdentifier1Arr().iterator(); j.hasNext();) {
 				DOMAttr lAttr = (DOMAttr) j.next();
-				prDDPins.print(lfc);
+				if (isNewLine) prDDPins.println("");
 				if (lAttr.isEnumerated) {
 					prDDPins.print("    [" + lAttr.evdDataIdentifier + "]");
 				} else {
 					prDDPins.print("    [" + lAttr.nevdDataIdentifier + "]");
 				}
-				lfc = "\n";
+				isNewLine = true;
 			}
-			prDDPins.print(")\n");
+			prDDPins.println(")");
 			prDDPins.println(" 	(steward [" + DMDocument.stewardValue + "])");
 			prDDPins.println(" 	(submitter [" + DMDocument.submitterValue + "])");
 			prDDPins.println(" 	(terminologicalEntry [" + "TE." + gIdentifier + "])");
@@ -735,26 +740,26 @@ class WriteDOMDDJSONFile extends Object{
 			prDDPins.println("	(administrationRecord [" + DMDocument.administrationRecordValue + "])");
 			prDDPins.println("	(dataIdentifier \"" + dbIdentifier  + "\")");
 
-			String lfc = "";
+			boolean isNewLine = false;
 			prDDPins.println("  (expressing ");
 			for (Iterator<DOMAttr> j = lIndex.getSortedIdentifier1Arr().iterator(); j.hasNext();) {
 				DOMAttr lAttr = (DOMAttr) j.next();
-				prDDPins.print(lfc);
+				if (isNewLine) prDDPins.println("");
 				prDDPins.print("    [" + lAttr.deDataIdentifier + "]");
-				lfc = "\n";
+				isNewLine = true;
 			}
-			prDDPins.print(")\n");
+			prDDPins.println(")");
 			prDDPins.println(" 	(registeredBy [" + DMDocument.registeredByValue+ "])");
 			prDDPins.println(" 	(registrationAuthorityIdentifier [" + DMDocument.registrationAuthorityIdentifierValue + "])");
-			lfc = "";
 			prDDPins.println("  (specifying ");
+			isNewLine = false;
 			for (Iterator<String> j = lIndex.getSortedIdentifier2Arr().iterator(); j.hasNext();) {
 				String lCD = (String) j.next();
-				prDDPins.print(lfc);
+				if (isNewLine) prDDPins.println("");
 				prDDPins.print("    [" + "CD_" + lCD + "]");
-				lfc = "\n";
+				isNewLine = true;
 			}
-			prDDPins.print(")\n");
+			prDDPins.println(")");
 			prDDPins.println(" 	(steward [" + DMDocument.stewardValue + "])");
 			prDDPins.println(" 	(submitter [" + DMDocument.submitterValue + "])");
 			prDDPins.println(" 	(terminologicalEntry [" + "TE." + gIdentifier + "])");
@@ -784,6 +789,7 @@ class WriteDOMDDJSONFile extends Object{
 		// print the Terminological Entry
 		for (Iterator<DOMAttr> i = DOMInfoModel.masterDOMAttrArr.iterator(); i.hasNext();) {
 			DOMAttr lAttr = (DOMAttr) i.next();
+			if (lAttr.isInactive) continue;
 			if (lAttr.isUsedInClass && lAttr.isAttribute) {
 				// print TE section
 				prDDPins.println("([" + lAttr.teDataIdentifier + "] of TerminologicalEntry");
@@ -887,6 +893,7 @@ class WriteDOMDDJSONFile extends Object{
 		// write the unitOfMeasure
 		for (Iterator<DOMUnit> i = DOMInfoModel.masterDOMUnitArr.iterator(); i.hasNext();) {
 			DOMUnit lUnit = (DOMUnit) i.next();		
+			if (lUnit.isInactive) continue;
 			prDDPins.println("([" + lUnit.title + "] of UnitOfMeasure");
 			prDDPins.println("	(measureName \"" + lUnit.title + "\")");
 			prDDPins.println("	(defaultUnitId \"" + DOMInfoModel.escapeProtegeString(lUnit.default_unit_id) + "\")");
@@ -915,6 +922,7 @@ class WriteDOMDDJSONFile extends Object{
 		// print data types
 		for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
 			DOMClass lDataType = (DOMClass) i.next();
+			if (lDataType.isInactive) continue;
 			if (! lDataType.isDataType) continue;
 			prDDPins.println("([" + lDataType.title + "] of DataType");
 			prDDPins.println("  (dataTypeName \"" + lDataType.title + "\")");

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
@@ -32,6 +32,8 @@ package gov.nasa.pds.model.plugin;
 import java.io.*;
 import java.util.*;
 
+// Write the PDS4 Data Dictionary DocBook file.
+
 class WriteDOMDocBook extends Object {
 	// class structures
 	TreeMap <String, ClassClassificationDefnDOM> classClassificationMap;
@@ -101,6 +103,7 @@ class WriteDOMDocBook extends Object {
 		// get the class classification maps
 		for (Iterator <DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
 			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
 			getClassClassification (lClass);
 		}
 		
@@ -113,6 +116,7 @@ class WriteDOMDocBook extends Object {
 		// get the attribute classification maps
 		for (Iterator <DOMAttr> i = DOMInfoModel.masterDOMAttrArr.iterator(); i.hasNext();) {
 			DOMAttr lAttr = (DOMAttr) i.next();
+			if (lAttr.isInactive) continue;
 			getAttrClassification (lAttr);
 		}
 		
@@ -697,6 +701,7 @@ class WriteDOMDocBook extends Object {
 		TreeMap <String, DOMClass> sortDataTypeMap = new TreeMap <String, DOMClass> ();
 		for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
 			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
 			if (lNameSpaceIdNC.compareTo(lClass.nameSpaceIdNC) != 0) continue;
 			if (!lClass.isDataType) continue;
 			sortDataTypeMap.put(lClass.title, lClass);
@@ -841,6 +846,7 @@ class WriteDOMDocBook extends Object {
 		TreeMap <String, DOMClass> sortUnitsMap = new TreeMap <String, DOMClass> ();
 		for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
 			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
 			if (lNameSpaceIdNC.compareTo(lClass.nameSpaceIdNC) != 0) continue;
 			if (! lClass.isUnitOfMeasure) continue;
 			sortUnitsMap.put(lClass.title, lClass);
@@ -1161,6 +1167,7 @@ class WriteDOMDocBook extends Object {
 		ArrayList <DOMClass> refClassArr = new ArrayList <DOMClass> ();
 		for (Iterator <DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
 			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
 			if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) != 0) {
 				for (Iterator <DOMProp> j = lClass.ownedAssocArr.iterator(); j.hasNext();) {
 					DOMProp lProp = j.next();

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Wed Sep 08 12:33:54 EDT 2021
+; Thu Feb 03 21:40:39 EST 2022
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Wed Sep 08 12:33:54 EDT 2021
+; Thu Feb 03 21:40:39 EST 2022
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -9653,7 +9653,7 @@
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
-(defclass Schematron_Rule
+(defclass Schematron_Rule "The Schematron_Rule Class is used to capture schemtron rule statements."
 	(is-a TNDO_Supplemental)
 	(role concrete)
 	(single-slot identifier
@@ -9727,7 +9727,7 @@
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
-(defclass Schematron_Assert
+(defclass Schematron_Assert "The Schematron_Assert Class is used to capture schemtron assert statements."
 	(is-a TNDO_Supplemental)
 	(role concrete)
 	(single-slot identifier
@@ -10029,7 +10029,7 @@
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
-(defclass Output_Data
+(defclass Output_Data "The Output_Data Class is used to"
 	(is-a Entity)
 	(role concrete)
 	(single-slot was_generated_by
@@ -10038,15 +10038,15 @@
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
-(defclass Input_Data
+(defclass Input_Data "The Input_Data Class is used to"
 	(is-a Entity)
 	(role concrete))
 
-(defclass Methods
+(defclass Methods "The Methods Class is used to"
 	(is-a Entity)
 	(role concrete))
 
-(defclass Config
+(defclass Config "The Config Class is used to"
 	(is-a Entity)
 	(role concrete))
 
@@ -10776,7 +10776,7 @@
 ;+		(allowed-classes DD_Permissible_Value_Full)
 		(create-accessor read-write)))
 
-(defclass DD_Static_Permissible_Value
+(defclass DD_Static_Permissible_Value "The DD_Static_Permissible_Value Class is used to"
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
 	(single-slot local_identifier
@@ -13476,7 +13476,7 @@
 	(is-a USER)
 	(role concrete))
 
-(defclass ChangeLog
+(defclass ChangeLog "The ChangeLog Class is used to capture chages."
 	(is-a USER)
 	(role concrete)
 	(single-slot desc


### PR DESCRIPTION
Issue #428 - IMTool Refactoring - Phase 2 - Move deprecated values to Protege ontology file.

This is phase 2 of Issue 306 - Refactor Class information from config to Data Dictionary - This phase focuses on moving deprecation information from the code to the Protege ontology. Also the version identifier for classes and attributes are being moved to the ontology file.

Resolves #428
