### PR TITLE
Issue #269 - IM Spec Inconsistent Ordering Permissible Values

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSpecification.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSpecification.java
@@ -987,8 +987,14 @@ private void printAttrUnit (DOMAttr attr) {
 			} else {
 				prhtml.println("<p><i>Extended Value for: " + lPermValueExt.xpath + "</i><br>");
 			}
-		
-			for (Iterator <PermValueDefn> j = lPermValueExt.permValueExtArr.iterator(); j.hasNext();) {
+			
+			// sort the permissible values
+			TreeMap <String, PermValueDefn> sortPermValueDefnMap = new TreeMap <String, PermValueDefn> ();
+			for (PermValueDefn lPermValueDefn : lPermValueExt.permValueExtArr) {
+				sortPermValueDefnMap.put(lPermValueDefn.identifier + lPermValueDefn.value, lPermValueDefn);
+			}
+			ArrayList <PermValueDefn> sortPermValueDefnArr = new ArrayList <PermValueDefn> (sortPermValueDefnMap.values());
+			for (Iterator <PermValueDefn> j = sortPermValueDefnArr.iterator(); j.hasNext();) {
 				PermValueDefn lPermValueDefn = (PermValueDefn) j.next();
 				if (lPermValueDefn.value.compareTo("...") == 0) {
 					elipflag = true;


### PR DESCRIPTION
Issue #269 - The PDS4 IM Specification Document is not consistent in the ordering of Permissible Values.

The use of alphabetical order within the IM specification is wide spread. Sometimes, for no obvious reason the convention is dropped which can lead the unwary (read lazy) to oversights.

See Extended Values for: pds:Product_Context/pds:Reference_List/pds:Internal_Reference:
resource_to_target - The resource is associated to a target
target_to_document - The target is associated to a document
target_to_instrument - The target is associated to an instrument
target_to_instrument_host - The target is associated to an instrument_host

Resolves #269
