### PR TITLE
#431 - Stage IM V1.18.0.0 - Fix

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/SchemaFileDefn.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/SchemaFileDefn.java
@@ -331,6 +331,10 @@ public class SchemaFileDefn {
 			if (lDigit.compareTo("15") == 0) lDigit = "F";
 			if (lDigit.compareTo("16") == 0) lDigit = "G";
 			if (lDigit.compareTo("17") == 0) lDigit = "H";
+			if (lDigit.compareTo("18") == 0) lDigit = "I";
+			if (lDigit.compareTo("19") == 0) lDigit = "J";
+			if (lDigit.compareTo("20") == 0) lDigit = "K";
+			if (lDigit.compareTo("21") == 0) lDigit = "L";
 			lId += lDigit;
 		}
 		lab_version_id = lId;
@@ -387,6 +391,10 @@ public class SchemaFileDefn {
 			if (lDigit.compareTo("15") == 0) lDigit = "F";
 			if (lDigit.compareTo("16") == 0) lDigit = "G";
 			if (lDigit.compareTo("17") == 0) lDigit = "H";
+			if (lDigit.compareTo("18") == 0) lDigit = "I";
+			if (lDigit.compareTo("19") == 0) lDigit = "J";
+			if (lDigit.compareTo("20") == 0) lDigit = "K";
+			if (lDigit.compareTo("21") == 0) lDigit = "L";
 			lId += lDigit;
 		}
 		labelVersionID = lId;


### PR DESCRIPTION
Issue #431 - Stage the IMTool system for V1.18.0.0 to allow the implementation of approved SCRs and bug fixes.

Had to fix the conversion of the Version Id from 1.18.0.0 to 1I00 for file names.

Resolves #431
