### PR TITLE
CCB-343 - Revise Product_Metadata_Supplemental Desc

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
@@ -260,10 +260,6 @@ class XML4LabelSchemaDOM extends Object {
 				lEntry = lFileInfo.ont_version_id + " - " + lFileInfo.nameSpaceId + " - " + lFileInfo.lddName + lSpaces73;
 				lEntry = lEntry.substring(0, 73);
 				prXML.println("  <!-- " + lEntry + " -->");
-				
-//				lEntry = "file:" + lFileInfo.sourceFileName + lSpaces73;
-//				lEntry = lEntry.substring(0, 71);
-//				prXML.println("  <!--   " + lEntry + " -->");
 			}
 			prXML.println("  <!--                                                                           -->");
 		}

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Wed Mar 02 09:20:23 EST 2022
+; Thu Mar 03 10:34:10 EST 2022
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Wed Mar 02 09:20:23 EST 2022
+; Thu Mar 03 10:34:10 EST 2022
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -5289,7 +5289,7 @@
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
-(defclass Product_Metadata_Supplemental "The Product_Metadata_Supplemental class is used to provide new, and/or improved, metadata for some or all of the basic products in a single collection. More than one Product_Metadata_Supplemental may apply to any given collection, but a Product_Metadata_Supplemental may only be associated with a single collection. Each Product_Metadata_Supplemental will be a primary member of the collection to which it applies."
+(defclass Product_Metadata_Supplemental "The Product_Metadata_Supplemental class is used to provide new, and/or improved, metadata for some or all of the basic products in a single collection. More than one Product_Metadata_Supplemental may apply to any given collection."
 	(is-a Product)
 	(role concrete)
 	(single-slot reference_list


### PR DESCRIPTION
CCB-343 - Revise Product_Metadata_Supplemental  Description

The request is to remove the restriction that Product_Metadata_Supplemental may only be associated with one collection. Removing this restriction requires changing text in the description of the class in the IM and associated text in the Standards Reference. This change will improve the effective use of Product_Metadata_Supplemental.

Deprecated code was also removed from XML4LabelSchemaDOM

Resolves #448
Refs CCB-343

For testing the IM Spec can be checked. The class description of Product_Metadata_Supplemental has been changed as per the Request Changes section in the SCR.

