### PR TITLE
CCB-339	add Units_of_Power with SI watts as option - Bugfix

### DIFF
--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Thu Mar 10 09:29:41 EST 2022
+; Thu Mar 24 08:27:10 EDT 2022
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -518,7 +518,7 @@
 	(isMissionOnly "false")
 	(roleId "warning")
 	(type "TBD_type")
-	(xpath "DD_Value_Domain/pds:unit_of_measure_type"))
+	(xpath "pds:DD_Value_Domain/pds:unit_of_measure_type"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3ADD_Value_Domain%2Fpds%3Aunit_of_measure_type.100004582.101] of  Schematron_Assert
 
@@ -542,7 +542,7 @@
 	(isMissionOnly "false")
 	(roleId "warning")
 	(type "TBD_type")
-	(xpath "DD_Value_Domain[pds:unit_of_measure_type = ('Units_of_Radiance')]"))
+	(xpath "pds:DD_Value_Domain[pds:unit_of_measure_type = ('Units_of_Radiance')]"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3ADD_Value_Domain%5Bpds%3Aunit_of_measure_type+%3D+%28%27Units_of_Radiance%27%29%5D.100004583.101] of  Schematron_Assert
 

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Thu Mar 10 09:29:41 EST 2022
+; Thu Mar 24 08:27:10 EDT 2022
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -27,16 +27,16 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
+	(multislot dd_class_reference
+;+		(comment "The dd_class_reference association is a relationship to DD_Class_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes DD_Class_Reference)
+		(create-accessor read-write))
 	(single-slot cross_reference_area
 ;+		(comment "The cross_reference_area association is a relationship to Cross_Reference_Area a set of identifiers that reference other products.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot dd_class_reference
-;+		(comment "The dd_class_reference association is a relationship to DD_Class_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Class_Reference)
 		(create-accessor read-write))
 	(multislot lowest_detectable_opacity
 ;+		(comment "lowest_detectable_opacity indicates the sensitivity of a ring occultation data set to nearly opaque rings. It specifies the rough value for the smallest normal ring opacity that can be detected in the data at the resolution provided, incorporating both statistical effects and calibration uncertainties. Strongly recommended in labels of ring occultation observations. Not intended as a value for a table field.")
@@ -48,23 +48,28 @@
 ;+		(value "2TB")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot type_list_identifer
-;+		(comment "The type_list_identifier attribute identifies the list from which the values in the type_list were selected.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot field_length
-;+		(comment "The field_length attribute provides the number of bytes in the field.")
-		(type INTEGER)
-		(create-accessor read-write))
 	(single-slot median
 ;+		(comment "The median attribute provides the number separating the higher half of the values from the lower half; empty and Special_Constants values are excluded.")
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot field_length
+;+		(comment "The field_length attribute provides the number of bytes in the field.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot type_list_identifer
+;+		(comment "The type_list_identifier attribute identifies the list from which the values in the type_list were selected.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot has_Geo_Transformation
 ;+		(comment "The xxx association is a relationship to yyy.")
 		(type INSTANCE)
 ;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot east_bounding_coordinate
+;+		(comment "The east_bounding_coordinate attribute provides the eastern-most coordinate of the limit of coverage expressed in longitude.")
+		(type FLOAT)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot created_by
 ;+		(comment "The created_by slot provides the names of the people who create the data set.")
@@ -72,23 +77,18 @@
 ;+		(allowed-classes)
 		(cardinality 1 10)
 		(create-accessor read-write))
-	(single-slot east_bounding_coordinate
-;+		(comment "The east_bounding_coordinate attribute provides the eastern-most coordinate of the limit of coverage expressed in longitude.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot lidvid_reference_from
 ;+		(comment "The lid_reference_from provides the identifier of the starting object in a one  directional relationship.")
 		(type INSTANCE)
 ;+		(allowed-classes LIDVID_ID_Reference_From)
 		(create-accessor read-write))
-	(single-slot instrument_host_desc
-;+		(comment "The instrument_host_desc provides a description of an instrument host")
+	(single-slot mission_start_date
+;+		(comment "The mission_start_date attribute provides the date of the beginning of a mission in UTC system format.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot mission_start_date
-;+		(comment "The mission_start_date attribute provides the date of the beginning of a mission in UTC system format.")
+	(single-slot instrument_host_desc
+;+		(comment "The instrument_host_desc provides a description of an instrument host")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -106,15 +106,15 @@
 ;+		(allowed-classes)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot earth_received_start_time
-;+		(comment "The earth_received_start_time attribute gives the beginning time at which a signal (such a telemetry) was received on Earth.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot occultation_type
 ;+		(comment "occultation_type distinguishes between three types of occultation experiments: Stellar, Solar, or Radio. Stellar occultations involve observing a star as a targeted ring or body passes in front, as seen from either a spacecraft or Earth-based observatory. Solar occultations are similar to stellar occultations except that the Sun is used in place of a star. Radio occultations typically involve observing the continuous-wave radio transmissions from a spacecraft as it passes behind the target as seen from a radio telescope on Earth or another spacecraft. Required in labels of occultation observations. Normally not intended as a value for a table field.")
 		(type STRING)
 ;+		(value "Radio" "Solar" "Stellar")
+		(create-accessor read-write))
+	(single-slot earth_received_start_time
+;+		(comment "The earth_received_start_time attribute gives the beginning time at which a signal (such a telemetry) was received on Earth.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot keyword
 ;+		(comment "The keyword attribute provides one or more words to be used for  keyword search.")
@@ -125,14 +125,14 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot upperleft_corner_x
-;+		(comment "The upperleft_corner_x and upperleft_corner_y attributes provide the projection x and y values, in meters, relative to the map projection origin, at sample 0.5 and line 0.5 (upper left corner of pixel 1,1 within image array).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot group_location
 ;+		(comment "The group_location attribute provides the starting position for a Group_Field within the containing Record or Group_Field class, in bytes. Location '1' indicates the first byte of the containing class.")
 		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot upperleft_corner_x
+;+		(comment "The upperleft_corner_x and upperleft_corner_y attributes provide the projection x and y values, in meters, relative to the map projection origin, at sample 0.5 and line 0.5 (upper left corner of pixel 1,1 within image array).")
+		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot upperleft_corner_y
@@ -151,16 +151,16 @@
 ;+		(allowed-classes)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_scaled_value
-;+		(comment "The minimum_scaled_value attribute provides the minimum value after application of scaling_factor and value_offset (see their definitions; minimum_scaled_value is the minimum of Ov).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot contains_primary_member
 ;+		(comment "The contains_primary_member attribute indicates whether a collection contains products that are primary members of the collection.")
 		(type SYMBOL)
 		(allowed-values FALSE TRUE)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_scaled_value
+;+		(comment "The minimum_scaled_value attribute provides the minimum value after application of scaling_factor and value_offset (see their definitions; minimum_scaled_value is the minimum of Ov).")
+		(type FLOAT)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot calibration_collection_reference
 ;+		(comment "The calibration collection reference attribute provides the logical_identifier for a calibrartion collection.")
@@ -219,14 +219,14 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot property_map_type
+;+		(comment "The property_map_type attribute indicates the category of the property map.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot local_planar_description
 ;+		(comment "The local_planar_description attribute provides a description of the local planar system.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot property_map_type
-;+		(comment "The property_map_type attribute indicates the category of the property map.")
-		(type STRING)
 		(create-accessor read-write))
 	(single-slot axis_index_order
 ;+		(comment "The axis_index_order attribute provides the axis index that varies fastest with respect to storage order.")
@@ -248,22 +248,22 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot upper_110709_Class2
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot color_display_axis
 ;+		(comment "The color_display_axis attribute identifies, by name, the axis of an Array %28or Array subclass%29 that is intended to be displayed in the color dimension of a display device. I.e., bands from this dimension will be loaded into the red, green, and blue bands of the display device. The value of this attribute must match the value of one, and only one, axis_name attribute in an Axis_Array class of the associated Array.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot upper_110709_Class0
+	(single-slot upper_110709_Class2
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot sampling_parameter_name
 ;+		(comment "The sampling_parameter_name element provides the name of the parameter which determines the sampling interval of a particular instrument or dataset parameter. For example, magnetic field intensity is sampled in time increments, and a spectrum is sampled in wavelength or frequency.")
 		(type STRING)
+		(create-accessor read-write))
+	(single-slot upper_110709_Class0
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot upper_110709_Class1
 		(type STRING)
@@ -320,12 +320,12 @@
 ;+		(comment "The maximum_record_bytes atrtribute provides the maximum number of bytes that may be contained in a record.")
 		(type INTEGER)
 		(create-accessor read-write))
-	(multislot property_name
-;+		(comment "The property name attribute provides a word or a combination of words by which a property is known.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot home
 ;+		(comment "The home attribute indicates where  an object resides. It provides sufficient information to be able to access the object.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot property_name
+;+		(comment "The property name attribute provides a word or a combination of words by which a property is known.")
 		(type STRING)
 		(create-accessor read-write))
 	(multislot superclass_name
@@ -337,44 +337,44 @@
 ;+		(allowed-classes Vector_Component)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
+	(single-slot local_planar_georeference_information
+;+		(comment "The local_planar_georeference_information attribute provides a description of the information provided to register the local planar system to a planet %28e.g. control points, satellite ephemeral data, inertial navigation data%29.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot document_format
 ;+		(comment "The document_format attribute associates a Document_Format with the Document_Format_Set.")
 		(type INSTANCE)
 ;+		(allowed-classes Document_Edition)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot local_planar_georeference_information
-;+		(comment "The local_planar_georeference_information attribute provides a description of the information provided to register the local planar system to a planet %28e.g. control points, satellite ephemeral data, inertial navigation data%29.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot volumes
 ;+		(comment "An integer value indicating the number of archive volumes in this delivery.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot longitude_of_central_meridian
+;+		(comment "The longitude_of_central_meridian attribute defines the line of longitude at the center of a map projection generally used as the basis for constructing the projection.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot first_line_sample
+;+		(comment "The first_line_sample attribute provides the sample within a source image line that corresponds to the first line in a sub-image.")
+		(type INTEGER)
 		(create-accessor read-write))
 	(single-slot geometry_collection_reference
 ;+		(comment "The geometry collection reference attribute provides the logical_identifier for a geometry collection.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot first_line_sample
-;+		(comment "The first_line_sample attribute provides the sample within a source image line that corresponds to the first line in a sub-image.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot longitude_of_central_meridian
-;+		(comment "The longitude_of_central_meridian attribute defines the line of longitude at the center of a map projection generally used as the basis for constructing the projection.")
-		(type FLOAT)
+	(multislot local_identifier_reference
+;+		(comment "The local_identifier_reference attribute provides the value of the local_identifier of the entity described by the referencing class. Note that a local_identifier attribute, with the same value as this local_identifier_reference, must be present within the label.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot loop_flag
 ;+		(comment "The loop_flag attribute specifies whether or not a movie object should be played repeatedly without prompting from the user.")
 		(type STRING)
 ;+		(value "false" "true")
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot local_identifier_reference
-;+		(comment "The local_identifier_reference attribute provides the value of the local_identifier of the entity described by the referencing class. Note that a local_identifier attribute, with the same value as this local_identifier_reference, must be present within the label.")
-		(type STRING)
 		(create-accessor read-write))
 	(single-slot expected_packets
 ;+		(comment "The expected_packets attribute provides the total number of telemetry packets which constitute a complete data product, i.e., a data product without missing data.")
@@ -393,22 +393,22 @@
 ;+		(comment "The x attribute provides the value of the x coordinate in a position vector.")
 		(type FLOAT)
 		(create-accessor read-write))
-	(multislot z
-;+		(comment "The z attribute provides the value of the z coordinate in a position vector.")
-		(type FLOAT)
-		(create-accessor read-write))
 	(multislot source
 ;+		(comment "The bibliographic_reference association is a relationship to bibliographic reference.")
 		(type INSTANCE)
 ;+		(allowed-classes External_Reference_Extended)
 		(create-accessor read-write))
-	(multislot supported_operating_system_note
-;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
-		(type STRING)
+	(multislot z
+;+		(comment "The z attribute provides the value of the z coordinate in a position vector.")
+		(type FLOAT)
 		(create-accessor read-write))
 	(single-slot upper_110421_test_Slot_0
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot supported_operating_system_note
+;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot software_type
 ;+		(comment "The software type attribute identifies the class of which the software is a member.")
@@ -439,14 +439,14 @@
 ;+		(comment "The collection_type attribute provides a classification for the collection.")
 		(type STRING)
 		(create-accessor read-write))
+	(multislot source_pds3_id
+;+		(comment "source_pds3_id is the PDS3 product identifier for the source product. If the source product has been archived under PDS4, use the Internal_Reference class in the Investigation_Area. source_pds3_id is constructed as PDS3 dataset_id, a colon, then the PDS3 product_id. The acceptable nil_reasons are 'inapplicable' and 'unknown'.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot reference_longitude
 ;+		(comment "This attribute is used in the image map projection. Under review.")
 		(type STRING)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot source_pds3_id
-;+		(comment "source_pds3_id is the PDS3 product identifier for the source product. If the source product has been archived under PDS4, use the Internal_Reference class in the Investigation_Area. source_pds3_id is constructed as PDS3 dataset_id, a colon, then the PDS3 product_id. The acceptable nil_reasons are 'inapplicable' and 'unknown'.")
-		(type STRING)
 		(create-accessor read-write))
 	(single-slot preference_id
 ;+		(comment "The preference id provides a formal name used to refer to the prefered item.")
@@ -476,60 +476,60 @@
 ;+		(comment "minimum_observed_ring_azimuth specifes the smallest value for observed_ring_azimuth in the data file. Values range from 0 to 360 in units of degrees. Required in label files for ring occultation data.")
 		(type FLOAT)
 		(create-accessor read-write))
+	(multislot time_series_direction
+;+		(comment "time_series_direction indicates the direction the occultation proceeds through the target within a particular data product. Possible values are 'ingress', 'egress', 'both' or 'multiple'. The value 'Multiple' is only used for some Hubble-based occultations where the occultation track is not monotonic over relatively short time scales. Not intended as a value for a table field.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot start_bit_location
 ;+		(comment "The start_bit_location attribute provides the position of the first bit in a bit field relative to the first bit in the parent packed data field. Bytes are sequential and bits are numbered continuously across byte boundaries within a single bit field. The first bit position in the packed data field is \"1\".")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot time_series_direction
-;+		(comment "time_series_direction indicates the direction the occultation proceeds through the target within a particular data product. Possible values are 'ingress', 'egress', 'both' or 'multiple'. The value 'Multiple' is only used for some Hubble-based occultations where the occultation track is not monotonic over relatively short time scales. Not intended as a value for a table field.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot subtype
 		(type STRING)
-		(create-accessor read-write))
-	(single-slot data_type
-;+		(comment "The data_type attribute provides the hardware representation used to store a value.")
-		(type STRING)
-;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot has_document_file
 ;+		(comment "The has_document_file association is a relationship to a document file.")
 		(type INSTANCE)
 ;+		(allowed-classes Document_File)
 		(create-accessor read-write))
+	(single-slot data_type
+;+		(comment "The data_type attribute provides the hardware representation used to store a value.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot telephone_number
 ;+		(comment "The telephone_number attribute provides a telephone number in  international notation which complies with the ITU-T E.164 format recommendation.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot group_number
+;+		(comment "The group_number attribute provides the position of a group, within a series of groups, counting from 1.  If two groups within a record are physically separated by one or more fields, they have consecutive group numbers; the intervening fields are numbered separately.  Groups within a parent group, but separated by one or more fields, will also have consecutive group numbers.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot spice_filename
+;+		(comment "spice_filename gives the file name%28s%29 of SPICE files used in the analysis. Only used if the SPICE files cannot be identified using a LID or LIDVID. Otherwise the association is made in the Reference_Class using the Internal_Reference class. Optional in labels for radio occultation. Nillable in which case the nil_reason should be 'inapplicable'.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot name_
 ;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot spice_filename
-;+		(comment "spice_filename gives the file name%28s%29 of SPICE files used in the analysis. Only used if the SPICE files cannot be identified using a LID or LIDVID. Otherwise the association is made in the Reference_Class using the Internal_Reference class. Optional in labels for radio occultation. Nillable in which case the nil_reason should be 'inapplicable'.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot group_number
-;+		(comment "The group_number attribute provides the position of a group, within a series of groups, counting from 1.  If two groups within a record are physically separated by one or more fields, they have consecutive group numbers; the intervening fields are numbered separately.  Groups within a parent group, but separated by one or more fields, will also have consecutive group numbers.")
-		(type INTEGER)
-		(create-accessor read-write))
 	(single-slot row_bytes
 ;+		(comment "The row bytes attribute provides the count of the bytes in a row.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot external_reference
-;+		(comment "The external_reference association is a relationship to External_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes External_Reference)
-		(create-accessor read-write))
 	(single-slot offset
 ;+		(comment "The offset attribute provides the displacement of the object starting position from the beginning of the parent structure (file, record, etc.).  If there is no displacement, offset=0.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot external_reference
+;+		(comment "The external_reference association is a relationship to External_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes External_Reference)
 		(create-accessor read-write))
 	(multislot has_Local_ID_Relation
 ;+		(comment "The has_Local_ID_Relation association is a relationship to Local_ID_Relation.")
@@ -558,8 +558,13 @@
 ;+		(comment "The category attribute identifies the type of function that the tool or service performs.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot reference_type
-;+		(comment "The reference_type attribute provides the name of the association.")
+	(single-slot country
+;+		(comment "The country attribute provides the full  name of a country.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot naif_target_id
+;+		(comment "The naif_target_id element provides the numeric ID used within the SPICE system to identify the target..")
 		(type STRING)
 		(create-accessor read-write))
 	(single-slot target_desc
@@ -567,38 +572,33 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot naif_target_id
-;+		(comment "The naif_target_id element provides the numeric ID used within the SPICE system to identify the target..")
+	(multislot reference_type
+;+		(comment "The reference_type attribute provides the name of the association.")
 		(type STRING)
-		(create-accessor read-write))
-	(single-slot country
-;+		(comment "The country attribute provides the full  name of a country.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot axis_display
-;+		(comment "The has_Axis_Display association is a relationship to Axis_Display.")
-		(type INSTANCE)
-;+		(allowed-classes)
 		(create-accessor read-write))
 	(single-slot container_type
 ;+		(comment "The container type attribute indicates the method used to package the components.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot axis_display
+;+		(comment "The has_Axis_Display association is a relationship to Axis_Display.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
 	(multislot document_editions
 ;+		(comment "The document_editions attribute provides a count of the total number of complete, distinct editions of the document.")
 		(type STRING)
-		(create-accessor read-write))
-	(single-slot application_process_name
-;+		(comment "The application_process_name attribute provides the name associated with the source or process which created the data.")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot refer_data_set_projection
 ;+		(comment "Associated Data Set Projection.")
 		(type INSTANCE)
 ;+		(allowed-classes)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot application_process_name
+;+		(comment "The application_process_name attribute provides the name associated with the source or process which created the data.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot observing_system_component_type
@@ -615,14 +615,14 @@
 ;+		(comment "The manifest reference attribute provides a reference to a manifest product.")
 		(type STRING)
 		(create-accessor read-write))
+	(multislot minimum_ring_longitude
+;+		(comment "minimum_ring_longitude specifes one boundary for the ring longitude range in the data; normally the smallest value. However, for ranges that cross the prime meridian, the minimum ring longitude will have a value greater than the maximum ring longitude. Values range from 0 to 360 in units of degrees. Required in label files for ring occultation data.")
+		(type FLOAT)
+		(create-accessor read-write))
 	(single-slot volume_version_id
 ;+		(comment "The volume_version_id attribute identifies the version of a data volume. All original volumes should use a volume_version_id of 'Version 1'.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot minimum_ring_longitude
-;+		(comment "minimum_ring_longitude specifes one boundary for the ring longitude range in the data; normally the smallest value. However, for ranges that cross the prime meridian, the minimum ring longitude will have a value greater than the maximum ring longitude. Values range from 0 to 360 in units of degrees. Required in label files for ring occultation data.")
-		(type FLOAT)
 		(create-accessor read-write))
 	(single-slot stop_date
 ;+		(comment "The stop_date attribute provides the date when an activity ended.")
@@ -664,20 +664,20 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Axis_Array
-;+		(comment "The has_Axis_Array association is a relationship to Axis_Array.")
-		(type INSTANCE)
-;+		(allowed-classes Axis_Array)
+	(single-slot service_type
+;+		(comment "The service type attribute identifies the class of system function provided.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot has_Field_File_Specification_Name
 ;+		(comment "The has_Field_File_Specification_Name association is a relationship to Field_File_Specification_Name.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot service_type
-;+		(comment "The service type attribute identifies the class of system function provided.")
-		(type STRING)
-;+		(cardinality 0 1)
+	(multislot has_Axis_Array
+;+		(comment "The has_Axis_Array association is a relationship to Axis_Array.")
+		(type INSTANCE)
+;+		(allowed-classes Axis_Array)
 		(create-accessor read-write))
 	(multislot id_reference_to
 ;+		(comment "The id_reference_to provides the identifier of the ending object in a one  directional relationship.")
@@ -688,29 +688,29 @@
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot observing_system_name
-;+		(comment "The observing_system_name attribute provides a unique name for an observing system.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot internal_reference
 ;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
 		(type INSTANCE)
 ;+		(allowed-classes Internal_Reference)
 		(create-accessor read-write))
-	(multislot acted_on_behalf_of
-;+		(comment "The acted_on_behalf_of association is a recursive relationship on agent.")
-		(type INSTANCE)
-;+		(allowed-classes Agent)
+	(multislot observing_system_name
+;+		(comment "The observing_system_name attribute provides a unique name for an observing system.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot earth_received_stop_date_time
+;+		(comment "The earth_received_stop_date_time attribute provides the latest time at which any component telemetry data for a particular product was received.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot manifest_checksum
 ;+		(comment "The manifest checksum provides the checksum for the manifest file.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot earth_received_stop_date_time
-;+		(comment "The earth_received_stop_date_time attribute provides the latest time at which any component telemetry data for a particular product was received.")
-		(type STRING)
-;+		(cardinality 0 1)
+	(multislot acted_on_behalf_of
+;+		(comment "The acted_on_behalf_of association is a recursive relationship on agent.")
+		(type INSTANCE)
+;+		(allowed-classes Agent)
 		(create-accessor read-write))
 	(single-slot planar_coordinate_encoding_method
 ;+		(comment "The planar_coordinate_encoding_method attribute indicates the means used to represent horizontal positions.")
@@ -721,15 +721,15 @@
 ;+		(comment "The discipline_name attribute describes the observing discipline (as opposed to a PDS Discipline Node Name, though the concepts and values are similar). Some of these values are, with respect to the PDS Nodes, inter-disciplinary and should be used when they are applicable in perference to the more restrictive values.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot external_namespace_id
-;+		(comment "The external_namespace_id attribute provides a namespace_id external to this context.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot directory_delimiter
 ;+		(comment "The directory delimiter is a character that separates a directory name from another directory name or from a file name.")
 		(type STRING)
 		(default "<slash>")
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot external_namespace_id
+;+		(comment "The external_namespace_id attribute provides a namespace_id external to this context.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot default_blue
 ;+		(comment "The default_blue attribute provides the number of the plane along the axis that is to be loaded, by default, into the blue plane of a display device.")
@@ -768,15 +768,15 @@
 ;+		(comment "The classTitle attribute provides the name of the class to be used for display.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot attribute_data_type
-;+		(comment "The attribute_data_type attribute provides the  data type used to represent the value.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot coordinate_system_name
 ;+		(comment "This attribute is used in the image map projection. Under review. xxx E. RYE;DS xxx")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot attribute_data_type
+;+		(comment "The attribute_data_type attribute provides the  data type used to represent the value.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot reference_latitude
 ;+		(comment "This attribute is used in the image map projection. Under review.")
@@ -787,15 +787,15 @@
 ;+		(comment "The model_id attribute helps discriminate instrument hardware. For example \"flight\", \"engineering\", or \"proto\" have been used.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot value_data_type
-;+		(comment "The value_data_type attribute is used in a data dictionary to specify the data type of an attribute's value.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot has_primary_result_description
 ;+		(comment "The has_primary_result_description association is a relationship to Primary_Result_Description.")
 		(type INSTANCE)
 ;+		(allowed-classes Primary_Result_Summary)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot value_data_type
+;+		(comment "The value_data_type attribute is used in a data dictionary to specify the data type of an attribute's value.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot investigation_reference
 ;+		(comment "The investigation reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object..")
@@ -811,15 +811,15 @@
 ;+		(comment "The reference_key_id attribute provides the catalog with an identifier for a reference document.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot associated_optional_description
-;+		(comment "The associated_optional_description association is a relationship to optional descriptions.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
 	(single-slot invalid_constant
 ;+		(comment "The invalid_constant attribute provides a value that indicates the original value was outside the valid range for the parameter.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot associated_optional_description
+;+		(comment "The associated_optional_description association is a relationship to optional descriptions.")
+		(type INSTANCE)
+;+		(allowed-classes)
 		(create-accessor read-write))
 	(multislot has_Spatial_Reference_Information
 ;+		(comment "The xxx association is a relationship to yyy.")
@@ -840,14 +840,14 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot system_requirements_note
-;+		(comment "The system requirements note attribute identifies what is necessary to process the software.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot utm_zone_number
 ;+		(comment "The utm_zone_number attribute provides the identifier for the UTM zone.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot system_requirements_note
+;+		(comment "The system requirements note attribute identifies what is necessary to process the software.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot submitter_name
 ;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
@@ -869,19 +869,19 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot electronic_mail_id
-;+		(comment "The eletronic mail id provides a formal name used to refer to an electronic mail address.")
+	(single-slot time_display_axis
+;+		(comment "The time_display_axis attribute identifies, by name, the axis of an Array %28or Array subclass%29, the bands of which are intended to be displayed sequentially in time on a display device. The frame_rate attribute, if present, provides the rate at which these bands are to be displayed.")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot maximum_value_exclusive_flag
 ;+		(comment "The maximum_value_exclusive_flag attribute indicates that the  maximum_value is exclusive, when true.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot time_display_axis
-;+		(comment "The time_display_axis attribute identifies, by name, the axis of an Array %28or Array subclass%29, the bands of which are intended to be displayed sequentially in time on a display device. The frame_rate attribute, if present, provides the rate at which these bands are to be displayed.")
+	(single-slot electronic_mail_id
+;+		(comment "The eletronic mail id provides a formal name used to refer to an electronic mail address.")
 		(type STRING)
-;+		(cardinality 1 1)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot data_set_id
 ;+		(comment "The data set id provides a formal name used to refer to a data set.")
@@ -896,43 +896,43 @@
 ;+		(comment "The field_number attribute provides the position of a field, within a series of fields, counting from 1. If two fields within a record are physically separated by one or more groups, they have consecutive field numbers; the fields within the intervening group(s) are numbered separately.  Fields within a group separated by one or more (sub)groups, will also have consecutive field numbers.")
 		(type INTEGER)
 		(create-accessor read-write))
-	(single-slot was_associated_with
-		(type INSTANCE)
-;+		(allowed-classes Agent)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot virtual_relation
 ;+		(comment "The virtual_relation association is a relationship to Virtual_Relation.")
 		(type INSTANCE)
 ;+		(allowed-classes Virtual_Relation)
 		(create-accessor read-write))
-	(multislot geometry_reference
-;+		(comment "The geometry reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier::version_id")
+	(single-slot was_associated_with
+		(type INSTANCE)
+;+		(allowed-classes Agent)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot longitude_resolution
 ;+		(comment "The longitude_resolution attribute indicates the minimum difference between two adjacent longitude values expressed in angular units of measure.")
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot geometry_reference
+;+		(comment "The geometry reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier::version_id")
+		(create-accessor read-write))
+	(multislot identifier_reference
+;+		(comment "The identifier_reference attribute provides the value of an identifier.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot postal_address_text
 ;+		(comment "The postal address text attribute provides a mailing address.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot identifier_reference
-;+		(comment "The identifier_reference attribute provides the value of an identifier.")
+	(multislot compile_note
+;+		(comment "The compile note attribute provides a brief statement giving particulars about the compilation of the software source.")
 		(type STRING)
 		(create-accessor read-write))
 	(single-slot bound_character
 ;+		(comment "bound-character = non-quote-character  |  quote ; The bound-characters, and the escape character, are required in any implementation to be associated with particular members of the implementation character set. - A bound-character is required to be associated with the member having the corresponding symbol, if any, in any implementation character-set derived from ISO/IEC 10646.")
 		(type STRING)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot compile_note
-;+		(comment "The compile note attribute provides a brief statement giving particulars about the compilation of the software source.")
-		(type STRING)
 		(create-accessor read-write))
 	(single-slot directory_name_token
 ;+		(comment "The directory name token is a substring that names a directory. The maximum size of a directory name is thirty characters.")
@@ -952,14 +952,14 @@
 ;+		(comment "The encoding_type attribute provides the storage format (binary or character).")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot full_name
-;+		(comment "The full_name attribute provides the complete name for a person and includes titles and suffixes.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot distribution_type
 ;+		(comment "This attribute is used in by the data set release class. It is under review.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot full_name
+;+		(comment "The full_name attribute provides the complete name for a person and includes titles and suffixes.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot record_delimiter
 ;+		(comment "The record_delimiter attribute provides the character or characters used to indicate the end of a record.")
@@ -973,26 +973,26 @@
 	(multislot assertType
 		(type STRING)
 		(create-accessor read-write))
-	(multislot earth_received_stop_time_utc
-;+		(comment "earth_received_stop_time_utc gives the UTC time corresponding to the latest time for the data product at which telemetry or other photons were received on Earth. Optional for occultation data.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot orbit_direction
 ;+		(comment "The orbit_direction element provides the direction of movement along the orbit about the primary as seen from the north pole of the 'invariable plane of the solar system', which is the plane passing through the center of mass of the solar system and perpendicular to the angular momentum vector of the solar system orbit motion. PROGRADE for positive rotation according to the right-hand rule, RETROGRADE for negative rotation.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot isMissionOnly
-;+		(comment "The isMissionOnly attribute indicates whether a rule is for mission level dictionaries only.")
+	(multislot earth_received_stop_time_utc
+;+		(comment "earth_received_stop_time_utc gives the UTC time corresponding to the latest time for the data product at which telemetry or other photons were received on Earth. Optional for occultation data.")
 		(type STRING)
+		(create-accessor read-write))
+	(multislot last_sampling_parameter_value
+;+		(comment "The last_sampling_parameter_value element provides the last value in an ascending series and is therefore the maximum value at which a given data item was sampled.")
+		(type FLOAT)
 		(create-accessor read-write))
 	(single-slot data_set_terse_desc
 ;+		(comment "A one line description of the data set")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot last_sampling_parameter_value
-;+		(comment "The last_sampling_parameter_value element provides the last value in an ascending series and is therefore the maximum value at which a given data item was sampled.")
-		(type FLOAT)
+	(multislot isMissionOnly
+;+		(comment "The isMissionOnly attribute indicates whether a rule is for mission level dictionaries only.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot edition_name
 ;+		(comment "The edition name attribute provides a name by which the edition is known.")
@@ -1072,28 +1072,28 @@
 ;+		(comment "The type attribute provides a classification for the resource.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot creation_date_time
-;+		(comment "The creation_date_time attribute provides a date and time when the object was created.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot radial_resolution
 ;+		(comment "radial_resolution indicates the nominal radial distance over which changes in ring properties can be detected within a data product. Note: this value may be larger than the radial_sampling_interval value, because a data product can be over-sampled. Required in labels if the value is fixed, as it is for stellar occultations. If the value varies, the corresponding minimum and maximum attributes must be used instead. Not intended to be used as a table field.")
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot creation_date_time
+;+		(comment "The creation_date_time attribute provides a date and time when the object was created.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot local_true_solar_time
 ;+		(comment "The local_true_solar_time (LTST) attribute provides the local time on a rotating solar system body where LTST is 12 h at the sub-solar point (SSP) and increases 1 h for each 15 degree increase in east longitude away from the SSP for prograde rotation.")
 		(type STRING)
-		(create-accessor read-write))
-	(multislot observing_system_component
-;+		(comment "The observing_system_component association is a relationship to Observing_System_Component.")
-		(type INSTANCE)
-;+		(allowed-classes Observing_System_Component)
 		(create-accessor read-write))
 	(multislot instrument_host_reference
 ;+		(comment "The instrument host  reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
 		(type STRING)
 		(default "logical_identifier")
+		(create-accessor read-write))
+	(multislot observing_system_component
+;+		(comment "The observing_system_component association is a relationship to Observing_System_Component.")
+		(type INSTANCE)
+;+		(allowed-classes Observing_System_Component)
 		(create-accessor read-write))
 	(multislot has_Table_Character_Grouped
 ;+		(comment "The has_Table_Character_Grouped association is a relationship to grouped sequence of fields.")
@@ -1104,9 +1104,10 @@
 ;+		(comment "The bits attribute provides the number of bits in the object.")
 		(type INTEGER)
 		(create-accessor read-write))
-	(multislot external_property_maps_id
-;+		(comment "The external_property_maps_id attribute provides the identifier of a property_maps instance external to this context.")
+	(single-slot release_id
+;+		(comment "This attribute is used in by the data set release class. It is under review.")
 		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot alias_list
 ;+		(comment "The alias_list association is a relationship to Alias_List, a list of alternate names and identifications.")
@@ -1114,10 +1115,9 @@
 ;+		(allowed-classes Alias_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot release_id
-;+		(comment "This attribute is used in by the data set release class. It is under review.")
+	(multislot external_property_maps_id
+;+		(comment "The external_property_maps_id attribute provides the identifier of a property_maps instance external to this context.")
 		(type STRING)
-;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot valid_minimum
 ;+		(comment "The valid_minimum attribute specifies the minimum valid value in the field or digital object with which the Special_Constants class is associated. Values below the valid_minimum have a special meaning. Values of this attribute should be represented in the same data_type as the elements in the object or field described.")
@@ -1128,12 +1128,12 @@
 		(type INSTANCE)
 ;+		(allowed-classes Local_ID_Reference)
 		(create-accessor read-write))
-	(multislot document_collection_reference
-;+		(comment "The document collection reference attribute provides the logical_identifier for a document collection.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot external_source_product_identifier
 ;+		(comment "The external_source_product_identifier provides unique identifiers for one or more source products that are not in the PDS4 Registry. For guidelines on the construction of this identifier, refer to section E.2.6.1.2 of the Data Provider's Handbook.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot document_collection_reference
+;+		(comment "The document collection reference attribute provides the logical_identifier for a document collection.")
 		(type STRING)
 		(create-accessor read-write))
 	(multislot node_puid
@@ -1172,23 +1172,23 @@
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot processing_level_id
+;+		(comment "The processing_level_id attribute provides a broad indication of data processing level.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot has_Display_2d_Image
 ;+		(comment "The has_Display_2d_Image association is a relationship to Display_2d_Image.")
 		(type INSTANCE)
 ;+		(allowed-classes Display_2D_Image)
 		(create-accessor read-write))
-	(multislot processing_level_id
-;+		(comment "The processing_level_id attribute provides a broad indication of data processing level.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot sample_bit_mask
-;+		(comment "The sample_bit_mask attribute identifies the active bits in a sample. Note:  In the PDS, the domain of sample_bit_mask is dependent upon the currently-described value in the sample_bits attribute and only applies to integer values. For an 8-bit sample where all bits are active the sample_bit_mask would be 2#11111111#.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot north_bounding_coordinate
 ;+		(comment "The north_bounding_coordinate attribute provides the northern-most coordinate of the limit of coverage expressed in latitude.")
 		(type FLOAT)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot sample_bit_mask
+;+		(comment "The sample_bit_mask attribute identifies the active bits in a sample. Note:  In the PDS, the domain of sample_bit_mask is dependent upon the currently-described value in the sample_bits attribute and only applies to integer values. For an 8-bit sample where all bits are active the sample_bit_mask would be 2#11111111#.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot dictionary_type
 ;+		(comment "The dictionary_type attribute provides the name of a dictionary category.")
@@ -1256,21 +1256,16 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot pixel_resolution_y
-;+		(comment " The pixel_resolution_x and pixel_resolution_y attributes indicate the image array pixel resolution %28distance%2Fpixel or degree%2Fpixel%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y resolution values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where resolution may differ for each axis %28%47rectangular%47 pixels%29. NOTE: Definition of this PDS4 attribute differs from how %47resolution%47 was defined within PDS3. ")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot ring_event_stop_tdb
-;+		(comment "ring_event_stop_tdb indicates the value for latest time in the described data, and is given in ring_event_tdb format. Optional in labels; not intended for use as a table field.")
-		(type FLOAT)
-		(create-accessor read-write))
 	(multislot reference_entry
 ;+		(comment "The reference_entry association is a relationship to Reference_Entry.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot pixel_resolution_x
+	(multislot ring_event_stop_tdb
+;+		(comment "ring_event_stop_tdb indicates the value for latest time in the described data, and is given in ring_event_tdb format. Optional in labels; not intended for use as a table field.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot pixel_resolution_y
 ;+		(comment " The pixel_resolution_x and pixel_resolution_y attributes indicate the image array pixel resolution %28distance%2Fpixel or degree%2Fpixel%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y resolution values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where resolution may differ for each axis %28%47rectangular%47 pixels%29. NOTE: Definition of this PDS4 attribute differs from how %47resolution%47 was defined within PDS3. ")
 		(type FLOAT)
 ;+		(cardinality 1 1)
@@ -1279,14 +1274,19 @@
 ;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot interface_type
-;+		(comment "The interface type attribute identifies the class of interconnection provided.")
-		(type STRING)
+	(single-slot pixel_resolution_x
+;+		(comment " The pixel_resolution_x and pixel_resolution_y attributes indicate the image array pixel resolution %28distance%2Fpixel or degree%2Fpixel%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y resolution values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where resolution may differ for each axis %28%47rectangular%47 pixels%29. NOTE: Definition of this PDS4 attribute differs from how %47resolution%47 was defined within PDS3. ")
+		(type FLOAT)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot volume_de_fullname
 ;+		(comment "The volume_de_fullname attribute provide the full name of the data engineer.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot interface_type
+;+		(comment "The interface type attribute identifies the class of interconnection provided.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot local_association_class
 ;+		(comment "The local_association_class association provides a relationship to a class.")
@@ -1302,18 +1302,22 @@
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot repetitions
-;+		(comment "The repetitions attribute provides the number of occurrences.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot instrument_host_version_id
 ;+		(comment "The instrument_host_version_id attribute provides the version of the instrument host.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot repetitions
+;+		(comment "The repetitions attribute provides the number of occurrences.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(multislot operations_contact_puid
 ;+		(comment "The operations_contact indicates the node person responsible for node operations.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot cs_local_identifier_reference
+;+		(comment "The cs_local_identifier_reference attribute is used to reference one component of a composite structure.")
 		(type STRING)
 		(create-accessor read-write))
 	(multislot has_Geodetic_Model
@@ -1321,20 +1325,16 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot cs_local_identifier_reference
-;+		(comment "The cs_local_identifier_reference attribute is used to reference one component of a composite structure.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot high_representation_saturation
 ;+		(comment "The high_representative_saturation attribute specifies a special value whose presence indicates the true value cannot be represented in the chosen data type and length -- in this case being above the allowable range -- which may happen during conversion from another data type. The value must be less than the value of the valid_minimum attribute or more than the value of the valid_maximum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot encoding_standard_id
-;+		(comment "The encoding_standard_id attribute provides the formal name of a standard used for the structure of an Encoded Byte Stream digital object.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot url
 ;+		(comment "The url attribute provides a Uniform Resource Identifier (URI) that specifies where a resource is available and the mechanism for retrieving it.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot encoding_standard_id
+;+		(comment "The encoding_standard_id attribute provides the formal name of a standard used for the structure of an Encoded Byte Stream digital object.")
 		(type STRING)
 		(create-accessor read-write))
 	(single-slot phone_book_flag
@@ -1360,15 +1360,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot data_set_release_date
-;+		(comment "The data_set_release_date attribute provides the date when a data set is released by the data producer for archive or publication. In many systems this represents the end of a proprietary or validation period. Formation rule In AMMOS identify the date at which a product may be released to the general public from proprietary access. AMMOS-related systems should apply this attribute only to proprietary data.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot associated_Electronic_Mail
 ;+		(comment "The associated_Electronic_Mail association is a relationship to Electronic Mail.")
 		(type INSTANCE)
 ;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot data_set_release_date
+;+		(comment "The data_set_release_date attribute provides the date when a data set is released by the data producer for archive or publication. In many systems this represents the end of a proprietary or validation period. Formation rule In AMMOS identify the date at which a product may be released to the general public from proprietary access. AMMOS-related systems should apply this attribute only to proprietary data.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot loop_count
 ;+		(comment "The loop_count attribute specifies the number of times a movie should be 'looped' or replayed before stopping.")
@@ -1406,12 +1406,12 @@
 ;+		(comment "The instrument id provides a formal name used to refer to an instrument.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot program_notes_id
-;+		(comment "The program notes id attribute provides an identifier to a brief statement giving particulars about a software program.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot associated_object_local_id
 ;+		(comment "The associated_object_local_id associates another object using its local identifier.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot program_notes_id
+;+		(comment "The program notes id attribute provides an identifier to a brief statement giving particulars about a software program.")
 		(type STRING)
 		(create-accessor read-write))
 	(single-slot upper_120227b_Class2
@@ -1427,25 +1427,25 @@
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot modification_detail
-;+		(comment "The modification_detail association is a relationship to Modification_Detail, the details of one round of modification for the product.")
-		(type INSTANCE)
-;+		(allowed-classes Modification_Detail)
-		(create-accessor read-write))
 	(single-slot attribute_concept
 ;+		(comment "The attribute_concept attribute provides the type of information (classification) conveyed by the attribute -- e.g., stop_date_time has  attribute_concept = date_time.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot local_internal_reference
-;+		(comment "The local_internal_reference association is a relationship to the class Local_Internal_Reference.")
+	(multislot modification_detail
+;+		(comment "The modification_detail association is a relationship to Modification_Detail, the details of one round of modification for the product.")
 		(type INSTANCE)
-;+		(allowed-classes Local_Internal_Reference)
+;+		(allowed-classes Modification_Detail)
 		(create-accessor read-write))
 	(multislot associated_data_object
 ;+		(comment "The associated_data_object association is a relationship to data object.")
 		(type INSTANCE)
 ;+		(allowed-classes Tagged_Digital_Object Tagged_NonDigital_Object)
+		(create-accessor read-write))
+	(multislot local_internal_reference
+;+		(comment "The local_internal_reference association is a relationship to the class Local_Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Local_Internal_Reference)
 		(create-accessor read-write))
 	(single-slot confidence_level_note
 ;+		(comment "The confidence_level_note attribute is a text field which characterizes the reliability of data within a data set or the reliability of a particular programming algorithm or software component. Essentially, this note discusses the level of confidence in the accuracy of the data or in the ability of the software to produce accurate results.")
@@ -1477,15 +1477,15 @@
 		(type STRING)
 		(default "logical_identifier")
 		(create-accessor read-write))
-	(single-slot detector_number
-;+		(comment "The detector_number attribute provides the spectrometer detector number corresponding to a band of a spectral qube. Detector numbers are usually assigned consecutively from 1, in order of increasing wavelength.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot collected_under
 ;+		(comment "The collected_under association is a relationship to circumstances of observation.")
 		(type INSTANCE)
 ;+		(allowed-classes Context_Area)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot detector_number
+;+		(comment "The detector_number attribute provides the spectrometer detector number corresponding to a band of a spectral qube. Detector numbers are usually assigned consecutively from 1, in order of increasing wavelength.")
+		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot band_width
@@ -1506,38 +1506,38 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot model_object_type
-;+		(comment "The model_object_type attribute provides a classification for a modeled object.")
-		(type STRING)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(multislot supported_architecture_note
 ;+		(comment "The supported architecture note attribute identifies  the hardware architecture that can process the software.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot observation_area
-;+		(comment "The observation_area association is a relationship to Observation_Area.")
-		(type INSTANCE)
-;+		(allowed-classes Context_Area)
+	(multislot model_object_type
+;+		(comment "The model_object_type attribute provides a classification for a modeled object.")
+		(type STRING)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
 	(single-slot version_id
 ;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot observation_area
+;+		(comment "The observation_area association is a relationship to Observation_Area.")
+		(type INSTANCE)
+;+		(allowed-classes Context_Area)
+		(create-accessor read-write))
 	(single-slot easternmost_longitude
 ;+		(comment "This attribute is used in the image map projection. Under review. xxx E. Rye xxx")
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot identifier
+;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot fields
 ;+		(comment "The fields attribute provides a count of the total number of scalar fields directly associated with a table record.  Fields within groups within the record are not included in this count.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot identifier
-;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
-		(type STRING)
 		(create-accessor read-write))
 	(multislot virtual_area
 ;+		(comment "The virtual_area association is a relationship to Virtual Area")
@@ -1585,30 +1585,30 @@
 ;+		(comment "The reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot key_electronic_mail_address
-;+		(comment "The key electronic mail address attribute provides a unique identifier for each individual who is allowed access to the PDS.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot software_version_id
 ;+		(comment "The software_version_id attribute provides the version of the software.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot key_electronic_mail_address
+;+		(comment "The key electronic mail address attribute provides a unique identifier for each individual who is allowed access to the PDS.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot has_Group_Facet2
 ;+		(comment "The has_Group_Facet2 association is a relationship to Group_Facet2.")
 		(type INSTANCE)
 ;+		(allowed-classes Group_Facet2)
 		(create-accessor read-write))
-	(multislot has_Group_Facet1
-;+		(comment "The has_Group_Facet1 association is a relationship to Group_Facet1.")
-		(type INSTANCE)
-;+		(allowed-classes Group_Facet1)
-		(create-accessor read-write))
 	(multislot has_document
 ;+		(comment "The has_document association is a relationship to one Document.")
 		(type INSTANCE)
 ;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot has_Group_Facet1
+;+		(comment "The has_Group_Facet1 association is a relationship to Group_Facet1.")
+		(type INSTANCE)
+;+		(allowed-classes Group_Facet1)
 		(create-accessor read-write))
 	(single-slot UpperModel_180912x_1B00_Prov_Class5
 		(type STRING)
@@ -1670,16 +1670,16 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot has_Element_Array
-;+		(comment "The has_Element_Array association is a relationship to Element_Array")
-		(type INSTANCE)
-;+		(allowed-classes Element_Array)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot pds_address_book_flag
 ;+		(comment " The pds_address_book_flag data attribute indicates whether or not a registered PDS user will have an entry in the PDS telephone directory.")
 		(type SYMBOL)
 		(allowed-values N NULL Y)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot has_Element_Array
+;+		(comment "The has_Element_Array association is a relationship to Element_Array")
+		(type INSTANCE)
+;+		(allowed-classes Element_Array)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot has_Planar_Coordinate_Information
@@ -1699,15 +1699,15 @@
 ;+		(comment "The attribute_relative_xpath attribute provides a location path for an attribute within a tree representation of an XML document. The location path includes the attribute name.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot quote
-;+		(comment "quote = '\"' ; (* quotation mark *)")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot virtual_structure
 ;+		(comment "The virtual_structure association is a relationship to Virtual Structure")
 		(type INSTANCE)
 ;+		(allowed-classes Virtual_Structure)
+		(create-accessor read-write))
+	(single-slot quote
+;+		(comment "quote = '\"' ; (* quotation mark *)")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot has_Transfer_Manifest
 ;+		(comment "The has_Transfer_Manifest association is a relationship to Transfer_Manifest.")
@@ -1824,14 +1824,14 @@
 		(type INSTANCE)
 ;+		(allowed-classes Field_Bit)
 		(create-accessor read-write))
-	(single-slot upper_101016_Slot_0
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot curated_by
 ;+		(comment "Association for curation nodes.")
 		(type INSTANCE)
 ;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot upper_101016_Slot_0
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot loop_back_and_forth_flag
 ;+		(comment "The loop_back_and_forth_flag attribute specifies whether or not a movie should only be 'looped' or played repeatedly in the forward direction, or whether it should be played forward followed by played in reverse, iteratively.")
@@ -1850,13 +1850,13 @@
 ;+		(allowed-classes)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot min_inclusive
-;+		(comment "The min inclusive attribute provides a value that is less than or equal to all the values in the object.")
+	(single-slot value_end_date
+;+		(comment "The value_end_date attribute provides the last date on which the permissible value is in effect.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot value_end_date
-;+		(comment "The value_end_date attribute provides the last date on which the permissible value is in effect.")
+	(single-slot min_inclusive
+;+		(comment "The min inclusive attribute provides a value that is less than or equal to all the values in the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -1882,10 +1882,10 @@
 		(type INSTANCE)
 ;+		(allowed-classes Source_Product_Internal)
 		(create-accessor read-write))
-	(multislot has_Geographic
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes XSChoice%23)
+	(single-slot volume_set_name
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot resource_desc
 ;+		(comment "The resource_desc attribute provides a description for the resource")
@@ -1894,10 +1894,10 @@
 ;+		(value "Text")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot volume_set_name
-;+		(comment "This attribute is used in by the volume class. It is under review.")
-		(type STRING)
-;+		(cardinality 1 1)
+	(multislot has_Geographic
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes XSChoice%23)
 		(create-accessor read-write))
 	(multislot update_entry
 ;+		(comment "The update_entry association is a relationship to Update_Entry.")
@@ -1924,12 +1924,12 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot instrument_puid
 ;+		(comment "The instrument_puid attribute provides a globally unique identifer for an instrument.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 		(create-accessor read-write))
 	(single-slot scale_factor_at_center_line
@@ -1951,14 +1951,14 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot spacecraft_event_stop_time_utc
-;+		(comment "spacecraft_event_stop_time_utc gives the UTC time corresponding to the latest time given by spacecraft_event_time in the data table. However, while spacecraft_event_time is given as seconds offset from a reference time, spacecraft_event_stop_time_utc is given as a UTC date time. Required in the label for radio occultation data. Not used for stellar occultations.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot sample_first_pixel
 ;+		(comment "This attribute is used in the image map projection. Under review.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot spacecraft_event_stop_time_utc
+;+		(comment "spacecraft_event_stop_time_utc gives the UTC time corresponding to the latest time given by spacecraft_event_time in the data table. However, while spacecraft_event_time is given as seconds offset from a reference time, spacecraft_event_stop_time_utc is given as a UTC date time. Required in the label for radio occultation data. Not used for stellar occultations.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot has_Software
 ;+		(comment "The has_Software association is a relationship to Software.")
@@ -1969,14 +1969,14 @@
 ;+		(comment "The modification_date attribute provides date the modifications were completed")
 		(type STRING)
 		(create-accessor read-write))
+	(multislot orbit_number
+;+		(comment "The orbit_number attribute provides the number of the orbital revolution of one body around another.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot volume_series_name
 ;+		(comment "This attribute is used in by the volume class. It is under review.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot orbit_number
-;+		(comment "The orbit_number attribute provides the number of the orbital revolution of one body around another.")
-		(type STRING)
 		(create-accessor read-write))
 	(multislot axis_name
 ;+		(comment "The axis_name attribute provides a word or combination of words by which the axis is known.")
@@ -2030,14 +2030,14 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot id_reference_from
-;+		(comment "The id_reference_from provides the identifier of the starting object in a  one directional relationship.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot checksum
 ;+		(comment "The checksum attribute provides a computed value which depends on the contents of a block of data and is used to detect corruption of the data.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot id_reference_from
+;+		(comment "The id_reference_from provides the identifier of the starting object in a  one directional relationship.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot Vz
 ;+		(comment "The Vz attribute provides the value of the z coordinate in a velocity vector.")
@@ -2056,18 +2056,19 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
+	(multislot objectives_summary
+;+		(comment "The objectives_summary attribute describes the scientific objectives of an investigation")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot bytes
 ;+		(comment "The bytes attribute provides the number of bytes in the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot objectives_summary
-;+		(comment "The objectives_summary attribute describes the scientific objectives of an investigation")
+	(single-slot map_scale
+;+		(comment "This attribute is used in the image map projection. Under review.")
 		(type STRING)
-		(create-accessor read-write))
-	(multislot maximum_field_length
-;+		(comment "The maximum_field_length attribute sets an upper, inclusive bound on the number of bytes in the field.")
-		(type INTEGER)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot pds_version_id
 ;+		(comment "The pds version id provides a formal name used to refer to a version of the PDS standards.")
@@ -2075,23 +2076,22 @@
 ;+		(value "PDS4.0")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot map_scale
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 1 1)
+	(multislot maximum_field_length
+;+		(comment "The maximum_field_length attribute sets an upper, inclusive bound on the number of bytes in the field.")
+		(type INTEGER)
 		(create-accessor read-write))
 	(multislot logical_identifier
 ;+		(comment "The logical_identifer attribute identifies the set of all versions of a product; it is a product identifier without a version.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot mission_name
+;+		(comment "The mission_name attribute identifies a major planetary mission or project. A given planetary mission may be associated with one or more spacecraft.")
 		(type STRING)
 		(create-accessor read-write))
 	(single-slot map_resolution
 ;+		(comment "This attribute is used in the image map projection. Under review.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot mission_name
-;+		(comment "The mission_name attribute identifies a major planetary mission or project. A given planetary mission may be associated with one or more spacecraft.")
-		(type STRING)
 		(create-accessor read-write))
 	(single-slot upper_111230e_Class0
 		(type STRING)
@@ -2101,41 +2101,41 @@
 ;+		(comment "The contained product reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a product being packaged.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot map_projection_name
-;+		(comment "The map_projection_name attribute provides the name of the map projection.")
+	(single-slot character_literal
+;+		(comment "character-literal = apostrophe, any-character, apostrophe ; any-character = bound-character | added-character | escape-character ; escape-character = escape, character-name, escape ; character-name = identifier, { \" \", identifier } ;")
 		(type STRING)
-;+		(cardinality 1 1)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot maximum_radial_sampling_interval
 ;+		(comment "maximum_radial_sampling_interval indicates the smallest radial spacing between consecutive points in a ring profile. In practice, this may be somewhat smaller than the radial_resolution because a profile may be over-sampled. If the value of radial_sampling_interval varies, the minimum and maximum attributes are required in labels. Not intended to be used as a table field.")
 		(type FLOAT)
 		(create-accessor read-write))
-	(single-slot character_literal
-;+		(comment "character-literal = apostrophe, any-character, apostrophe ; any-character = bound-character | added-character | escape-character ; escape-character = escape, character-name, escape ; character-name = identifier, { \" \", identifier } ;")
+	(single-slot map_projection_name
+;+		(comment "The map_projection_name attribute provides the name of the map projection.")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot associated_Coordinate_System
 ;+		(comment "The associated_Coordinate_System association is a relationship to Coordinate System.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot id_reference
-;+		(comment "The id_reference provides the identifier of an object in a one  directional relationship.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot source_product_external
 ;+		(comment "The source_product_external association is a relationship to Source Product External.")
 		(type INSTANCE)
 ;+		(allowed-classes Source_Product_External)
 		(create-accessor read-write))
-	(multislot has_Table_Character_Field_Sequence
-;+		(comment "The has_Table_Character_Field_Sequence association is a relationship to field sequence.")
-		(type INSTANCE)
-;+		(allowed-classes)
+	(multislot id_reference
+;+		(comment "The id_reference provides the identifier of an object in a one  directional relationship.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot file_area_LID_Secondary
 ;+		(comment "The file_area association is a relationship to File Area")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot has_Table_Character_Field_Sequence
+;+		(comment "The has_Table_Character_Field_Sequence association is a relationship to field sequence.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
@@ -2157,36 +2157,36 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot file_size
-;+		(comment "The file_size attribute provides the size of the file.")
-		(type INTEGER)
-		(create-accessor read-write))
 	(single-slot used
 		(type INSTANCE)
 ;+		(allowed-classes Methods Config Input_Data)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot file_size
+;+		(comment "The file_size attribute provides the size of the file.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot elements
+;+		(comment "The elements attribute provides the count of the number of elements along an array axis.")
+		(type INTEGER)
 		(create-accessor read-write))
 	(single-slot coordinate_system_type
 ;+		(comment "This attribute is used in the image map projection. Under review. xxx E. RYE;DS xxx")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot elements
-;+		(comment "The elements attribute provides the count of the number of elements along an array axis.")
-		(type INTEGER)
-		(create-accessor read-write))
 	(multislot update_purpose
 ;+		(comment "The update purpose attribute indicates the intended objective of this update.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot subscription_id
-;+		(comment "The subscriber_id provides the identification of a PDS subscription.")
 		(type STRING)
 		(create-accessor read-write))
 	(single-slot release_medium
 ;+		(comment "This attribute is used in by the data set release class. It is under review.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot subscription_id
+;+		(comment "The subscriber_id provides the identification of a PDS subscription.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot affiliation_type
 ;+		(comment "The affiliation type attribute describes the type of relationship an individual has with the PDS.  Individuals with PDS affiliations are generally listed in the PDS Phone Book.")
@@ -2221,13 +2221,13 @@
 ;+		(allowed-classes)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot facility_name
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot valid_maximum
 ;+		(comment "The valid_maximum attribute specifies the maximum valid value in the field or digital object with which the Special_Constants class is associated. Values above the valid_maximum have a special meaning. Values of this attribute should be represented in the same data_type as the elements in the object or field described. (Note that PDS3 had no qube-related valid_maximum values because all special constants were set below the valid_minimum.)")
 		(type STRING)
+		(create-accessor read-write))
+	(single-slot facility_name
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot has_identification_area
 ;+		(comment "The has_identification_area association is a relationship to Identification Area.")
@@ -2235,14 +2235,14 @@
 ;+		(allowed-classes Identification_Area)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot longitude
+;+		(comment "The longitude attribute provides the angular distance east or west on the object's surface, measured by the angle contained between the meridian of a particular place and some prime meridian.")
+		(type FLOAT)
+		(create-accessor read-write))
 	(multislot has_Band_Bin_Set
 ;+		(comment "The has_Band_Bin_Set association is a relationship to Band_Bin_Set.")
 		(type INSTANCE)
 ;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot longitude
-;+		(comment "The longitude attribute provides the angular distance east or west on the object's surface, measured by the angle contained between the meridian of a particular place and some prime meridian.")
-		(type FLOAT)
 		(create-accessor read-write))
 	(single-slot registration_authority
 ;+		(comment "The registration_authority attribute provides the name of the group  responsible for the terminological entry.")
@@ -2250,23 +2250,23 @@
 ;+		(value "PDS4" "PDS3" "VICAR")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot instrument_host_name
+;+		(comment "The instrument_host_name attribute provides the full name of the platform or facility upon which an instrument or other device is mounted. For example, the host can be a spacecraft, a ground-based telescope, or a laboratory.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot instrument_reference
 ;+		(comment "The instrument  reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
 		(type STRING)
 		(default "logical_identifier")
 		(create-accessor read-write))
-	(multislot instrument_host_name
-;+		(comment "The instrument_host_name attribute provides the full name of the platform or facility upon which an instrument or other device is mounted. For example, the host can be a spacecraft, a ground-based telescope, or a laboratory.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot naif_instrument_id
-;+		(comment "The naif_instrument_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot collected_in
 ;+		(comment "The collected_in association is a relationship to data set.")
 		(type INSTANCE)
 ;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot naif_instrument_id
+;+		(comment "The naif_instrument_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot nillable_flag
 ;+		(comment "The nillable_flag attribute indicates whether an attribute is allowed to take on nil as a value.")
@@ -2308,15 +2308,15 @@
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot standard_id
+;+		(comment "The standard_id attribute provides the formal name of an established norm or requirement.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot has_Data_Brick_Sequence
 ;+		(comment "The has_Data_Brick_Sequence association is a relationship to data brick.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(multislot standard_id
-;+		(comment "The standard_id attribute provides the formal name of an established norm or requirement.")
-		(type STRING)
 		(create-accessor read-write))
 	(multislot has_type_list_entry
 ;+		(comment "The has_type_list_entry association is a relationship to Type_List_Entry")
@@ -2346,60 +2346,60 @@
 		(type INSTANCE)
 ;+		(allowed-classes LIDVID_ID_Reference_To)
 		(create-accessor read-write))
+	(multislot aip_label_checksum
+;+		(comment "The aip_label_checksum attribute provides the checksum for the Archival Information Package label.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot start_date_time
 ;+		(comment "The start_date_time attribute provides the date and time at the beginning of a time interval of interest.")
 		(type STRING)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot aip_label_checksum
-;+		(comment "The aip_label_checksum attribute provides the checksum for the Archival Information Package label.")
-		(type STRING)
 		(create-accessor read-write))
 	(multislot refer_directory
 ;+		(comment "This attribute is used in by the volume class. It is under review.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot has_image_2d_display
-;+		(comment "The has_image_2d_display association is a relationship to Image_2D_Array.")
-		(type INSTANCE)
-;+		(allowed-classes)
+	(multislot alternate_designation
+;+		(comment "The alternate_designation attribute provides a known alternate name or identifier.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot green_channel_band
 ;+		(comment "The green_channel_band attribute identifies the number of the band, along the band axis, that should be loaded, by default, into the green channel of a display device. The first band along the band axis has band number 1.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot alternate_designation
-;+		(comment "The alternate_designation attribute provides a known alternate name or identifier.")
-		(type STRING)
+	(multislot has_image_2d_display
+;+		(comment "The has_image_2d_display association is a relationship to Image_2D_Array.")
+		(type INSTANCE)
+;+		(allowed-classes)
 		(create-accessor read-write))
 	(multislot calibration_reference
 ;+		(comment "The calibration reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
 		(type STRING)
 		(default "logical_identifier::version_id")
 		(create-accessor read-write))
-	(multislot object_length
-;+		(comment "The object_length attribute provides the length of the digital object in bytes.")
-		(type INTEGER)
-		(create-accessor read-write))
 	(single-slot pixel_scale_y
 ;+		(comment " The pixel_scale_x and pixel_scale_y attributes indicate the image array pixel scale %28pixel%2Fdegree or pixel%2Fdistance%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y scale values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where scale may differ for each axis %28%47rectangular%47 pixels%29. NOTE1: For presentation of hard-copy maps, a map scale is traditionally expressed as a %47representative fraction%47 %28the ratio of a hard-copy map to the actual subject surface %28e.g. 1:250,000, where one unit of measure on the map equals 250,000 of the same unit on the body surface%29%29. This usage is relevant when map%2Fdata are presented on hard-copy media %28paper, computer screen,etc%29. When defining pixel scale within a stored image%2Farray context here, we are expressing a ratio between the image array and the actual surface %28thus, pixel%2Fdegree or pixel%2Fdistance units%29. NOTE2: Definition of this PDS4 attribute differs from how %47scale%47 was defined within PDS3 ")
 		(type FLOAT)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot object_length
+;+		(comment "The object_length attribute provides the length of the digital object in bytes.")
+		(type INTEGER)
 		(create-accessor read-write))
 	(single-slot pixel_scale_x
 ;+		(comment " The pixel_scale_x and pixel_scale_y attributes indicate the image array pixel scale %28pixel%2Fdegree or pixel%2Fdistance%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y scale values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where scale may differ for each axis %28%47rectangular%47 pixels%29. NOTE1: For presentation of hard-copy maps, a map scale is traditionally expressed as a %47representative fraction%47 %28the ratio of a hard-copy map to the actual subject surface %28e.g. 1:250,000, where one unit of measure on the map equals 250,000 of the same unit on the body surface%29%29. This usage is relevant when map%2Fdata are presented on hard-copy media %28paper, computer screen,etc%29. When defining pixel scale within a stored image%2Farray context here, we are expressing a ratio between the image array and the actual surface %28thus, pixel%2Fdegree or pixel%2Fdistance units%29. NOTE2: Definition of this PDS4 attribute differs from how %47scale%47 was defined within PDS3 ")
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot spice_file_name
-;+		(comment "The spice_file_name attribute provides the names of the SPICE files used in processing the data.")
+	(single-slot file_extension_token
+;+		(comment "The file extension token is a substring that provides a file extension. The maximum size of a directory name is tbd characters.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot file_extension_token
-;+		(comment "The file extension token is a substring that provides a file extension. The maximum size of a directory name is tbd characters.")
+	(single-slot spice_file_name
+;+		(comment "The spice_file_name attribute provides the names of the SPICE files used in processing the data.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -2412,16 +2412,16 @@
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot grid_coordinate_system_name
-;+		(comment "The grid_coordinate_system_name attribute provides the name of the grid coordinate system.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot has_Delivery_Manifest_Entry
 ;+		(comment "The has_Delivery_Manifest_Entry association is a relationship to delivery manifest entry.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot grid_coordinate_system_name
+;+		(comment "The grid_coordinate_system_name attribute provides the name of the grid coordinate system.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot sample_display_direction
 ;+		(comment "The sample_display_direction attribute provides the preferred orientation of samples within a line for viewing on a display device. The default is right, meaning samples are viewed from left to right on the display. sample_display_direction must be used with line_display_direction.")
@@ -2435,9 +2435,10 @@
 ;+		(comment "reference_time_utc provides a date and time in UTC format. Given in a label when time values in a table are given as elapsed seconds offset from a reference time. Unless there are compelling reasons to do otherwise, reference_time_utc should correspond to the start of a day. Required anytime a table field is given relative to a specific date and time other than when Barycentric Dynamical Time is used (e.g., observed_event_tdb).")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot semi_minor_radius
-;+		(comment "The semi_minor_radius attribute provides the value of the intermediate axis of the ellipsoid that defines the approximate shape of a target body. The semi-minor axis is usually in the equatorial plane.")
-		(type FLOAT)
+	(single-slot has_Discipline_Facets
+;+		(comment "The has_Discipline_Facets association is a relationship to Discipline_Facets.")
+		(type INSTANCE)
+;+		(allowed-classes Discipline_Facets)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot sequence_class
@@ -2446,10 +2447,9 @@
 ;+		(allowed-classes Physical_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot has_Discipline_Facets
-;+		(comment "The has_Discipline_Facets association is a relationship to Discipline_Facets.")
-		(type INSTANCE)
-;+		(allowed-classes Discipline_Facets)
+	(single-slot semi_minor_radius
+;+		(comment "The semi_minor_radius attribute provides the value of the intermediate axis of the ellipsoid that defines the approximate shape of a target body. The semi-minor axis is usually in the equatorial plane.")
+		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot vertical_display_axis
@@ -2457,14 +2457,14 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot continuous_loop_flag
+;+		(comment "The continuous_loop_flag attribute indicates whether or not to keep replaying a movie.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot refer_file
 ;+		(comment "This attribute is used in by the volume class. It is under review.")
 		(type INSTANCE)
 ;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot continuous_loop_flag
-;+		(comment "The continuous_loop_flag attribute indicates whether or not to keep replaying a movie.")
-		(type STRING)
 		(create-accessor read-write))
 	(multislot software_language
 ;+		(comment "The software language attribute identifies the language used to write the software.")
@@ -2474,29 +2474,29 @@
 ;+		(comment "dsn_station_number identifies the receiving DSN station. Required in labels for radio occultations; not used for stellar occultations. Nillable in which case the nil_reason should be 'inapplicable'.")
 		(type INTEGER)
 		(create-accessor read-write))
-	(multislot has_Delimited_Field_Grouped
-;+		(comment "The has_Delimited_Field_Grouped association is a relationship to the field types for a group.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
 	(single-slot digit
 ;+		(comment "digit = \"0\" | \"1\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" ;")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_Delimited_Field_Grouped
+;+		(comment "The has_Delimited_Field_Grouped association is a relationship to the field types for a group.")
+		(type INSTANCE)
+;+		(allowed-classes)
 		(create-accessor read-write))
 	(single-slot date_time
 ;+		(comment "The date_time attribute provides the date and time of an event.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot context_reference
-;+		(comment "The context reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot resource_reference
 ;+		(comment "The resource reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
 		(type STRING)
 		(default "logical_identifier")
+		(create-accessor read-write))
+	(multislot context_reference
+;+		(comment "The context reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot sort_name
 ;+		(comment "The sort name attribute provides a string to be used in ordering. For people, the last name (surname) is typically first, followed by a comma and then other names.")
@@ -2508,13 +2508,13 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot attribute_name
-;+		(comment "The attribute_name attribute provides the common name by which an attribute is known.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot record_length
 ;+		(comment "The record_length attribute provides the length of a record, including a record delimiter if present.")
 		(type INTEGER)
+		(create-accessor read-write))
+	(multislot attribute_name
+;+		(comment "The attribute_name attribute provides the common name by which an attribute is known.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot sclk_start_time
 ;+		(comment "sclk_start_time is the value of the spacecraft clock corresponding to the start_date_time given in the label.")
@@ -2525,20 +2525,20 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot relates_to_data_set
-;+		(comment "Associated data set.")
-		(type INSTANCE)
-;+		(allowed-classes Data_Set_PDS3)
-;+		(cardinality 1 1)
+	(multislot transfer_manifest_checksum
+;+		(comment "The transfer manifest checksum provides the checksum for the transfer manifest file.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot xml_schema_collection_reference
 ;+		(comment "The xml schema collection reference attribute provides the logical_identifier for a xml schema collection.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot transfer_manifest_checksum
-;+		(comment "The transfer manifest checksum provides the checksum for the transfer manifest file.")
-		(type STRING)
+	(single-slot relates_to_data_set
+;+		(comment "Associated data set.")
+		(type INSTANCE)
+;+		(allowed-classes Data_Set_PDS3)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot designation
 ;+		(comment "The designation attribute provides a name for the term in the language selected.")
@@ -2567,14 +2567,14 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot domain
-;+		(comment "The radial ‘zone’ or ‘shell’ of the target for which the observations were collected or which are represented in the product(s).  The value may depend on wavelength_range and size of the target.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot was_generated_by
 		(type INSTANCE)
 ;+		(allowed-classes Activity)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot domain
+;+		(comment "The radial ‘zone’ or ‘shell’ of the target for which the observations were collected or which are represented in the product(s).  The value may depend on wavelength_range and size of the target.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot has_Data_Object
 ;+		(comment "The has_Data_Object association is a relationship to Data Object.")
@@ -2582,15 +2582,25 @@
 ;+		(allowed-classes Data_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot spacecraft_event_start_time_utc
-;+		(comment "spacecraft_event_start_time_utc gives the UTC time corresponding to the earliest time given by spacecraft_event_time in the data table. However, while spacecraft_event_time is given as seconds offset from a reference time, spacecraft_event_start_time_utc is given as a UTC date time. Required in the label for radio occultation data. Not used for stellar occultations.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot reference_value_type
 ;+		(comment "The reference_value_type attribute indicates whether the reference value is a logical_identifier or logical identifier plus a version_id.")
 		(type STRING)
 ;+		(value "LID" "LID::VID")
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot spacecraft_event_start_time_utc
+;+		(comment "spacecraft_event_start_time_utc gives the UTC time corresponding to the earliest time given by spacecraft_event_time in the data table. However, while spacecraft_event_time is given as seconds offset from a reference time, spacecraft_event_start_time_utc is given as a UTC date time. Required in the label for radio occultation data. Not used for stellar occultations.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_observing_system
+;+		(comment "The has_observing_system association is a relationship to Observing_System.")
+		(type INSTANCE)
+;+		(allowed-classes Observing_System)
+		(create-accessor read-write))
+	(multislot thumbnail_reference
+;+		(comment "The thumbnail reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier")
 		(create-accessor read-write))
 	(single-slot has_time_coordinates
 ;+		(comment "The has_time_coordinates association is a relationship to Time_Coordinates.")
@@ -2598,36 +2608,26 @@
 ;+		(allowed-classes Time_Coordinates)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot thumbnail_reference
-;+		(comment "The thumbnail reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+	(multislot conceptual_domain
+;+		(comment "The conceptual_domain attribute provides the domain to which the value has been assigned.")
 		(type STRING)
-		(default "logical_identifier")
-		(create-accessor read-write))
-	(multislot has_observing_system
-;+		(comment "The has_observing_system association is a relationship to Observing_System.")
-		(type INSTANCE)
-;+		(allowed-classes Observing_System)
-		(create-accessor read-write))
-	(multislot maximum_observed_ring_elevation
-;+		(comment "maximum_observed_ring_elevation specifes the largest value for observed_ring_elevation in the data file. Only used if the value is not constant over the observation. Values range from -90 to %2B90 in units of degrees. Not intended for use in the data file.")
-		(type FLOAT)
 		(create-accessor read-write))
 	(multislot manifest_url
 ;+		(comment "The manifest url provides the URL to the manifest file.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot conceptual_domain
-;+		(comment "The conceptual_domain attribute provides the domain to which the value has been assigned.")
-		(type STRING)
+	(multislot maximum_observed_ring_elevation
+;+		(comment "maximum_observed_ring_elevation specifes the largest value for observed_ring_elevation in the data file. Only used if the value is not constant over the observation. Values range from -90 to %2B90 in units of degrees. Not intended for use in the data file.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot minimum_wavelength
+;+		(comment "minimum_wavelength is the smallest wavelength used in the observation. Optional in labels. Used with maximum_wavelength when the observation is over a wavelength range.")
+		(type FLOAT)
 		(create-accessor read-write))
 	(single-slot target_type
 ;+		(comment "The target_type attribute identifies the type of a named target.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot minimum_wavelength
-;+		(comment "minimum_wavelength is the smallest wavelength used in the observation. Optional in labels. Used with maximum_wavelength when the observation is over a wavelength range.")
-		(type FLOAT)
 		(create-accessor read-write))
 	(single-slot curating_facility
 ;+		(comment "The curating_facility attribute provides a unique name or identifier for the curating facility maintaining the source product.")
@@ -2660,15 +2660,15 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot local_reference_type
-;+		(comment "The local_reference_type attribute provides the name of an association between an entity identified by a local_identifier_reference and another corresponding entity identified by a local_identifier. The values for the local_reference_type are expected to be enumerated for appropriate contexts in the Schematron files of local (i.e., discipline and mission) data dictionaries.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot quaternion_component
 ;+		(comment "The quaternion_component association is a relationship to Quaternion_Component.")
 		(type INSTANCE)
 ;+		(allowed-classes Quaternion_Component)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(multislot local_reference_type
+;+		(comment "The local_reference_type attribute provides the name of an association between an entity identified by a local_identifier_reference and another corresponding entity identified by a local_identifier. The values for the local_reference_type are expected to be enumerated for appropriate contexts in the Schematron files of local (i.e., discipline and mission) data dictionaries.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot subfacet2
 ;+		(comment "The subfacet2 attribute provides a sub-categorization under the facet2 value.  The allowed values are restricted according to the value of facet2.")
@@ -2709,34 +2709,34 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot telemetry_provider_id
-;+		(comment "The telemetry_provider_id attribute identifies the provider and or version of the telemetry data used in the generation of this data.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot product_description
 ;+		(comment "Description at the identifiable layer.")
 		(type INSTANCE)
 ;+		(allowed-classes Tagged_NonDigital_Object Tagged_Digital_Object)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot image_id
-;+		(comment "This attribute is used in the image map projection. Under review.")
+	(single-slot telemetry_provider_id
+;+		(comment "The telemetry_provider_id attribute identifies the provider and or version of the telemetry data used in the generation of this data.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot start_orbit_number
-;+		(comment "The start_orbit_number attribute provides the first in a series of numbers that represent a set of orbital revolutions of one body around another.")
-		(type STRING)
+	(single-slot maximum_scaled_value
+;+		(comment "The maximum_scaled_value attribute provides the maximum value after application of scaling_factor and value_offset (see their definitions; maximum_scaled_value is the maximum of Ov).")
+		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot document_name
 ;+		(comment "The document_name attribute provides the full name of the published document. This optional attribute is used only if the title in the identification area of the document product is not sufficient.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot maximum_scaled_value
-;+		(comment "The maximum_scaled_value attribute provides the maximum value after application of scaling_factor and value_offset (see their definitions; maximum_scaled_value is the maximum of Ov).")
-		(type FLOAT)
+	(single-slot start_orbit_number
+;+		(comment "The start_orbit_number attribute provides the first in a series of numbers that represent a set of orbital revolutions of one body around another.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot image_id
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot primary_collection_reference
@@ -2762,24 +2762,24 @@
 ;+		(comment "The frame_rate attribute provides the time, in specified units, between frames for display of a movie.")
 		(type STRING)
 		(create-accessor read-write))
+	(multislot minimum_value_exclusive_flag
+;+		(comment "The minimum_value_exclusive_flag attribute indicates that the  minimum_value is exclusive, when true.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot was_informed_by
 ;+		(comment "The was_informed_by association is a recursive relationship on activity.")
 		(type INSTANCE)
 ;+		(allowed-classes Activity)
 		(create-accessor read-write))
-	(multislot minimum_value_exclusive_flag
-;+		(comment "The minimum_value_exclusive_flag attribute indicates that the  minimum_value is exclusive, when true.")
+	(single-slot brick_identifier
+;+		(comment "The identifier of the data brick – Best practice is to use the data brick serial number.")
 		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot has_Property_Map_Entry
 ;+		(comment "The has_Property_Map_Entry association is a relationship to property map entry.")
 		(type INSTANCE)
 ;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot brick_identifier
-;+		(comment "The identifier of the data brick – Best practice is to use the data brick serial number.")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot product_subclass
 ;+		(comment "The product_subclass attribute provides the name of a subclass under a product_class. For example, User_Manual is a subclass of Product_Document.")
@@ -2790,13 +2790,13 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot first_line
-;+		(comment "The first_line attribute provides the line within a source image that corresponds to the first line in a sub-image.")
-		(type INTEGER)
-		(create-accessor read-write))
 	(multislot along_track_timing_offset
 ;+		(comment "along_track_timing_offset is a timing offset to the along track spacecraft position. It is the value that minimizes differences in radii of matching circular ring features observed on the ingress and egress sides of the occultation track. Optional in labels for radio occultation. Nillable in which case the nil_reason should be 'inapplicable'. ")
 		(type FLOAT)
+		(create-accessor read-write))
+	(multislot first_line
+;+		(comment "The first_line attribute provides the line within a source image that corresponds to the first line in a sub-image.")
+		(type INTEGER)
 		(create-accessor read-write))
 	(multislot radial_sampling_interval
 ;+		(comment "radial_sampling_interval indicates the radial spacing between consecutive points in a ring profile. In practice, this may be somewhat smaller than the radial_resolution because a profile may be over-sampled. Required in labels if the value is fixed. If the value varies, the corresponding minimum and and maximum attributes must be used instead. Not intended to be used as a table field.")
@@ -2830,15 +2830,15 @@
 ;+		(comment "The alternate_id attribute provides an additional identifier supplied by the data provider.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot has_document_edition
-;+		(comment "The has document edition association is a relationship to Document Edition.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
 	(single-slot maximum
 ;+		(comment "The maximum attribute provides the largest stored value which actually appears; empty and Special_Constant field values are excluded.")
 		(type FLOAT)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_document_edition
+;+		(comment "The has document edition association is a relationship to Document Edition.")
+		(type INSTANCE)
+;+		(allowed-classes)
 		(create-accessor read-write))
 	(single-slot transfer_command_text
 ;+		(comment "This attribute is used in by the volume class. It is under review.")
@@ -2862,15 +2862,29 @@
 ;+		(comment "The install note attribute provides a brief statement giving particulars about the installation of the software.")
 		(type STRING)
 		(create-accessor read-write))
+	(single-slot first_element
+;+		(comment "The first element attribute indicates the position of the first element of an array.")
+		(type STRING)
+;+		(value "TOPLEFT")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot map_projection_rotation
 ;+		(comment "This attribute is used in the image map projection. Under review.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot first_element
-;+		(comment "The first element attribute indicates the position of the first element of an array.")
+	(multislot data_set_reference
+;+		(comment "Association for additional information.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot character_encoding
+;+		(comment "The character_encoding attribute identifies the standard that maps a set of allowed characters to their machine readable code.")
 		(type STRING)
-;+		(value "TOPLEFT")
+		(create-accessor read-write))
+	(single-slot min_index
+;+		(comment "The min index attribute provides a value that indicates the position of the element at the beginning of a sequence of elements. This value is typically 0 or 1.")
+		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot horizontal_display_axis
@@ -2878,38 +2892,24 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot min_index
-;+		(comment "The min index attribute provides a value that indicates the position of the element at the beginning of a sequence of elements. This value is typically 0 or 1.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot character_encoding
-;+		(comment "The character_encoding attribute identifies the standard that maps a set of allowed characters to their machine readable code.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot data_set_reference
-;+		(comment "Association for additional information.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
 	(multislot software_format_set
 ;+		(comment "The software_format_set association is a relationship to a set of one or more software formats.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot campaign_name
-;+		(comment "The campaign name attribute provides a word or a combination of words by which a campaign is designated, called, or known.")
+	(single-slot target_logical_identifier
+;+		(comment "The target logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
 		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot rotational_element_desc
 ;+		(comment "This attribute is used in the image map projection. Under review.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot target_logical_identifier
-;+		(comment "The target logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
+	(multislot campaign_name
+;+		(comment "The campaign name attribute provides a word or a combination of words by which a campaign is designated, called, or known.")
 		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot field_unit
 ;+		(comment "The field unit attribute indicates the unit of measurement associated with a field value.")
@@ -2943,15 +2943,15 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Group_Field_Character
-;+		(comment "The has_Group_Field_Character association is a relationship to the Group_Field_Character.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
 	(multislot has_discipline_area
 ;+		(comment "The has_discipline_area association is a relationship to Discipline Area.")
 		(type INSTANCE)
 ;+		(allowed-classes Discipline_Area)
+		(create-accessor read-write))
+	(multislot has_Group_Field_Character
+;+		(comment "The has_Group_Field_Character association is a relationship to the Group_Field_Character.")
+		(type INSTANCE)
+;+		(allowed-classes)
 		(create-accessor read-write))
 	(multislot dd_association
 ;+		(comment "The local_association_attribute association provides a relationship to an attribute.")
@@ -2963,14 +2963,14 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
+	(multislot classSteward
+;+		(comment "The classSteward attribute provides the name of the steward for this rule.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot records
 ;+		(comment "The records attribute provides a count of records.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot classSteward
-;+		(comment "The classSteward attribute provides the name of the steward for this rule.")
-		(type STRING)
 		(create-accessor read-write))
 	(multislot referenced_object_type
 ;+		(comment "The reference object type attribute indicates the type of the object being referenced.")
@@ -2996,13 +2996,17 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot member_type
+;+		(comment "The member_type attribute indicates the type of member references that  are provided.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot abstract_desc
 ;+		(comment "The abstract desc attribute provides a summary of a text, scientific article, or document.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot member_type
-;+		(comment "The member_type attribute indicates the type of member references that  are provided.")
+	(multislot specified_unit_id
+;+		(comment "The specified_unit_id attribute provides the unit chosen for maximum_value, minimum_value, and permissible_value.")
 		(type STRING)
 		(create-accessor read-write))
 	(multislot has_Delimited_Field
@@ -3010,27 +3014,23 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot specified_unit_id
-;+		(comment "The specified_unit_id attribute provides the unit chosen for maximum_value, minimum_value, and permissible_value.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot telescope_longitude
 ;+		(comment "The telescope_longitude attribute provides the angular distance of the telescope east (positive), measured by the angle contained between the meridian of the telescope and the reference figure (or datum) prime meridian.")
 		(type FLOAT)
 		(create-accessor read-write))
-	(single-slot upper_120127c_Class0
-		(type STRING)
-;+		(cardinality 0 1)
+	(multislot has_Character_Field
+;+		(comment "The has_Character_Field association is a relationship to the field types.")
+		(type INSTANCE)
+;+		(allowed-classes)
 		(create-accessor read-write))
 	(single-slot programmers_manual_id
 ;+		(comment "The programmers manual id attribute provides an identifier to a document giving instruction about the programming of the software.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot has_Character_Field
-;+		(comment "The has_Character_Field association is a relationship to the field types.")
-		(type INSTANCE)
-;+		(allowed-classes)
+	(single-slot upper_120127c_Class0
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot optional_data_object_set
 ;+		(comment "Associated optional data object set.")
@@ -3054,14 +3054,14 @@
 ;+		(comment "The vector_components attribute provides a count of vector components.")
 		(type INTEGER)
 		(create-accessor read-write))
+	(multislot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot has_Map_Projection
 ;+		(comment "The xxx association is a relationship to yyy.")
 		(type INSTANCE)
 ;+		(allowed-classes XSChoice%23)
-		(create-accessor read-write))
-	(multislot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
 		(create-accessor read-write))
 	(single-slot second_standard_parallel
 ;+		(comment "This attribute is used in the image map projection. Under review.")
@@ -3072,29 +3072,29 @@
 ;+		(comment "The reference_association_type attribute provides the name of the association used in a reference.")
 		(type STRING)
 		(create-accessor read-write))
+	(multislot observed_event_start_tdb
+;+		(comment "observed_event_start_tdb indicates the value for earliest time in the described data, and is given in elapsed seconds since the J2000 epoch. Optional in labels; not intended for use as a table field.")
+		(type FLOAT)
+		(create-accessor read-write))
 	(multislot has_Polyconic
 ;+		(comment "The xxx association is a relationship to yyy.")
 		(type INSTANCE)
 ;+		(allowed-classes XSChoice%23)
 		(create-accessor read-write))
-	(multislot observed_event_start_tdb
-;+		(comment "observed_event_start_tdb indicates the value for earliest time in the described data, and is given in elapsed seconds since the J2000 epoch. Optional in labels; not intended for use as a table field.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot has_Delimited_Group_Sequence
-;+		(comment "The has_Delimited_Group_Sequence association is a relationship to field sequence.")
-		(type INSTANCE)
-;+		(allowed-classes)
+	(single-slot missing_constant
+;+		(comment "The missing_constant attribute provides a value that indicates the original value was missing, such as due to a gap in coverage.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot node_name
 ;+		(comment "The node_name attribute provides the name of a PDS Node.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot missing_constant
-;+		(comment "The missing_constant attribute provides a value that indicates the original value was missing, such as due to a gap in coverage.")
-		(type STRING)
-;+		(cardinality 0 1)
+	(multislot has_Delimited_Group_Sequence
+;+		(comment "The has_Delimited_Group_Sequence association is a relationship to field sequence.")
+		(type INSTANCE)
+;+		(allowed-classes)
 		(create-accessor read-write))
 	(single-slot registered_by
 ;+		(comment "The registered_by attribute provides the name of the person or organization that registered the object.")
@@ -3116,16 +3116,16 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
+	(multislot has_Science_Facet
+;+		(comment "The has_Science_Facet association is a relationship Science_Facet.")
+		(type INSTANCE)
+;+		(allowed-classes Science_Facets)
+		(create-accessor read-write))
 	(single-slot flatten_class_org
 ;+		(comment "Housekeeping.")
 		(type INSTANCE)
 ;+		(allowed-classes Element_Array Axis_Array)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_Science_Facet
-;+		(comment "The has_Science_Facet association is a relationship Science_Facet.")
-		(type INSTANCE)
-;+		(allowed-classes Science_Facets)
 		(create-accessor read-write))
 	(single-slot band_number
 ;+		(comment "The band_number attribute provides a number corresponding to the band in the spectral qube. The band number is equivalent to the instrument band number.")
@@ -3145,16 +3145,12 @@
 ;+		(comment "The instrument serial number element provides the manufacturer's serial number assigned to an instrument. This number may be used to uniquely identify a particular instrument for tracing its components or determining its calibration history, for example.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot facet1
-;+		(comment "The facet1 attribute provides a sub-categorization under the discipline_name.  The values are restricted according to the value of discipline_name.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot minimum_light_source_incidence_angle
 ;+		(comment "minimum_light_source_incidence_angle specifes the smallest value for observed_ring_elevation in the observation. Only used if the value is not constant over the observation. Values range from 0 to %2B90 in units of degrees. Not intended for use in the data file.")
 		(type FLOAT)
 		(create-accessor read-write))
-	(multislot facet2
-;+		(comment "The facet2 attribute provides a sub-categorization (under the discipline_name) of the type of data being described by Primary_Result_Summary.  The  facet1  and  factet2  values are intended to provide independent sub-categorizations. The values are restricted according to the value of discipline_name. Type: ASCII_Short_String_Collapsed")
+	(multislot facet1
+;+		(comment "The facet1 attribute provides a sub-categorization under the discipline_name.  The values are restricted according to the value of discipline_name.")
 		(type STRING)
 		(create-accessor read-write))
 	(single-slot local_georeference_information
@@ -3162,28 +3158,32 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot facet2
+;+		(comment "The facet2 attribute provides a sub-categorization (under the discipline_name) of the type of data being described by Primary_Result_Summary.  The  facet1  and  factet2  values are intended to provide independent sub-categorizations. The values are restricted according to the value of discipline_name. Type: ASCII_Short_String_Collapsed")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot md5_checksum
 ;+		(comment "The md5_checksum attribute is the 32-character hexadecimal number computed using the MD5 algorithm for the contiguous bytes of single digital object (as stored) or for an entire file.")
 		(type STRING)
-		(create-accessor read-write))
-	(multislot campaign_start_date
-;+		(comment "The campaign start date attribute provides the date when a campaign began.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot unit_of_measure_type
-;+		(comment "The unit_of_measure_type attribute identifies the class from which the attribute being defined in this data dictionary draws its possible expressions for units.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot non_quote_character
-;+		(comment "non-quote-character = letter | digit | special | underscore | apostrophe | space ;")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot modification_history
 ;+		(comment "The modification_history association is a relationship to Modification_History, a history of changes made to the product.")
 		(type INSTANCE)
 ;+		(allowed-classes Modification_History)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot non_quote_character
+;+		(comment "non-quote-character = letter | digit | special | underscore | apostrophe | space ;")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot unit_of_measure_type
+;+		(comment "The unit_of_measure_type attribute identifies the class from which the attribute being defined in this data dictionary draws its possible expressions for units.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot campaign_start_date
+;+		(comment "The campaign start date attribute provides the date when a campaign began.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot has_Schematron_Assert
 		(type INSTANCE)
@@ -3202,19 +3202,15 @@
 ;+		(comment "The standard_parallel_1 attribute defines the first standard parallel %28applicable only for specific projections%29, the first line of constant latitude at which the surface of the planet and the plane or developable surface intersect. ")
 		(type FLOAT)
 		(create-accessor read-write))
-	(multislot assertMsg
-		(type STRING)
-		(create-accessor read-write))
 	(multislot instrument_host_id
 ;+		(comment "The instrument_host_id attribute provides a unique identifier for the host on which an instrument is located. This host can be either a spacecraft or an earth base (e.g. earth).")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot sampling_parameter_unit
-;+		(comment "The sampling_parameter_unit element specifies the unit of measure of associated data sampling parameters.")
+	(multislot assertMsg
 		(type STRING)
 		(create-accessor read-write))
-	(multislot revision_comment
-;+		(comment "The revision comment attribute provides notes on the revision of the product.")
+	(multislot sampling_parameter_unit
+;+		(comment "The sampling_parameter_unit element specifies the unit of measure of associated data sampling parameters.")
 		(type STRING)
 		(create-accessor read-write))
 	(single-slot sequence_class_org
@@ -3222,6 +3218,10 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot revision_comment
+;+		(comment "The revision comment attribute provides notes on the revision of the product.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot value
 ;+		(comment "The value attribute provides a single, allowed numerical or character string value.")
@@ -3302,14 +3302,14 @@
 ;+		(comment "The low_representative_saturation attribute specifies a special value whose presence indicates the true value cannot be represented in the chosen data type and length -- in this case being below the allowable range -- which may happen during conversion from another data type. The value must be less than the value of the valid_minimum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
 		(type STRING)
 		(create-accessor read-write))
+	(multislot software_dialect
+;+		(comment "The software dialect attribute indicates the variety of a language used to write the software.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot browse_reference
 ;+		(comment "The browse reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
 		(type STRING)
 		(default "logical_identifier")
-		(create-accessor read-write))
-	(multislot software_dialect
-;+		(comment "The software dialect attribute indicates the variety of a language used to write the software.")
-		(type STRING)
 		(create-accessor read-write))
 	(multislot instance_id
 ;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
@@ -3319,33 +3319,33 @@
 ;+		(comment "The files attribute provides the number of files.")
 		(type INTEGER)
 		(create-accessor read-write))
-	(multislot has_Field_Bit
-;+		(comment "The has_Field_Bit association is a relationship to Field_Bits.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot UpperModel_191218_CCB-256_ReferenceTypes_Retry_Class0
+	(single-slot western_most_longitude
+;+		(comment "This attribute is used in the image map projection. Under review.")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot registration_date
 ;+		(comment "The registration_date attribute provides the date of registration within the PDS system.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot western_most_longitude
-;+		(comment "This attribute is used in the image map projection. Under review.")
+	(single-slot UpperModel_191218_CCB-256_ReferenceTypes_Retry_Class0
 		(type STRING)
-;+		(cardinality 1 1)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot associated_optional_folder
-;+		(comment "The associated_optional_folder association is a relationship to optional folders.")
+	(multislot has_Field_Bit
+;+		(comment "The has_Field_Bit association is a relationship to Field_Bits.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
 	(multislot minimum_observed_event_time
 ;+		(comment "minimum_observed_event_time gives the smallest value for observed_event_time in the associated data file. It is given in numeric seconds as an offset from the specified UTC reference time. minimum_observed_event_time is optional in labels since the data file time interval end point values are given by the required start_date_time_utc and stop_date_time_utc attributes in the Time_Coordinates class.")
 		(type FLOAT)
+		(create-accessor read-write))
+	(multislot associated_optional_folder
+;+		(comment "The associated_optional_folder association is a relationship to optional folders.")
+		(type INSTANCE)
+;+		(allowed-classes)
 		(create-accessor read-write))
 	(single-slot underscore
 ;+		(comment "underscore = \"_\" ; (* low line *)")
@@ -3381,15 +3381,15 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot lidvid_reference
-;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
-		(type STRING)
-		(default "logical_identifier::version_id")
-		(create-accessor read-write))
 	(single-slot delivery_identifier
 ;+		(comment "The identifier for the delivery. Formation Rule: Curating_Node_Id + “_” + Subnode _Id + “_” +  yy-mm-ddThhmmss  - e.g. IMAGING_USGS_2008-06-23T120000.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot lidvid_reference
+;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
+		(type STRING)
+		(default "logical_identifier::version_id")
 		(create-accessor read-write))
 	(single-slot latitude_type
 ;+		(comment " The latitude_type attribute defines the type of latitude %28planetographic, planetocentric%29 used within a cartographic product and as reflected in attribute values within associated PDS labels. The IAU definition for direction of positive longitude should be adopted: http:%2F%2Fastrogeology.usgs.gov%2Fgroups%2FIAU-WGCCRE. ")
@@ -3407,31 +3407,17 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot ring_event_start_time_utc
-;+		(comment "ring_event_start_time_utc gives the UTC time corresponding to the earliest time given by ring_event_time or ring_event_tdb in the data table. ring_event_start_time_utc is required for all ring occultation data. ring_event_start_time_utc is required label attribute for all ring occultation data.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot comment
 ;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot ring_event_start_time_utc
+;+		(comment "ring_event_start_time_utc gives the UTC time corresponding to the earliest time given by ring_event_time or ring_event_tdb in the data table. ring_event_start_time_utc is required for all ring occultation data. ring_event_start_time_utc is required label attribute for all ring occultation data.")
 		(type STRING)
 		(create-accessor read-write))
 	(single-slot start_bit
 ;+		(comment "The start_bit attribute provides the position of the first bit within an ordered sequence of bits.")
 		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot resource_name
-;+		(comment "The resource_name attribute provides a name for the resouce")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot spacecraft_clock_count_partition
-;+		(comment "The spacecraft_clock_count_partition attribute provides the clock partition active for spacecraft_clock_start_count and spacecraft_clock_stop_count.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot std_ref_version_id
-;+		(comment "The std ref version id attribute provides the version identifier for the standard reference document.")
-		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot has_display_direction
@@ -3440,14 +3426,28 @@
 ;+		(allowed-classes)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot release_parameter_text
-;+		(comment "This attribute is used in by the data set release class. It is under review.")
+	(single-slot std_ref_version_id
+;+		(comment "The std ref version id attribute provides the version identifier for the standard reference document.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot spacecraft_clock_count_partition
+;+		(comment "The spacecraft_clock_count_partition attribute provides the clock partition active for spacecraft_clock_start_count and spacecraft_clock_stop_count.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot resource_name
+;+		(comment "The resource_name attribute provides a name for the resouce")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot distance_resolution
 ;+		(comment "The distance_resolution attribute provides the minimum distance measurable between two points, expressed in Planar Distance Units of measure.")
 		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot release_parameter_text
+;+		(comment "This attribute is used in by the data set release class. It is under review.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot product_class
@@ -3459,14 +3459,14 @@
 ;+		(comment "The sampling_parameter_scale element specifies whether the sampling interval is linear or something other such as logarithmic.")
 		(type STRING)
 		(create-accessor read-write))
+	(multislot alternate_title
+;+		(comment "The alternate _title attribute provides an alternate title for the product.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot producer_full_name
 ;+		(comment "The producer_full_name attribute provides the full_name of the individual mainly responsible for the production of the data set. This individual does not have to be registered with the PDS.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot alternate_title
-;+		(comment "The alternate _title attribute provides an alternate title for the product.")
-		(type STRING)
 		(create-accessor read-write))
 	(multislot default_red
 ;+		(comment "The default_red attribute provides the number of the plane along the axis that is to be loaded, by default, into the red plane of a display device.")
@@ -3500,14 +3500,14 @@
 ;+		(allowed-classes)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot has_Universal_Transverse_Mercator
 ;+		(comment "The xxx association is a relationship to yyy.")
 		(type INSTANCE)
 ;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot has_Resource_Section
 ;+		(comment "The has_Resource_Section association is a relationship to resources.")
@@ -3553,24 +3553,24 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot serial_number
-;+		(comment "The serial number attribute provides the manufacturer's serial number assigned to an instrument host.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot team_name
 ;+		(comment "The team_name attribute provides the name of a group of individuals working together.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot serial_number
+;+		(comment "The serial number attribute provides the manufacturer's serial number assigned to an instrument host.")
 		(type STRING)
 		(create-accessor read-write))
 	(multislot rule_type
 ;+		(comment "The rule_type attribute indicates the type of statement to be executed.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot copyright
-;+		(comment "The copyright attribute is a character string giving  information about the exclusive right to make copies, license, and otherwise exploit an object, whether physical or digital.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot instrument_host_puid
 ;+		(comment "The instrument_host_puid attribute provides a globally unique identifer for an instrument_host.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot copyright
+;+		(comment "The copyright attribute is a character string giving  information about the exclusive right to make copies, license, and otherwise exploit an object, whether physical or digital.")
 		(type STRING)
 		(create-accessor read-write))
 	(multislot value_domain_entry
@@ -3626,27 +3626,27 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot abstract_flag
-;+		(comment "The abstract flag attribute indicates whether or not the class can be instantiated. Abstract flag is only included if a value of 'true' is desired and indicates that the class is abstract and cannot be used in a label.")
+	(single-slot date
 		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot value_offset
 ;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot date
+	(multislot abstract_flag
+;+		(comment "The abstract flag attribute indicates whether or not the class can be instantiated. Abstract flag is only included if a value of 'true' is desired and indicates that the class is abstract and cannot be used in a label.")
 		(type STRING)
-;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot sampling_parameters
+;+		(comment "The sampling_parameters attribute provides the total number of sampling parameter values between first_sampling_parameter_value and last_sampling_parameter_value (inclusive).")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot oblique_line_longitude
 ;+		(comment "The oblique_line_longitude attribute provides the longitude of a point defining the oblique line.")
 		(type FLOAT)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot sampling_parameters
-;+		(comment "The sampling_parameters attribute provides the total number of sampling parameter values between first_sampling_parameter_value and last_sampling_parameter_value (inclusive).")
-		(type STRING)
 		(create-accessor read-write))
 	(multislot name_association_type
 ;+		(comment "The name_association_type attribute indicates whether the name is a primary, alternate, or deprecated name.")
@@ -3666,18 +3666,18 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot axis_index
-;+		(comment "The axis index attribute provides the index of the axis in an ordered set. The index of the first axis has a value of 1.")
-		(type INTEGER)
-;+		(cardinality 0 1)
+	(multislot curating_node_id
+;+		(comment "The curating_node_id attribute provides the id of the node currently maintaining the data set or volume and is responsible for maintaining catalog information.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot upper_110917_Class1
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot curating_node_id
-;+		(comment "The curating_node_id attribute provides the id of the node currently maintaining the data set or volume and is responsible for maintaining catalog information.")
-		(type STRING)
+	(single-slot axis_index
+;+		(comment "The axis index attribute provides the index of the axis in an ordered set. The index of the first axis has a value of 1.")
+		(type INTEGER)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot associated_Cartography
 ;+		(comment "The associated_Cartography association is a relationship to Cartography.")
@@ -3685,25 +3685,25 @@
 ;+		(allowed-classes)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot provider_site_id
-;+		(comment "The provider site id attribute provides an identifier for the provider.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot local_description
 ;+		(comment "The local_description attribute provides a description of the coordinate system and its orientation to the surface of a planet.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot provider_site_id
+;+		(comment "The provider site id attribute provides an identifier for the provider.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot starting_point_identifier
 ;+		(comment "The starting_point attribute provides the local_identifier of the object to be accessed first.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot supported_environment_note
-;+		(comment "The supported environment note attribute identifies  the environment  that can process the software.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot pattern
 ;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot supported_environment_note
+;+		(comment "The supported environment note attribute identifies  the environment  that can process the software.")
 		(type STRING)
 		(create-accessor read-write))
 	(multislot has_tagged_data_object2
@@ -3711,25 +3711,16 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot naif_host_id
-;+		(comment "The naif_host_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
+	(single-slot desc
 		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot software_format_type
 ;+		(comment "The software format type attribute classifies the format of the software.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot desc
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot data_set_logical_identifier
-;+		(comment "The data set logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot activity_type
-;+		(comment "The activity_type attribute provides a classification for the activity.")
+	(multislot naif_host_id
+;+		(comment "The naif_host_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
 		(type STRING)
 		(create-accessor read-write))
 	(single-slot has_zip
@@ -3737,6 +3728,15 @@
 		(type INSTANCE)
 ;+		(allowed-classes Zip)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot activity_type
+;+		(comment "The activity_type attribute provides a classification for the activity.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot data_set_logical_identifier
+;+		(comment "The data set logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot mission_phase_identifier
 ;+		(comment "The mission_phase_identifier attribute provides an identifier for a mission phase.")
@@ -3746,14 +3746,14 @@
 ;+		(comment "The editor_list attribute contains a semi-colon-separated list of names of people to be cited as editors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final editor. All editors should be listed explicitly - do not elide the list using \"et al.\".")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot roleId
-;+		(comment "The roleId attribute provides the role performed by this object.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot lid_reference_to
 ;+		(comment "The lid_reference_to provides the identifier of the ending object in a  one directional relationship.")
 		(type INSTANCE)
 ;+		(allowed-classes LID_ID_Reference_To)
+		(create-accessor read-write))
+	(multislot roleId
+;+		(comment "The roleId attribute provides the role performed by this object.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot bricks
 ;+		(comment "An integer value indicating the number of data bricks in this delivery. xxx OPS;DS, check steward, negative values xxx")
@@ -3801,8 +3801,8 @@
 ;+		(comment "The rule_value attribute provides values to be used to complete certain schematon statements.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot stop_bit_location
-;+		(comment "The stop_bit_location attribute provides the position of the last bit in a bit field relative to the first bit in the parent packed data field. Bytes are sequential and bits are numbered continuously across byte boundaries within a single bit field. The first bit position in the packed data field is \"1\".")
+	(single-slot operating_system_id
+;+		(comment "This attribute is used in by the volume class. It is under review.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -3812,8 +3812,8 @@
 ;+		(allowed-classes)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot operating_system_id
-;+		(comment "This attribute is used in by the volume class. It is under review.")
+	(single-slot stop_bit_location
+;+		(comment "The stop_bit_location attribute provides the position of the last bit in a bit field relative to the first bit in the parent packed data field. Bytes are sequential and bits are numbered continuously across byte boundaries within a single bit field. The first bit position in the packed data field is \"1\".")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -3826,22 +3826,22 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot field_data_type
-;+		(comment "The field_data_type attribute provides the machine  representation used to store the value.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot primary_body_name
 ;+		(comment "The primary_body_name attribute identifies the primary body with which a given target body is associated as a secondary body.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot sampling_parameter_interval
-;+		(comment "The sampling_parameter_interval attribute provides the spacing of points at which data are sampled and at which values for an instrument or other parameter are available. If x1 and xn are the first and last sampling parameter values, respectively, xn is larger than x1, n is the number of sampling parameters, the caret symbol (^) denotes exponentiation, and b, a positive real number, is the base for exponentiation, then the value of sampling_parameter_interval is: (xn-x1)/(n-1) (for sampling_parameter_scale = Linear), (xn/x1)^(1/(n-1)) (for sampling_parameter_scale = Logarithmic), (b^xn-b^x1)/(n-1) (for sampling_parameter_scale = Exponential).")
-		(type FLOAT)
+	(multislot field_data_type
+;+		(comment "The field_data_type attribute provides the machine  representation used to store the value.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot spice_kernel_file_name
 ;+		(comment "The spice_kernel_file_name attribute is used to identify SPICE kernel files used in the production of the product.")
 		(type STRING)
+		(create-accessor read-write))
+	(multislot sampling_parameter_interval
+;+		(comment "The sampling_parameter_interval attribute provides the spacing of points at which data are sampled and at which values for an instrument or other parameter are available. If x1 and xn are the first and last sampling parameter values, respectively, xn is larger than x1, n is the number of sampling parameters, the caret symbol (^) denotes exponentiation, and b, a positive real number, is the base for exponentiation, then the value of sampling_parameter_interval is: (xn-x1)/(n-1) (for sampling_parameter_scale = Linear), (xn/x1)^(1/(n-1)) (for sampling_parameter_scale = Logarithmic), (b^xn-b^x1)/(n-1) (for sampling_parameter_scale = Exponential).")
+		(type FLOAT)
 		(create-accessor read-write))
 	(single-slot original_band
 ;+		(comment "The original_band attribute of a spectral qube provides the sequence of band numbers in the qube relative to some original qube. In the original qube, the values are just consecutive integers beginning with 1. In a qube which contains a subset of the bands in the original qube, the values are the original sequence numbers from that qube.")
@@ -3869,14 +3869,14 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot high_instrument_saturation
-;+		(comment "The high_instrument_saturation attribute specifies a special value whose presence indicates the measuring instrument was saturated at the high end. The value must be less than the value of the valid_minimum attribute or more than the value of the valid_maximum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot instrument_host_type
 ;+		(comment "The instrument_host_type attribute provides the type of host on which an instrument is based. For example instrument is located on a spacecraft instrument_host_type attribute would have the value SPACECRAFT.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot high_instrument_saturation
+;+		(comment "The high_instrument_saturation attribute specifies a special value whose presence indicates the measuring instrument was saturated at the high end. The value must be less than the value of the valid_minimum attribute or more than the value of the valid_maximum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot document_puid
 ;+		(comment "The document_puid attribute provides a globally unique identifer for a document.")
@@ -3891,14 +3891,14 @@
 ;+		(comment "sub_stellar_clock_angle is an angle measured at a point in the ring plane, from the direction toward a star to the local radial direction. This angle is projected into the ring plane and measured in the clockwise %28retrograde%29 direction. Equivalently, this is the prograde angle from the local radial direction to the direction toward the star. For stellar occultation data, this angle is equal to %28180 - OBSERVED_RING_AZIMUTH%29 mod 360. It is available only for backward compatibility with previously published Cassini VIMS occultation data analysis; observed_ring_azimuth is the preferred quantity for archiving. sub_stellar_clock_angle is an optional data table field for Cassini VIMS occultation data; not recommended for other occultation data. In a label, the min and max variation attributes are optional for Cassini VIMS occultation data; not recommended for other occultation data. ")
 		(type FLOAT)
 		(create-accessor read-write))
+	(multislot latitude_of_projection_origin
+;+		(comment "The latitude_of_projection_origin attribute defines the latitude chosen as the origin of rectangular coordinates for a map projection.")
+		(type FLOAT)
+		(create-accessor read-write))
 	(single-slot mission_desc
 ;+		(comment "The mission_desc attribute summarizes major aspects of a planetary mission or project, including the number and type of spacecraft, the target body or bodies and major accomplishments.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot latitude_of_projection_origin
-;+		(comment "The latitude_of_projection_origin attribute defines the latitude chosen as the origin of rectangular coordinates for a map projection.")
-		(type FLOAT)
 		(create-accessor read-write))
 	(single-slot oblique_line_latitude
 ;+		(comment "The oblique_line_latitude attribute provides the latitude of a point defining the oblique line.")
@@ -3915,15 +3915,15 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Field_LIDVID
-;+		(comment "The has_Field_LIDVID association is a relationship to an LIDVID.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
 	(multislot lid_reference
 ;+		(comment "The lid_reference attribute provides the logical_identifier for a  product.")
 		(type STRING)
 		(default "logical_identifier")
+		(create-accessor read-write))
+	(multislot has_Field_LIDVID
+;+		(comment "The has_Field_LIDVID association is a relationship to an LIDVID.")
+		(type INSTANCE)
+;+		(allowed-classes)
 		(create-accessor read-write))
 	(multislot parsing_standard_id
 ;+		(comment "The parsing_standard_id attribute provides the formal name of a standard used for the structure of a Parsable Byte Stream digital object.")
@@ -3942,22 +3942,27 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot latitude
+;+		(comment "The latitude attribute provides the angular distance north or south from the equator of a point on the object's surface, measured on the meridian of the point.")
+		(type FLOAT)
+		(create-accessor read-write))
 	(single-slot citation_information
 ;+		(comment "The citation_information is a relationship to Citation_Information, fields often used in citing the product.")
 		(type INSTANCE)
 ;+		(allowed-classes Citation_Information)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot latitude
-;+		(comment "The latitude attribute provides the angular distance north or south from the equator of a point on the object's surface, measured on the meridian of the point.")
-		(type FLOAT)
+	(single-slot brick_description
+;+		(comment "The brick_description provides a text description of the storage brick and includes at least the brick's storage format.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot alternative
 ;+		(comment "An alternative name for the resource. Dublin Core.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot brick_description
-;+		(comment "The brick_description provides a text description of the storage brick and includes at least the brick's storage format.")
+	(single-slot data_set_desc
+;+		(comment "The data_set_desc attribute describes the content and type of a data set and provides information required to use the data (such as binning information).")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -3965,11 +3970,6 @@
 ;+		(comment "This attribute is used in by the volume class. It is under review.")
 		(type STRING)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot data_set_desc
-;+		(comment "The data_set_desc attribute describes the content and type of a data set and provides information required to use the data (such as binning information).")
-		(type STRING)
-;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot product_type
 ;+		(comment "The product type attribute provides the name of a class of which this object is a member.")
@@ -3982,15 +3982,15 @@
 ;+		(allowed-classes)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot last_modification_date_time
+;+		(comment "The last_modification_date_time attribute gives the most recent date and time that a change was made.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot has_File
 ;+		(comment "The has_File association is a relationship to File.")
 		(type INSTANCE)
 ;+		(allowed-classes File)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot last_modification_date_time
-;+		(comment "The last_modification_date_time attribute gives the most recent date and time that a change was made.")
-		(type STRING)
 		(create-accessor read-write))
 	(multislot data_standards
 ;+		(comment "The data standards association is a relationship to information about the controlling data standards.")
@@ -4001,14 +4001,14 @@
 ;+		(comment "The reference_text attribute provides a complete bibliographic citation for a published work.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot data_collection_reference
-;+		(comment "The data collection reference attribute provides the logical_identifier for a data collection.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot stop_date_time
 ;+		(comment "The stop_date_time attribute provides the date and time at the end of a time interval of interest.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot data_collection_reference
+;+		(comment "The data collection reference attribute provides the logical_identifier for a data collection.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot ring_profile_direction
 ;+		(comment "ring_profile_direction indicates the radial direction of a ring occultation within a particular data product. Possible values are 'Ingress', 'Egress', or 'Multiple'. The value 'Multiple' is only used for some Hubble-based occultations where the occultation track is not monotonic over relatively short time scales. Required in labels of ring occultation observations. Not intended as a value for a table field.")
@@ -4019,20 +4019,20 @@
 ;+		(comment "Information about rights held in and over the resource. - Dublin Core")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot longitude_direction
-;+		(comment "The longitude_direction attribute identifies the direction of longitude %28e.g. POSITIVE_EAST or POSITIVE_WEST%29 for a planet. The IAU definition for direction of positive longitude is adopted. Typically, for planets with prograde rotations, positive longitude direction is to the west. For planets with retrograde rotations, positive longitude direction is to the east. Note: The longitude_direction attribute should be used for planetographc systems, but not for planetocentric.")
-		(type STRING)
-;+		(cardinality 1 1)
+	(multislot name_resolution
+;+		(comment "The name_resolution class allows a primary name and several alternate names for an object.")
+		(type INSTANCE)
+;+		(allowed-classes Target_Identification)
 		(create-accessor read-write))
 	(single-slot container_file_name
 ;+		(comment "The file name attribute provides a word or a combination of words by which the file is known. The role of this file is a container.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot name_resolution
-;+		(comment "The name_resolution class allows a primary name and several alternate names for an object.")
-		(type INSTANCE)
-;+		(allowed-classes Target_Identification)
+	(single-slot longitude_direction
+;+		(comment "The longitude_direction attribute identifies the direction of longitude %28e.g. POSITIVE_EAST or POSITIVE_WEST%29 for a planet. The IAU definition for direction of positive longitude is adopted. Typically, for planets with prograde rotations, positive longitude direction is to the west. For planets with retrograde rotations, positive longitude direction is to the east. Note: The longitude_direction attribute should be used for planetographc systems, but not for planetocentric.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot instrument_desc
 ;+		(comment "The instrument_desc attribute describes a given instrument.")
@@ -4048,16 +4048,16 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot associated_Statistics
+;+		(comment "The associated_Object_Statistics association is a relationship to object statistics.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
 	(single-slot bearing_reference_meridian
 ;+		(comment "The bearing_reference_meridian attribute specifies the axis from which the bearing is measured.")
 		(type STRING)
 ;+		(value "Assumed" "Astronomic" "Geodetic" "Grid" "Magnetic")
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot associated_Statistics
-;+		(comment "The associated_Object_Statistics association is a relationship to object statistics.")
-		(type INSTANCE)
-;+		(allowed-classes)
 		(create-accessor read-write))
 	(single-slot checksum_type
 ;+		(comment "The checksum type attribute provides the name of the checksum algorithm used to calculate the checksum value.")
@@ -4099,14 +4099,14 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot line_display_direction
+;+		(comment "The line_display_direction element is the preferred orientation of lines within an image for viewing on a display device.  The default value is down, meaning lines are viewed top to bottom on the display. Note that if this keyword is present in a label, the SAMPLE_DISPLAY_DIRECTION keyword must also be present and must contain a value orthogonal to the value selected for this keyword.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot observing_system_reference
 ;+		(comment "The observing system reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
 		(type STRING)
 		(default "logical_identifier")
-		(create-accessor read-write))
-	(multislot line_display_direction
-;+		(comment "The line_display_direction element is the preferred orientation of lines within an image for viewing on a display device.  The default value is down, meaning lines are viewed top to bottom on the display. Note that if this keyword is present in a label, the SAMPLE_DISPLAY_DIRECTION keyword must also be present and must contain a value orthogonal to the value selected for this keyword.")
-		(type STRING)
 		(create-accessor read-write))
 	(single-slot center_latitude
 ;+		(comment "This attribute is used in the image map projection. Under review.")
@@ -4131,15 +4131,15 @@
 ;+		(comment "The rule_assign attribute provides an assignment statement for a schematron rule.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot nssdc
-;+		(comment "The nssdc association is a relationship to NSSDC.")
-		(type INSTANCE)
-;+		(allowed-classes NSSDC)
-		(create-accessor read-write))
 	(single-slot institution_name
 ;+		(comment "The institution_name attribute provides the name of the associated institution.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot nssdc
+;+		(comment "The nssdc association is a relationship to NSSDC.")
+		(type INSTANCE)
+;+		(allowed-classes NSSDC)
 		(create-accessor read-write))
 	(multislot element_flag
 ;+		(comment "The element flag attribute indicates whether or not the class is defined as a xs:element in XML Schema.")
@@ -4167,14 +4167,14 @@
 ;+		(comment "The groups attribute provides a count of the total number of groups directly associated with a table record.  Groups within groups within the record are not included in this count.")
 		(type INTEGER)
 		(create-accessor read-write))
+	(multislot star_name
+;+		(comment "star_name provides the identifying name of star, including the catalog name if necessary. Examples include 'sigma Sgr' and 'SAO 123456' %28for star number 123456 in the Smithsonian Astrophysical Observatory catalog%29. Use 'Sun' for solar occultations. Required in labels for stellar and solar occultations. Not used for radio occultations.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot has_Equirectrangular
 ;+		(comment "The xxx association is a relationship to yyy.")
 		(type INSTANCE)
 ;+		(allowed-classes XSChoice%23)
-		(create-accessor read-write))
-	(multislot star_name
-;+		(comment "star_name provides the identifying name of star, including the catalog name if necessary. Examples include 'sigma Sgr' and 'SAO 123456' %28for star number 123456 in the Smithsonian Astrophysical Observatory catalog%29. Use 'Sun' for solar occultations. Required in labels for stellar and solar occultations. Not used for radio occultations.")
-		(type STRING)
 		(create-accessor read-write))
 	(single-slot record_bytes
 ;+		(comment "The record_bytes attribute provides a count of the bytes in a record, including a record delimiter if present.")
@@ -4198,27 +4198,27 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot has_Bounding_Coordinates
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
 	(single-slot repertoire_list
 ;+		(comment "UTF-8 (8-bit UCS/Unicode Transformation Format) is a variable-length character encoding for Unicode. It is able to represent any character in the Unicode standard, yet is backwards compatible with ASCII.")
 		(type STRING)
 ;+		(value "UTF-8")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Bounding_Coordinates
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
 	(multislot any_attribute
 ;+		(comment "xxx ddwg;DS xxx")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot document_standard_id
-;+		(comment "The document_standard_id attribute provides the formal name of a standard used for the structure of a document file.")
-		(type STRING)
-		(create-accessor read-write))
 	(multislot maximum_value
 ;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot document_standard_id
+;+		(comment "The document_standard_id attribute provides the formal name of a standard used for the structure of a document file.")
 		(type STRING)
 		(create-accessor read-write))
 	(multislot minimum_radial_sampling_interval
@@ -4244,13 +4244,13 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot light_source_incidence_angle
-;+		(comment "light_source_incidence_angle is an angle measured from the local surface normal vector to the direction of a photon arriving from the light source. For rings, the normal vector is that on the same side of the rings as the light source, so values always range between 0 and 90 in units of degrees. The value is always equal to 90 - %7C observed_ring_elevation %7C This will enable users to perform database searches based on the effective ring opening angle when they are not concerned about the the distinction between north-side and southside viewpoints. We have included the 'light source' prefix to the term so that this quantity is not confused with 'incidence angle', a term that is generally associated with sunlight rather than stars or radio transmitters. Required in the label if the value is constant for the observation. If the angle varies for the observation, the min and max attributes are required in the label. Optional as a field in the data table.")
-		(type FLOAT)
-		(create-accessor read-write))
 	(multislot enumeration_flag
 ;+		(comment "The enumeration_flag attribute indicates whether there is an enumerated set of permissible values.")
 		(type STRING)
+		(create-accessor read-write))
+	(multislot light_source_incidence_angle
+;+		(comment "light_source_incidence_angle is an angle measured from the local surface normal vector to the direction of a photon arriving from the light source. For rings, the normal vector is that on the same side of the rings as the light source, so values always range between 0 and 90 in units of degrees. The value is always equal to 90 - %7C observed_ring_elevation %7C This will enable users to perform database searches based on the effective ring opening angle when they are not concerned about the the distinction between north-side and southside viewpoints. We have included the 'light source' prefix to the term so that this quantity is not confused with 'incidence angle', a term that is generally associated with sunlight rather than stars or radio transmitters. Required in the label if the value is constant for the observation. If the angle varies for the observation, the min and max attributes are required in the label. Optional as a field in the data table.")
+		(type FLOAT)
 		(create-accessor read-write))
 	(multislot reference_relation_desc
 ;+		(comment "The reference relation desc attribute provides a short description of the relationship between two objects.")
@@ -4265,48 +4265,48 @@
 ;+		(comment "The validation_format attribute gives the magnitude and precision of the data value with the expectation that both will be validated exactly. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section \"Field Formats\" for details.")
 		(type STRING)
 		(create-accessor read-write))
+	(single-slot data_path
+;+		(comment "The relative path from the data brick mount point to the data directories. E.g. Data_Path = \"./\" indicates that the data directories are at the mount point of the disk brick. xxx ddwg;RS xxx")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot node_manager_pds_users_id
 ;+		(comment "The da_contact indicates the node person responsible for data administration.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot data_path
-;+		(comment "The relative path from the data brick mount point to the data directories. E.g. Data_Path = \"./\" indicates that the data directories are at the mount point of the disk brick. xxx ddwg;RS xxx")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot altitude
 ;+		(comment "The altitude attribute provides the height of anything above a given reference plane.")
 		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot note
-;+		(comment "The note attribute provides an explanatory or critical comment.")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot field_bytes
 ;+		(comment "The field bytes attribute provides the maximum number of bytes allowed for a field.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot note
+;+		(comment "The note attribute provides an explanatory or critical comment.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot apostrophe
 ;+		(comment "apostrophe = \"'\" ; (* apostrophe *)")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot personnel_reference
-;+		(comment "The personnel reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier")
+	(multislot maximum_sampling_parameter
+;+		(comment "The maximum_sampling_parameter element identifies the maximum value at which a given data item was sampled. For example, a spectrum that was measured in the 0.4 to 3.5 micrometer spectral region would have a maximum_sampling_parameter value of 3.5. The sampling parameter constrained by this value is identified by the sampling_parameter_name element. Note: The unit of measure for the sampling parameter is provided by the unit element.")
+		(type FLOAT)
 		(create-accessor read-write))
 	(multislot target_name
 ;+		(comment "The target_name attribute provides a name by which the target is formally known.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot maximum_sampling_parameter
-;+		(comment "The maximum_sampling_parameter element identifies the maximum value at which a given data item was sampled. For example, a spectrum that was measured in the 0.4 to 3.5 micrometer spectral region would have a maximum_sampling_parameter value of 3.5. The sampling parameter constrained by this value is identified by the sampling_parameter_name element. Note: The unit of measure for the sampling parameter is provided by the unit element.")
-		(type FLOAT)
+	(multislot personnel_reference
+;+		(comment "The personnel reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier")
 		(create-accessor read-write))
 	(multislot maximum_observed_event_time
 ;+		(comment "maximum_observed_event_time gives the largest value for observed_event_time in the associated data file. It is given in numeric seconds as an offset from the specified UTC reference time. maximum_observed_event_time is optional in labels since the data file time interval end point values are given by the required start_date_time_utc and stop_date_time_utc attributes in the Time_Coordinates class.")
@@ -4350,13 +4350,13 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot observed_event_stop_tdb
-;+		(comment "observed_event_stop_tdb indicates the value for latest time in the described data, and is given in elapsed seconds since the J2000 epoch. Optional in labels; not intended for use as a table field.")
-		(type FLOAT)
-		(create-accessor read-write))
 	(multislot target_puid
 ;+		(comment "The target_puid attribute provides a globally unique identifer for a target.")
 		(type STRING)
+		(create-accessor read-write))
+	(multislot observed_event_stop_tdb
+;+		(comment "observed_event_stop_tdb indicates the value for latest time in the described data, and is given in elapsed seconds since the J2000 epoch. Optional in labels; not intended for use as a table field.")
+		(type FLOAT)
 		(create-accessor read-write))
 	(single-slot center_wavelength
 ;+		(comment "The center_wavelength attribute provides the wavelength or frequency describing the center of a bin along the band axis of a spectral qube. When describing data from a spectrometer, the value corresponds to the peak of the response function for a particular detector and%2For grating position.")
@@ -4377,13 +4377,13 @@
 	(multislot specMesg
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot mission_logical_identifier
-;+		(comment "The mission logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
+	(single-slot map_projection_type
+;+		(comment "This attribute is used in the image map projection. Under review.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot map_projection_type
-;+		(comment "This attribute is used in the image map projection. Under review.")
+	(single-slot mission_logical_identifier
+;+		(comment "The mission logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -4454,25 +4454,25 @@
 		(type INSTANCE)
 ;+		(allowed-classes Entity)
 		(create-accessor read-write))
-	(single-slot stop_bit
-;+		(comment "The stop-bit attribute provides the location of the last bit in this bit field relative to the first bit in the packed_data field.  Bits are numbered continuously across byte boundaries.  The first bit location in the packed data field is \"1\".")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot has_Table_Binary_Field_Sequence
 ;+		(comment "The has_Table_Binary_Field_Sequence association is a relationship to field sequence.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot file_name_delimiter
-;+		(comment "The file name delimiter separates the file name from the file extension.")
-		(type STRING)
-		(default "<period>")
+	(single-slot stop_bit
+;+		(comment "The stop-bit attribute provides the location of the last bit in this bit field relative to the first bit in the packed_data field.  Bits are numbered continuously across byte boundaries.  The first bit location in the packed data field is \"1\".")
+		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot letter
 ;+		(comment "letter = \"a\" | \"b\" | \"c\" | \"d\" | \"e\" | \"f\" | \"g\" | \"h\" | \"i\" | \"j\" | \"k\" | \"l\" | \"m\" | \"n\" | \"o\" | \"p\" | \"q\" | \"r\" | \"s\" | \"t\" | \"u\" | \"v\" | \"w\" | \"x\" | \"y\" | \"z\" | \"A\" | \"B\" | \"C\" | \"D\" | \"E\" | \"F\" | \"G\" | \"H\" | \"I\" | \"J\" | \"K\" | \"L\" | \"M\" | \"N\" | \"O\" | \"P\" | \"Q\" | \"R\" | \"S\" | \"T\" | \"U\" | \"V\" | \"W\" | \"X\" | \"Y\" | \"Z\" ;")
 		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot file_name_delimiter
+;+		(comment "The file name delimiter separates the file name from the file extension.")
+		(type STRING)
+		(default "<period>")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot password
@@ -4489,15 +4489,15 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot value_begin_date
-;+		(comment "The value_begin_date attribute provides the first date on which the permissible value is in effect.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot has_Property_Maps
 ;+		(comment "The has_Property_Maps association is a relationship to a Property Maps class")
 		(type INSTANCE)
 ;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot value_begin_date
+;+		(comment "The value_begin_date attribute provides the first date on which the permissible value is in effect.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot ring_occultation_direction
 ;+		(comment "ring_occultation_direction indicates the radial direction of an occultation track. This refers to the observed occultation track overall, not to the subset that might appear in a particular file. Permitted values are 'Ingress', 'Egress', 'Both', and 'Multiple'. The value 'multiple' is only used for some Hubble-based occultations where the occultation track is not monotonic over relatively short time scales. Required in labels of ring occultation observations. Nillable if the observation is not a ring occultation in which case the nil_reason should be 'inapplicable'. Not intended as a value for a table field. ")
@@ -4521,29 +4521,29 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot has_occultation_supplement
-;+		(comment "The has_occultation_supplement association is a relationship to occultation_supplement")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
 	(single-slot language
 ;+		(comment "The language attribute provides the language used for definition and designation of the term.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_occultation_supplement
+;+		(comment "The has_occultation_supplement association is a relationship to occultation_supplement")
+		(type INSTANCE)
+;+		(allowed-classes)
 		(create-accessor read-write))
 	(single-slot sip_manifest_path
 ;+		(comment "The relative path from the data brick mount point to and including the SIP manifiest directory. E.g. SIP_Manifest_Path = “./SIP_Manifest/” - indicates that the SIP_Manifest directory is at the mount point of the disk brick.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot block_bytes
-;+		(comment "This attribute is used by the volume class. It is under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot mean
 ;+		(comment "The mean attribute provides the sum of the values divided by the number of values (empty or Special_Constants values are excluded).")
 		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot block_bytes
+;+		(comment "This attribute is used by the volume class. It is under review.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot white_space
@@ -4578,15 +4578,15 @@
 ;+		(comment "The axis_unit attribute is the units of each axis (the units associated with axis_name) (e.g., pixels, seconds, degrees, etc.).")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot maximum_light_source_incidence_angle
-;+		(comment "maximum_light_source_incidence_angle specifes the largest value for observed_ring_elevation in the observation. Only used if the value is not constant over the observation. Values range from 0 to %2B90 in units of degrees. Not intended for use in the data file.")
-		(type FLOAT)
-		(create-accessor read-write))
 	(single-slot has_color_display_settings
 ;+		(comment "The has_color_display_settings association is a relationship to Color_Display_Settings.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot maximum_light_source_incidence_angle
+;+		(comment "maximum_light_source_incidence_angle specifes the largest value for observed_ring_elevation in the observation. Only used if the value is not constant over the observation. Values range from 0 to %2B90 in units of degrees. Not intended for use in the data file.")
+		(type FLOAT)
 		(create-accessor read-write))
 	(single-slot earth_received_stop_time
 ;+		(comment "The earth_received_stop_time attribute gives the ending time at which a signal (such a telemetry) was received on Earth")
@@ -5379,17 +5379,17 @@
 ;+		(value "Product_Attribute_Definition" "Product_Browse" "Product_Bundle" "Product_Context" "Product_Collection" "Product_Document" "Product_File_Repository" "Product_File_Text" "Product_Observational" "Product_Service" "Product_Software" "Product_SPICE_Kernel" "Product_Thumbnail" "Product_Update" "Product_XML_Schema" "Product_Zipped" "Product_Data_Set_PDS3" "Product_Instrument_Host_PDS3" "Product_Instrument_PDS3" "Product_Mission_PDS3" "Product_Proxy_PDS3" "Product_Subscription_PDS3" "Product_Target_PDS3" "Product_Volume_PDS3" "Product_Volume_Set_PDS3" "Product_AIP" "Product_DIP" "Product_DIP_Deep_Archive" "Product_SIP" "Product_Class_Definition" "Product_Native" "Product_SIP_Deep_Archive" "Product_Ancillary" "Product_Metadata_Supplemental")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot information_model_version
-;+		(comment "The information_model_version attribute provides the  version identification of the PDS Information Model on which the label and schema are based.")
-		(type STRING)
-;+		(value "1.4.0.0" "1.0.0.0" "1.1.0.0" "1.2.0.0" "1.2.0.1" "1.3.0.0" "1.3.0.1" "1.5.0.0" "1.6.0.0" "1.7.0.0" "1.8.0.0" "1.9.0.0" "1.9.1.0" "1.10.0.0" "1.10.1.0" "1.11.0.0" "1.12.0.0" "1.13.0.0" "1.14.0.0" "1.15.0.0" "1.16.0.0" "1.17.0.0" "1.18.0.0")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot citation_information
 ;+		(comment "The citation_information is a relationship to Citation_Information, fields often used in citing the product.")
 		(type INSTANCE)
 ;+		(allowed-classes Citation_Information)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot information_model_version
+;+		(comment "The information_model_version attribute provides the  version identification of the PDS Information Model on which the label and schema are based.")
+		(type STRING)
+;+		(value "1.4.0.0" "1.0.0.0" "1.1.0.0" "1.2.0.0" "1.2.0.1" "1.3.0.0" "1.3.0.1" "1.5.0.0" "1.6.0.0" "1.7.0.0" "1.8.0.0" "1.9.0.0" "1.9.1.0" "1.10.0.0" "1.10.1.0" "1.11.0.0" "1.12.0.0" "1.13.0.0" "1.14.0.0" "1.15.0.0" "1.16.0.0" "1.17.0.0" "1.18.0.0")
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Context_Area "The Context Area provides context information for a product."
@@ -5400,27 +5400,16 @@
 		(type INSTANCE)
 ;+		(allowed-classes Investigation_Area)
 		(create-accessor read-write))
-	(single-slot has_primary_result_description
-;+		(comment "The has_primary_result_description association is a relationship to Primary_Result_Description.")
-		(type INSTANCE)
-;+		(allowed-classes Primary_Result_Summary)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot comment
 ;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot has_mission_area
-;+		(comment "The has_mission_area association is a relationship to Mission Area.")
+	(single-slot has_primary_result_description
+;+		(comment "The has_primary_result_description association is a relationship to Primary_Result_Description.")
 		(type INSTANCE)
-;+		(allowed-classes Mission_Area)
+;+		(allowed-classes Primary_Result_Summary)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_observing_system
-;+		(comment "The has_observing_system association is a relationship to Observing_System.")
-		(type INSTANCE)
-;+		(allowed-classes Observing_System)
 		(create-accessor read-write))
 	(single-slot has_time_coordinates
 ;+		(comment "The has_time_coordinates association is a relationship to Time_Coordinates.")
@@ -5428,16 +5417,27 @@
 ;+		(allowed-classes Time_Coordinates)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot has_discipline_area
-;+		(comment "The has_discipline_area association is a relationship to Discipline Area.")
+	(multislot has_observing_system
+;+		(comment "The has_observing_system association is a relationship to Observing_System.")
 		(type INSTANCE)
-;+		(allowed-classes Discipline_Area)
+;+		(allowed-classes Observing_System)
+		(create-accessor read-write))
+	(single-slot has_mission_area
+;+		(comment "The has_mission_area association is a relationship to Mission Area.")
+		(type INSTANCE)
+;+		(allowed-classes Mission_Area)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot has_target_identification
 ;+		(comment "The has_target_identification association is a relationship to Target_Identification.")
 		(type INSTANCE)
 ;+		(allowed-classes Target_Identification)
+		(create-accessor read-write))
+	(single-slot has_discipline_area
+;+		(comment "The has_discipline_area association is a relationship to Discipline Area.")
+		(type INSTANCE)
+;+		(allowed-classes Discipline_Area)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Observation_Area "The observation area consists of attributes that provide information about the circumstances under which the data were collected."
@@ -5449,17 +5449,17 @@
 ;+		(allowed-classes Investigation_Area)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(multislot has_observing_system
-;+		(comment "The has_observing_system association is a relationship to Observing_System.")
-		(type INSTANCE)
-;+		(allowed-classes Observing_System)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(single-slot has_time_coordinates
 ;+		(comment "The has_time_coordinates association is a relationship to Time_Coordinates.")
 		(type INSTANCE)
 ;+		(allowed-classes Time_Coordinates)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_observing_system
+;+		(comment "The has_observing_system association is a relationship to Observing_System.")
+		(type INSTANCE)
+;+		(allowed-classes Observing_System)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
 	(multislot has_target_identification
 ;+		(comment "The has_target_identification association is a relationship to Target_Identification.")
@@ -5490,13 +5490,13 @@
 ;+		(allowed-classes Internal_Reference)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot date_time
-;+		(comment "The date_time attribute provides the date and time of an event.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot date_time
+;+		(comment "The date_time attribute provides the date and time of an event.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -5625,23 +5625,23 @@
 (defclass Time_Coordinates "The Time_Coordinates class provides a list of time coordinates."
 	(is-a Product_Components)
 	(role concrete)
-	(single-slot start_date_time
-;+		(comment "The start_date_time attribute provides the date and time appropriate to the beginning of the product being labeled.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot stop_date_time
 ;+		(comment "The stop_date_time attribute provides the date and time appropriate to the end of the product being labeled.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot solar_longitude
-;+		(comment "The solar_longitude attribute provides the angle between the body-Sun line at the time of interest and the body-Sun line at its vernal equinox.")
+	(single-slot start_date_time
+;+		(comment "The start_date_time attribute provides the date and time appropriate to the beginning of the product being labeled.")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot local_mean_solar_time
 ;+		(comment "The local_mean_solar_time attribute provides the hour angle of the fictitious mean Sun at a fixed point on a rotating solar system body.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot solar_longitude
+;+		(comment "The solar_longitude attribute provides the angle between the body-Sun line at the time of interest and the body-Sun line at its vernal equinox.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -5659,17 +5659,17 @@
 		(type STRING)
 ;+		(value "Gamma Ray" "X-Ray" "Ultraviolet" "Visible" "Infrared" "Near Infrared" "Far Infrared" "Microwave" "Sub-Millimeter" "Millimeter" "Radio" "Magnetic Field" "Electric Field" "Ions" "Electrons" "Particles" "Dust" "Temperature" "Pressure")
 		(create-accessor read-write))
-	(single-slot type
-;+		(comment "The type attribute provides a classification for the resource.")
-		(type STRING)
-;+		(value "Astrometry" "E/B-Field Vectors" "Count" "Gravity Model" "Image" "Map" "Null Result" "Photometry" "Polarimetry" "Radiometry" "Shape Model" "Spectrum" "Altimetry" "Occultation" "Physical Parameters" "Lightcurves" "Reference" "Meteorology")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot processing_level
 ;+		(comment "The processing_level attribute provides a broad classification of data processing level.")
 		(type STRING)
 ;+		(value "Raw" "Calibrated" "Partially Processed" "Derived" "Telemetry")
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot type
+;+		(comment "The type attribute provides a classification for the resource.")
+		(type STRING)
+;+		(value "Astrometry" "E/B-Field Vectors" "Count" "Gravity Model" "Image" "Map" "Null Result" "Photometry" "Polarimetry" "Radiometry" "Shape Model" "Spectrum" "Altimetry" "Occultation" "Physical Parameters" "Lightcurves" "Reference" "Meteorology")
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot purpose
 ;+		(comment "The purpose attribute provides an indication of the primary purpose of the observations included.")
@@ -5677,16 +5677,16 @@
 ;+		(value "Science" "Navigation" "Calibration" "Checkout" "Engineering" "Observation Geometry" "Supporting Observation")
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(multislot has_Science_Facet
-;+		(comment "The has_Science_Facet association is a relationship Science_Facet.")
-		(type INSTANCE)
-;+		(allowed-classes Science_Facets)
-		(create-accessor read-write))
 	(single-slot processing_level_id
 ;+		(comment "The processing_level_id attribute provides a broad indication of data processing level.")
 		(type STRING)
 ;+		(value "Raw" "Calibrated" "Partially Processed" "Derived" "Telemetry")
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_Science_Facet
+;+		(comment "The has_Science_Facet association is a relationship Science_Facet.")
+		(type INSTANCE)
+;+		(allowed-classes Science_Facets)
 		(create-accessor read-write))
 	(single-slot description
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
@@ -5742,14 +5742,14 @@
 (defclass Internal_Reference "The Internal_Reference class is used to cross-reference other products in PDS4-compliant registries of PDS and its recognized international partners."
 	(is-a Product_Components)
 	(role concrete)
-	(single-slot lid_reference
-;+		(comment "The lid_reference attribute provides the logical_identifier for a  product.")
+	(single-slot lidvid_reference
+;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
 		(type STRING)
 		(default "XSChoice#1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot lidvid_reference
-;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
+	(single-slot lid_reference
+;+		(comment "The lid_reference attribute provides the logical_identifier for a  product.")
 		(type STRING)
 		(default "XSChoice#1")
 ;+		(cardinality 1 1)
@@ -5773,15 +5773,15 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot reference_text
 ;+		(comment "The reference_text attribute provides a complete bibliographic citation for a published work.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass External_Reference_Extended "The External_Reference_Extended class is used to reference a source outside the PDS registry system. This extension is used in the local data dictionary."
@@ -5801,14 +5801,14 @@
 (defclass Bundle_Member_Entry "The Bundle Member Entry class provides a member reference to a collection."
 	(is-a Product_Components)
 	(role concrete)
-	(single-slot lid_reference
-;+		(comment "The lid_reference attribute provides the logical_identifier for a  product.")
+	(single-slot lidvid_reference
+;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
 		(type STRING)
 		(default "XSChoice#1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot lidvid_reference
-;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
+	(single-slot lid_reference
+;+		(comment "The lid_reference attribute provides the logical_identifier for a  product.")
 		(type STRING)
 		(default "XSChoice#1")
 ;+		(cardinality 1 1)
@@ -6282,13 +6282,13 @@
 (defclass Table_Base "The Table Base class defines a heterogeneous repeating record of scalars. The Table Base class is the parent class for all heterogeneous repeating record of scalars."
 	(is-a Byte_Stream)
 	(role abstract)
-	(single-slot offset
-;+		(comment "The offset attribute provides the displacement of the object starting position from the beginning of the parent structure (file, record, etc.).  If there is no displacement, offset=0.")
+	(single-slot records
+;+		(comment "The records attribute provides a count of records.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot records
-;+		(comment "The records attribute provides a count of records.")
+	(single-slot offset
+;+		(comment "The offset attribute provides the displacement of the object starting position from the beginning of the parent structure (file, record, etc.).  If there is no displacement, offset=0.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -6370,14 +6370,14 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot object_length
 ;+		(comment "The object_length attribute provides the length of the digital object in bytes.")
 		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
@@ -6460,14 +6460,14 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot object_length
 ;+		(comment "The object_length attribute provides the length of the digital object in bytes.")
 		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
@@ -6485,16 +6485,16 @@
 ;+		(allowed-classes Uniformly_Sampled)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot has_delimited_record
-;+		(comment "The has_delimited_record association is a relationship to record.")
-		(type INSTANCE)
-;+		(allowed-classes Record_Delimited)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot record_delimiter
 ;+		(comment "The record_delimiter attribute provides the character or characters used to indicate the end of a record.")
 		(type STRING)
 ;+		(value "Carriage-Return Line-Feed" "carriage-return line-feed" "Line-Feed")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot has_delimited_record
+;+		(comment "The has_delimited_record association is a relationship to record.")
+		(type INSTANCE)
+;+		(allowed-classes Record_Delimited)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot parsing_standard_id
@@ -6671,17 +6671,17 @@
 ;+		(allowed-classes Digital_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot has_Element_Array
-;+		(comment "The has_Element_Array association is a relationship to Element_Array")
-		(type INSTANCE)
-;+		(allowed-classes Element_Array)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot local_internal_reference
 ;+		(comment "The local_internal_reference association is a relationship to the class Local_Internal_Reference.")
 		(type INSTANCE)
 ;+		(allowed-classes Local_Internal_Reference)
 ;+		(cardinality 0 0)
+		(create-accessor read-write))
+	(single-slot has_Element_Array
+;+		(comment "The has_Element_Array association is a relationship to Element_Array")
+		(type INSTANCE)
+;+		(allowed-classes Element_Array)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot associated_Special_Constants
 ;+		(comment "The associated_Special_Constants association is a relationship to special constants.")
@@ -6694,17 +6694,17 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Axis_Array
-;+		(comment "The has_Axis_Array association is a relationship to Axis_Array.")
-		(type INSTANCE)
-;+		(allowed-classes Axis_Array)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(single-slot axis_index_order
 ;+		(comment "The axis_index_order attribute provides the axis index that varies fastest with respect to storage order.")
 		(type STRING)
 ;+		(value "Last Index Fastest")
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Axis_Array
+;+		(comment "The has_Axis_Array association is a relationship to Axis_Array.")
+		(type INSTANCE)
+;+		(allowed-classes Axis_Array)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
 (defclass Array_2D "The Array 2D class is the parent class for all two dimensional array based classes."
@@ -6812,14 +6812,14 @@
 (defclass File "The File class consists of attributes that describe a file in a data store."
 	(is-a Tagged_Digital_Object)
 	(role concrete)
-	(single-slot md5_checksum
-;+		(comment "The md5_checksum attribute is the 32-character hexadecimal number computed using the MD5 algorithm for the contiguous bytes of single digital object (as stored) or for an entire file.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot records
 ;+		(comment "The records attribute provides a count of records.")
 		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot md5_checksum
+;+		(comment "The md5_checksum attribute is the 32-character hexadecimal number computed using the MD5 algorithm for the contiguous bytes of single digital object (as stored) or for an entire file.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot local_identifier
@@ -6875,13 +6875,13 @@
 (defclass Composite_Structure "The Composite Structure class provides a general framework for defining a structure that consists of two or more simpler structures"
 	(is-a Tagged_Digital_Object)
 	(role concrete)
-	(single-slot type_description
-;+		(comment "The type_description attribute provides a description of the object's type.")
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+	(single-slot type_description
+;+		(comment "The type_description attribute provides a description of the object's type.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -6920,13 +6920,13 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot elements
-;+		(comment "The elements attribute provides the count of the number of elements along an array axis.")
+	(single-slot sequence_number
+;+		(comment "The sequence_number attribute provides a number that is used to order axes in an array.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot sequence_number
-;+		(comment "The sequence_number attribute provides a number that is used to order axes in an array.")
+	(single-slot elements
+;+		(comment "The elements attribute provides the count of the number of elements along an array axis.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -6975,13 +6975,13 @@
 (defclass Special_Constants "The Special Constants class provides a set of values used to indicate special cases that occur in the data."
 	(is-a Tagged_Digital_Child)
 	(role concrete)
-	(single-slot error_constant
-;+		(comment "The error_constant attribute provides a value that indicates the original value was in error.")
+	(single-slot missing_constant
+;+		(comment "The missing_constant attribute provides a value that indicates the original value was missing, such as due to a gap in coverage.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot missing_constant
-;+		(comment "The missing_constant attribute provides a value that indicates the original value was missing, such as due to a gap in coverage.")
+	(single-slot error_constant
+;+		(comment "The error_constant attribute provides a value that indicates the original value was in error.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7070,14 +7070,14 @@
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot last_sampling_parameter_value
-;+		(comment "The last_sampling_parameter_value element provides the last value in an ascending series and is therefore the maximum value at which a given data item was sampled.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot sampling_parameter_name
 ;+		(comment "The sampling_parameter_name element provides the name of the parameter which determines the sampling interval of a particular instrument or dataset parameter. For example, magnetic field intensity is sampled in time increments, and a spectrum is sampled in wavelength or frequency.")
 		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot last_sampling_parameter_value
+;+		(comment "The last_sampling_parameter_value element provides the last value in an ascending series and is therefore the maximum value at which a given data item was sampled.")
+		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -7130,14 +7130,8 @@
 ;+		(value "SignedLSB2" "SignedLSB4" "SignedLSB8" "SignedMSB2" "SignedMSB4" "SignedMSB8" "UnsignedByte" "UnsignedLSB2" "UnsignedLSB4" "UnsignedMSB2" "UnsignedMSB4" "IEEE754MSBDouble" "IEEE754MSBSingle" "ASCII_File_Name" "ASCII_Boolean" "ASCII_Date_YMD" "ASCII_Integer" "ASCII_Real" "ASCII_AnyURI" "ASCII_Date_DOY" "ASCII_Date_Time_DOY_UTC" "ASCII_Date_Time_YMD_UTC" "ASCII_LID" "ASCII_LIDVID" "ASCII_MD5_Checksum" "ASCII_Time" "ASCII_VID" "ASCII_DOI" "ASCII_Numeric_Base2" "ASCII_Numeric_Base16" "ASCII_NonNegative_Integer" "ASCII_File_Specification_Name" "UnsignedLSB8" "UnsignedMSB8" "IEEE754LSBDouble" "IEEE754LSBSingle" "SignedByte" "UTF8_String" "ASCII_String" "SignedBitString" "UnsignedBitString" "ComplexLSB16" "ComplexLSB8" "ComplexMSB16" "ASCII_Directory_Path_Name" "ASCII_LIDVID_LID" "ASCII_Numeric_Base8" "ComplexMSB8" "ASCII_Date_Time_DOY" "ASCII_Date_Time_YMD" "ASCII_BibCode")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot has_Packed_Data_Fields
-;+		(comment "The has_Packed_Data_Fields association is a relationship to  Packed_Data_Fields.")
-		(type INSTANCE)
-;+		(allowed-classes Packed_Data_Fields)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot field_format
-;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
+	(single-slot unit
+;+		(comment "The unit attribute provides the unit of measurement.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7147,9 +7141,15 @@
 ;+		(allowed-classes Special_Constants)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot unit
-;+		(comment "The unit attribute provides the unit of measurement.")
+	(single-slot field_format
+;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
 		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot has_Packed_Data_Fields
+;+		(comment "The has_Packed_Data_Fields association is a relationship to  Packed_Data_Fields.")
+		(type INSTANCE)
+;+		(allowed-classes Packed_Data_Fields)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot name_
@@ -7198,8 +7198,8 @@
 ;+		(value "ASCII_Boolean" "ASCII_Date_YMD" "ASCII_Integer" "ASCII_Real" "ASCII_AnyURI" "ASCII_Date_DOY" "ASCII_Date_Time_DOY_UTC" "ASCII_Date_Time_YMD_UTC" "ASCII_LID" "ASCII_LIDVID" "ASCII_MD5_Checksum" "ASCII_Time" "ASCII_VID" "ASCII_DOI" "ASCII_Numeric_Base2" "ASCII_Numeric_Base16" "ASCII_NonNegative_Integer" "ASCII_File_Specification_Name" "ASCII_File_Name" "UTF8_String" "ASCII_String" "ASCII_Directory_Path_Name" "ASCII_LIDVID_LID" "ASCII_Numeric_Base8" "ASCII_Date_Time_DOY" "ASCII_Date_Time_YMD" "ASCII_BibCode")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot field_format
-;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
+	(single-slot unit
+;+		(comment "The unit attribute provides the unit of measurement.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7209,8 +7209,8 @@
 ;+		(allowed-classes Special_Constants)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot unit
-;+		(comment "The unit attribute provides the unit of measurement.")
+	(single-slot field_format
+;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7219,15 +7219,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot validation_format
-;+		(comment "The validation_format attribute gives the magnitude and precision of the data value with the expectation that both will be validated exactly. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section \"Field Formats\" for details.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot field_location
 ;+		(comment "The field_location attribute provides the starting byte for a field within a record or group, counting from '1'.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot validation_format
+;+		(comment "The validation_format attribute gives the magnitude and precision of the data value with the expectation that both will be validated exactly. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section \"Field Formats\" for details.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot scaling_factor
 ;+		(comment "The scaling_factor attribute is the scaling factor to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 1.")
@@ -7270,8 +7270,8 @@
 ;+		(value "ASCII_Boolean" "ASCII_Date_YMD" "ASCII_Integer" "ASCII_Real" "ASCII_AnyURI" "ASCII_Date_DOY" "ASCII_Date_Time_DOY_UTC" "ASCII_Date_Time_YMD_UTC" "ASCII_LID" "ASCII_LIDVID" "ASCII_MD5_Checksum" "ASCII_Time" "ASCII_VID" "ASCII_DOI" "ASCII_Numeric_Base2" "ASCII_Numeric_Base16" "ASCII_NonNegative_Integer" "ASCII_File_Specification_Name" "ASCII_File_Name" "UTF8_String" "ASCII_String" "ASCII_Directory_Path_Name" "ASCII_LIDVID_LID" "ASCII_Numeric_Base8" "ASCII_Date_Time_DOY" "ASCII_Date_Time_YMD" "ASCII_BibCode")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot field_format
-;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
+	(single-slot unit
+;+		(comment "The unit attribute provides the unit of measurement.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7281,8 +7281,8 @@
 ;+		(allowed-classes Special_Constants)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot unit
-;+		(comment "The unit attribute provides the unit of measurement.")
+	(single-slot field_format
+;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7325,19 +7325,19 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot start_bit
-;+		(comment "The start_bit attribute provides the position of the first bit within an ordered sequence of bits.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot data_type
 ;+		(comment "The data_type attribute provides the hardware representation used to store a value in Field_Bit (see PDS Standards Reference section \"Binary Data Types\").")
 		(type STRING)
 ;+		(value "UnsignedBitString" "SignedBitString")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot field_format
-;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
+	(single-slot start_bit
+;+		(comment "The start_bit attribute provides the position of the first bit within an ordered sequence of bits.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot unit
+;+		(comment "The unit attribute provides the unit of measurement.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7347,8 +7347,8 @@
 ;+		(allowed-classes Special_Constants)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot unit
-;+		(comment "The unit attribute provides the unit of measurement.")
+	(single-slot field_format
+;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7440,24 +7440,24 @@
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot repetitions
-;+		(comment "The repetitions attribute provides the number of times a set of repeating fields and, possibly, (sub)groups is replicated within a group.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot groups
 ;+		(comment "The groups attribute provides a count of the number of (sub)groups within the repeating structure of a group.  (Subsub)groups within (sub)groups within the group are not included in this count.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 0 1)
+	(single-slot repetitions
+;+		(comment "The repetitions attribute provides the number of times a set of repeating fields and, possibly, (sub)groups is replicated within a group.")
+		(type INTEGER)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot group_number
 ;+		(comment "The group_number attribute provides the position of a group, within a series of groups, counting from 1.  If two groups within a record are physically separated by one or more fields, they have consecutive group numbers; the intervening fields are numbered separately.  Groups within a parent group, but separated by one or more fields, will also have consecutive group numbers.")
 		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot description
@@ -7603,15 +7603,15 @@
 (defclass Investigation "A set of experiments and/or observations with a clearly defined purpose."
 	(is-a TNDO_Context)
 	(role concrete)
+	(single-slot stop_date
+;+		(comment "The stop_date attribute provides the date when an activity ended.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
 ;+		(allowed-classes Conceptual_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot stop_date
-;+		(comment "The stop_date attribute provides the date when an activity ended.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot type
@@ -7682,23 +7682,23 @@
 ;+		(value "Earth Based" "Rover" "Spacecraft" "Lander" "Earth-based" "Aircraft" "Balloon" "Suborbital Rocket")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot serial_number
-;+		(comment "The serial number attribute provides the manufacturer's serial number assigned to an instrument host.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot name_
 ;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot naif_host_id
-;+		(comment "The naif_host_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
+	(single-slot serial_number
+;+		(comment "The serial number attribute provides the manufacturer's serial number assigned to an instrument host.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot version_id
 ;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot naif_host_id
+;+		(comment "The naif_host_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7716,25 +7716,20 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot data_object
-;+		(comment "The data_object association is a relationship to Data Object.")
-		(type INSTANCE)
-;+		(allowed-classes Physical_Object)
-;+		(cardinality 1 1)
+	(multislot subtype
+;+		(comment "The subtype attribute is a special type included within the general type. It provides more specific clarifying and/or supplemental information as to the nature of the type.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot model_id
 ;+		(comment "The model_id attribute helps discriminate instrument hardware. For example \"flight\", \"engineering\", or \"proto\" have been used.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot subtype
-;+		(comment "The subtype attribute is a special type included within the general type. It provides more specific clarifying and/or supplemental information as to the nature of the type.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot type
-;+		(comment "The type attribute classifies the instrument according to its function.")
-		(type STRING)
-;+		(value "Accelerometer" "Altimeter" "Camera" "Cosmic Ray Detector" "Dust Detector" "Imaging Spectrometer" "Magnetometer" "Photometer" "Plasma Analyzer" "Radio Science" "Radio Spectrometer" "Radio Telescope" "Radiometer" "Reflectometer" "Spectrometer" "Spectrograph Imager" "Alpha Particle Detector" "Biology Experiments" "Bolometer" "Imager" "Energetic Particle Detector" "Gamma Ray Detector" "Gas Analyzer" "Grinding Tool" "Inertial Measurement Unit	" "Infrared Spectrometer" "Laser Induced Breakdown Spectrometer" "Mass Spectrometer" "Microwave Spectrometer" "Naked Eye" "Neutral Particle Detector" "Neutron Detector" "Plasma Detector" "Plasma Wave Spectrometer" "Polarimeter" "Radar" "Thermal Imager" "Ultraviolet Spectrometer" "Wet Chemistry Laboratory" "X-ray Diffraction Spectrometer" "X-ray Detector" "Atomic Force Microscope" "Alpha Particle X-Ray Spectrometer" "Moessbauer Spectrometer" "Thermal Probe" "Electrical Probe" "X-ray Fluorescence Spectrometer" "Anemometer" "Barometer" "Thermometer" "Hygrometer" "Robotic Arm" "Drilling Tool" "Weather Station" "Atmospheric Sciences" "Dust" "Gravimeter" "Interferometer" "Microscope" "Particle Detector" "Radio-Radar" "Small Bodies Sciences" "Seismometer" "Regolith Properties" "Spectrograph")
+	(single-slot data_object
+;+		(comment "The data_object association is a relationship to Data Object.")
+		(type INSTANCE)
+;+		(allowed-classes Physical_Object)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot has_type_list_area
 ;+		(comment "The has_type_list_area association is a relationship to Type_List_Area.")
@@ -7742,13 +7737,18 @@
 ;+		(allowed-classes Type_List_Area)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot serial_number
-;+		(comment "The serial number element provides the assigned manufacturer's serial number.")
+	(multislot type
+;+		(comment "The type attribute classifies the instrument according to its function.")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(value "Accelerometer" "Altimeter" "Camera" "Cosmic Ray Detector" "Dust Detector" "Imaging Spectrometer" "Magnetometer" "Photometer" "Plasma Analyzer" "Radio Science" "Radio Spectrometer" "Radio Telescope" "Radiometer" "Reflectometer" "Spectrometer" "Spectrograph Imager" "Alpha Particle Detector" "Biology Experiments" "Bolometer" "Imager" "Energetic Particle Detector" "Gamma Ray Detector" "Gas Analyzer" "Grinding Tool" "Inertial Measurement Unit	" "Infrared Spectrometer" "Laser Induced Breakdown Spectrometer" "Mass Spectrometer" "Microwave Spectrometer" "Naked Eye" "Neutral Particle Detector" "Neutron Detector" "Plasma Detector" "Plasma Wave Spectrometer" "Polarimeter" "Radar" "Thermal Imager" "Ultraviolet Spectrometer" "Wet Chemistry Laboratory" "X-ray Diffraction Spectrometer" "X-ray Detector" "Atomic Force Microscope" "Alpha Particle X-Ray Spectrometer" "Moessbauer Spectrometer" "Thermal Probe" "Electrical Probe" "X-ray Fluorescence Spectrometer" "Anemometer" "Barometer" "Thermometer" "Hygrometer" "Robotic Arm" "Drilling Tool" "Weather Station" "Atmospheric Sciences" "Dust" "Gravimeter" "Interferometer" "Microscope" "Particle Detector" "Radio-Radar" "Small Bodies Sciences" "Seismometer" "Regolith Properties" "Spectrograph")
 		(create-accessor read-write))
 	(single-slot name_
 ;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot serial_number
+;+		(comment "The serial number element provides the assigned manufacturer's serial number.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7851,14 +7851,14 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot electronic_mail_address
+;+		(comment "The electronic mail address attribute provides a multi-part email address: the first part (the user name), which identifies a unique user, is separated by an \"at sign\"  from the host name, which uniquely identifies the mail server.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot institution_name
 ;+		(comment "The institution_name attribute provides the name of the associated institution.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot electronic_mail_address
-;+		(comment "The electronic mail address attribute provides a multi-part email address: the first part (the user name), which identifies a unique user, is separated by an \"at sign\"  from the host name, which uniquely identifies the mail server.")
-		(type STRING)
 		(create-accessor read-write))
 	(single-slot telephone_number
 ;+		(comment "The telephone_number attribute provides a telephone number in  international notation in compliance with the E.164 telephone number format recommendation.")
@@ -7974,13 +7974,13 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot address
+;+		(comment "The address attribute provides a mailing address.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot address
-;+		(comment "The address attribute provides a mailing address.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -8004,29 +8004,29 @@
 ;+		(allowed-classes Physical_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot aperture
-;+		(comment "The aperture attribute provides a measure of the effective collecting area of the telescope -- its diameter (if single and circular) or its equivalent diameter (if non-circular and/or an array).  For purposes of this definition, aperture efficiency is assumed to be 100 percent.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot telescope_latitude
 ;+		(comment "The telescope_latitude attribute provides the angular distance of the telescope north (positive) from the equator, measured on the meridian of the telescope.")
 		(type FLOAT)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot aperture
+;+		(comment "The aperture attribute provides a measure of the effective collecting area of the telescope -- its diameter (if single and circular) or its equivalent diameter (if non-circular and/or an array).  For purposes of this definition, aperture efficiency is assumed to be 100 percent.")
+		(type FLOAT)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot telescope_longitude
 ;+		(comment "The telescope_longitude attribute provides the angular distance of the telescope east (positive), measured by the angle contained between the meridian of the telescope and the reference figure (or datum) prime meridian.")
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot altitude
 ;+		(comment "The altitude attribute provides the height of anything above a given reference plane.")
 		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
@@ -8048,13 +8048,13 @@
 ;+		(value "Tool" "Service")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot release_date
-;+		(comment "The release_date attribute provides the date that the product was released.")
+	(single-slot supported_operating_system_note
+;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot supported_operating_system_note
-;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
+	(single-slot release_date
+;+		(comment "The release_date attribute provides the date that the product was released.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -8074,16 +8074,16 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot system_requirements_note
+;+		(comment "The system requirements note attribute identifies what is necessary to process the software.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(multislot category
 ;+		(comment "The category attribute identifies the type of function that the tool or service performs.")
 		(type STRING)
 ;+		(value "Analysis" "Reader" "Design" "Dissemination" "Generation" "Planning" "Search" "Transformation" "Validation" "Visualization")
 		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot system_requirements_note
-;+		(comment "The system requirements note attribute identifies what is necessary to process the software.")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot version_id
 ;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
@@ -8150,13 +8150,13 @@
 (defclass Data_Set_PDS3 "The Data Set PDS3 class is used to capture the data set information from the PDS3 Data Set Catalog."
 	(is-a TNDO_Context_PDS3)
 	(role concrete)
-	(single-slot stop_date_time
-;+		(comment "The stop_date_time attribute provides the date and time at the end of the data set.")
+	(single-slot start_date_time
+;+		(comment "The start_date_time attribute provides the date and time at the beginning of the data set.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot start_date_time
-;+		(comment "The start_date_time attribute provides the date and time at the beginning of the data set.")
+	(single-slot stop_date_time
+;+		(comment "The stop_date_time attribute provides the date and time at the end of the data set.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -8165,15 +8165,15 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot nssdc
-;+		(comment "The nssdc association is a relationship to NSSDC.")
-		(type INSTANCE)
-;+		(allowed-classes NSSDC)
-		(create-accessor read-write))
 	(single-slot stop_time
 ;+		(comment "The stop_time element provides the date and time of the end of an observation or event (whether it be a spacecraft, ground-based, or system event) in UTC.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot nssdc
+;+		(comment "The nssdc association is a relationship to NSSDC.")
+		(type INSTANCE)
+;+		(allowed-classes NSSDC)
 		(create-accessor read-write))
 	(single-slot data_set_id
 ;+		(comment "The data set id provides a formal name used to refer to a data set.")
@@ -8217,13 +8217,13 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot confidence_level_note
-;+		(comment "The confidence_level_note attribute is a text field which characterizes the reliability of data within a data set or the reliability of a particular programming algorithm or software component. Essentially, this note discusses the level of confidence in the accuracy of the data or in the ability of the software to produce accurate results.")
+	(single-slot citation_text
+;+		(comment "The citation_text attribute provides a character string containing a literature or other citation in sufficient detail that the material  could be located in PDS or elsewhere.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot citation_text
-;+		(comment "The citation_text attribute provides a character string containing a literature or other citation in sufficient detail that the material  could be located in PDS or elsewhere.")
+	(single-slot confidence_level_note
+;+		(comment "The confidence_level_note attribute is a text field which characterizes the reliability of data within a data set or the reliability of a particular programming algorithm or software component. Essentially, this note discusses the level of confidence in the accuracy of the data or in the ability of the software to produce accurate results.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -8236,15 +8236,15 @@
 (defclass Mission_PDS3 "The Mission PDS3 class describes an activity involved in the collection of data. This class captures the PDS3 catalog Mission information."
 	(is-a TNDO_Context_PDS3)
 	(role concrete)
+	(single-slot mission_objectives_summary
+;+		(comment "The mission_objectives_summary attribute describes the major scientific objectives of a planetary mission or project.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
 ;+		(allowed-classes Conceptual_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot mission_objectives_summary
-;+		(comment "The mission_objectives_summary attribute describes the major scientific objectives of a planetary mission or project.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot mission_desc
@@ -8252,13 +8252,13 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot mission_name
-;+		(comment "The mission_name attribute identifies a major planetary mission or project. A given planetary mission may be associated with one or more spacecraft.")
+	(single-slot mission_start_date
+;+		(comment "The mission_start_date attribute provides the date of the beginning of a mission in UTC system format.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot mission_start_date
-;+		(comment "The mission_start_date attribute provides the date of the beginning of a mission in UTC system format.")
+	(single-slot mission_name
+;+		(comment "The mission_name attribute identifies a major planetary mission or project. A given planetary mission may be associated with one or more spacecraft.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -8316,15 +8316,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot instrument_host_id
+;+		(comment "The instrument_host_id attribute provides a unique identifier for the host on which an instrument is located. This host can be either a spacecraft or an earth base (e.g. earth).")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
 ;+		(allowed-classes Physical_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot instrument_host_id
-;+		(comment "The instrument_host_id attribute provides a unique identifier for the host on which an instrument is located. This host can be either a spacecraft or an earth base (e.g. earth).")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot instrument_host_desc
@@ -8346,15 +8346,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot rotation_direction
-;+		(comment "The rotation_direction element provides the direction of rotation as viewed from the north pole of the 'invariable plane of the solar system', which is the plane passing through the center of mass of the solar system and perpendicular to the angular momentum vector of the solar system. The value for this element is PROGRADE for counter -clockwise rotation, RETROGRADE for clockwise rotation and SYNCHRONOUS for satellites which are tidally locked with the primary. Sidereal_rotation_period and rotation_direction_type are unknown for a number of satellites, and are not applicable (N/A) for satellites which are tumbling.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot target_name
 ;+		(comment "The target_name attribute provides a name by which the target is formally known.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot rotation_direction
+;+		(comment "The rotation_direction element provides the direction of rotation as viewed from the north pole of the 'invariable plane of the solar system', which is the plane passing through the center of mass of the solar system and perpendicular to the angular momentum vector of the solar system. The value for this element is PROGRADE for counter -clockwise rotation, RETROGRADE for clockwise rotation and SYNCHRONOUS for satellites which are tidally locked with the primary. Sidereal_rotation_period and rotation_direction_type are unknown for a number of satellites, and are not applicable (N/A) for satellites which are tumbling.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
@@ -8396,22 +8396,17 @@
 ;+		(value "ARCHIVED" "IN_LIEN_RESOLUTION" "IN_PEER_REVIEW" "IN_QUEUE" "LOCALLY_ARCHIVED" "PRE_PEER_REVIEW" "SAFED" "SUPERSEDED" "IN_QUEUE_ACCUMULATING" "PRE_PEER_REVIEW_ACCUMULATING" "IN_PEER_REVIEW_ACCUMULATING" "IN_LIEN_RESOLUTION_ACCUMULATING" "LOCALLY_ARCHIVED_ACCUMULATING" "ARCHIVED_ACCUMULATING")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot curating_node_id
-;+		(comment "The curating_node_id attribute provides the id of the node currently maintaining the data set or volume and is responsible for maintaining catalog information.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot publication_date
 ;+		(comment "The publication_date attribute provides the date on which an item was published.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot curating_node_id
+;+		(comment "The curating_node_id attribute provides the id of the node currently maintaining the data set or volume and is responsible for maintaining catalog information.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot volume_version_id
 ;+		(comment "The volume_version_id attribute identifies the version of a data volume. All original volumes should use a volume_version_id of 'Version 1'.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot archive_status_note
-;+		(comment "The archive status note attribute provides a comment about the archive status.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -8421,13 +8416,13 @@
 ;+		(allowed-classes Conceptual_Object Physical_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot volume_id
-;+		(comment "The volume_id attribute provides a unique identifier for a data volume. Example: MG_1001.")
+	(single-slot archive_status_note
+;+		(comment "The archive status note attribute provides a comment about the archive status.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot volume_de_fullname
-;+		(comment "The volume_de_fullname attribute provide the full name of the data engineer.")
+	(single-slot volume_id
+;+		(comment "The volume_id attribute provides a unique identifier for a data volume. Example: MG_1001.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -8436,8 +8431,8 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot volume_size
-;+		(comment "The volume size attribute provide the number of bytes in the volume.")
+	(single-slot volume_de_fullname
+;+		(comment "The volume_de_fullname attribute provide the full name of the data engineer.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -8445,6 +8440,11 @@
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot volume_size
+;+		(comment "The volume size attribute provide the number of bytes in the volume.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot volume_name
 ;+		(comment "The volume_name attribute contains the name of a data volume.")
@@ -8471,13 +8471,13 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot volume_set_id
-;+		(comment "The volume_set_id attribute identifies a data volume or a set of volumes. Volume sets are normally considered as a single orderable entity. Examples: USA_NASA_PDS_MG_1001, USA_NASA_PDS_GR_0001_TO_GR_0009")
+	(single-slot volume_set_name
+;+		(comment "The volume_set_name element provides the full, formal name of one or more data volumes containing a single data set or a collection of related data sets. Volume sets are normally considered as a single orderable entity.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot volume_set_name
-;+		(comment "The volume_set_name element provides the full, formal name of one or more data volumes containing a single data set or a collection of related data sets. Volume sets are normally considered as a single orderable entity.")
+	(single-slot volume_set_id
+;+		(comment "The volume_set_id attribute identifies a data volume or a set of volumes. Volume sets are normally considered as a single orderable entity. Examples: USA_NASA_PDS_MG_1001, USA_NASA_PDS_GR_0001_TO_GR_0009")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -8543,8 +8543,8 @@
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot maximum_scaled_value
-;+		(comment "The maximum_scaled_value attribute provides the maximum value after application of scaling_factor and value_offset (see their definitions; maximum_scaled_value is the maximum of Ov).")
+	(single-slot standard_deviation
+;+		(comment "The standard_deviation attribute provides the standard deviation of the stored array element values after application of any bit mask (Special_Constants values are excluded from the computation).")
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -8553,8 +8553,8 @@
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot standard_deviation
-;+		(comment "The standard_deviation attribute provides the standard deviation of the stored array element values after application of any bit mask (Special_Constants values are excluded from the computation).")
+	(single-slot maximum_scaled_value
+;+		(comment "The maximum_scaled_value attribute provides the maximum value after application of scaling_factor and value_offset (see their definitions; maximum_scaled_value is the maximum of Ov).")
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -8660,27 +8660,27 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot vector_components
+;+		(comment "The vector_components attribute provides a count of vector components.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
 ;+		(allowed-classes Conceptual_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot vector_components
-;+		(comment "The vector_components attribute provides a count of vector components.")
-		(type INTEGER)
+	(single-slot data_type
+;+		(comment "The data_type attribute provides the hardware representation used to store a value in Vector (see PDS Standards Reference section \"Attribute Data Types\").")
+		(type STRING)
+;+		(value "ASCII_Real")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot type
 ;+		(comment "The type attribute classifies Vector according to the meaning of its contents.")
 		(type STRING)
 ;+		(value "Position" "Velocity" "Acceleration" "Pointing")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot data_type
-;+		(comment "The data_type attribute provides the hardware representation used to store a value in Vector (see PDS Standards Reference section \"Attribute Data Types\").")
-		(type STRING)
-;+		(value "ASCII_Real")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot name_
@@ -8746,30 +8746,30 @@
 (defclass DD_Attribute_Full "The DD_Attribute_Full class provides a more complete definition of an attribute in the data dictionary."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(multislot terminological_entry
-;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
-		(type INSTANCE)
-;+		(allowed-classes Terminological_Entry)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot submitter_name
-;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot value_domain_entry
 ;+		(comment "The value_domain_entry association is a relationship to Value_Domain.")
 		(type INSTANCE)
 ;+		(allowed-classes DD_Value_Domain_Full)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+	(single-slot submitter_name
+;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot terminological_entry
+;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
+		(type INSTANCE)
+;+		(allowed-classes Terminological_Entry)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
 	(single-slot registered_by
 ;+		(comment "The registered_by attribute provides the name of the person or organization that registered the object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -8960,13 +8960,13 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot programmers_manual_id
+;+		(comment "The programmers manual id attribute provides an identifier to a document giving instruction about the programming of the software.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot programmers_manual_id
-;+		(comment "The programmers manual id attribute provides an identifier to a document giving instruction about the programming of the software.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -9031,13 +9031,13 @@
 ;+		(allowed-classes Document_Edition)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot copyright
+;+		(comment "The copyright attribute is a character string giving  information about the exclusive right to make copies, license, and otherwise exploit an object, whether physical or digital.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot copyright
-;+		(comment "The copyright attribute is a character string giving  information about the exclusive right to make copies, license, and otherwise exploit an object, whether physical or digital.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -9045,15 +9045,15 @@
 (defclass Software_Source "The Software Source class provides a description of a software code that is stored as source code."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot software_dialect
-;+		(comment "The software dialect attribute indicates the variety of a language used to write the software.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot supported_operating_system_note
 ;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
 		(type STRING)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot software_dialect
+;+		(comment "The software dialect attribute indicates the variety of a language used to write the software.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot software_language
 ;+		(comment "The software language attribute identifies the language used to write the software.")
@@ -9086,14 +9086,14 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot software_format_type
-;+		(comment "The software format type attribute classifies the format of the software.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot files
 ;+		(comment "The files attribute provides the number of files.")
 		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot software_format_type
+;+		(comment "The software format type attribute classifies the format of the software.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot program_notes_id
@@ -9161,14 +9161,14 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot software_format_type
-;+		(comment "The software format type attribute classifies the format of the software.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot files
 ;+		(comment "The files attribute provides the number of files.")
 		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot software_format_type
+;+		(comment "The software format type attribute classifies the format of the software.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot program_notes_id
@@ -9252,23 +9252,23 @@
 (defclass DD_Class_Full "The DD_Class_Full class provides a more complete definition of a class for a data dictionary."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(multislot terminological_entry
-;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
-		(type INSTANCE)
-;+		(allowed-classes Terminological_Entry)
-		(create-accessor read-write))
 	(single-slot submitter_name
 ;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
-		(type STRING)
-;+		(cardinality 1 1)
+	(multislot terminological_entry
+;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
+		(type INSTANCE)
+;+		(allowed-classes Terminological_Entry)
 		(create-accessor read-write))
 	(single-slot registered_by
 ;+		(comment "The registered_by attribute provides the name of the person or organization that registered the object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -9287,15 +9287,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot dd_association
-;+		(comment "The local_association_attribute association provides a relationship to an attribute.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Association)
-		(create-accessor read-write))
 	(single-slot element_flag
 ;+		(comment "The element flag attribute indicates whether or not the class is defined as a xs:element in XML Schema.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot dd_association
+;+		(comment "The local_association_attribute association provides a relationship to an attribute.")
+		(type INSTANCE)
+;+		(allowed-classes DD_Association)
 		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
@@ -9324,16 +9324,16 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot abstract_flag
-;+		(comment "The abstract flag attribute indicates whether or not the class can be instantiated. Abstract flag is only included if a value of 'true' is desired and indicates that the class is abstract and cannot be used in a label.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot steward_id
 ;+		(comment "The steward_id attribute provides the abbreviation of the organization that manages the set of registered attributes and classes.")
 		(type STRING)
 ;+		(value "pds" "atm" "geo" "img" "naif" "ppi" "rings" "rs" "sbn" "ops")
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot abstract_flag
+;+		(comment "The abstract flag attribute indicates whether or not the class can be instantiated. Abstract flag is only included if a value of 'true' is desired and indicates that the class is abstract and cannot be used in a label.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Zip "The Zip class describes a zip file."
@@ -9450,15 +9450,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot steward_id
-;+		(comment "The steward_id attribute provides the abbreviation of the organization that manages the set of registered attributes and classes.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot has_Property_Maps
 ;+		(comment "The has_Property_Maps association is a relationship to a Property Maps class")
 		(type INSTANCE)
 ;+		(allowed-classes Property_Maps)
+		(create-accessor read-write))
+	(single-slot steward_id
+;+		(comment "The steward_id attribute provides the abbreviation of the organization that manages the set of registered attributes and classes.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot dictionary_type
 ;+		(comment "The dictionary_type attribute provides the name of a dictionary category.")
@@ -9470,9 +9470,10 @@
 (defclass DD_Attribute "The DD_Attribute class defines an attribute for a data dictionary."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot submitter_name
-;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
-		(type STRING)
+	(single-slot value_domain_entry
+;+		(comment "The value_domain_entry association is a relationship to Value_Domain.")
+		(type INSTANCE)
+;+		(allowed-classes DD_Value_Domain)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot terminological_entry
@@ -9480,14 +9481,8 @@
 		(type INSTANCE)
 ;+		(allowed-classes Terminological_Entry)
 		(create-accessor read-write))
-	(single-slot value_domain_entry
-;+		(comment "The value_domain_entry association is a relationship to Value_Domain.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Value_Domain)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot nillable_flag
-;+		(comment "The nillable_flag attribute indicates whether an attribute is allowed to take on nil as a value.")
+	(single-slot submitter_name
+;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -9496,16 +9491,21 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot data_object
-;+		(comment "The data_object association is a relationship to Data Object.")
-		(type INSTANCE)
-;+		(allowed-classes Conceptual_Object)
+	(single-slot nillable_flag
+;+		(comment "The nillable_flag attribute indicates whether an attribute is allowed to take on nil as a value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot internal_reference
 ;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
 		(type INSTANCE)
 ;+		(allowed-classes Internal_Reference)
+		(create-accessor read-write))
+	(single-slot data_object
+;+		(comment "The data_object association is a relationship to Data Object.")
+		(type INSTANCE)
+;+		(allowed-classes Conceptual_Object)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot comment
 ;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
@@ -9531,31 +9531,31 @@
 (defclass DD_Class "The DD_Class class defines a class for a data dictionary."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot submitter_name
-;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot terminological_entry
 ;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
 		(type INSTANCE)
 ;+		(allowed-classes Terminological_Entry)
+		(create-accessor read-write))
+	(single-slot submitter_name
+;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot local_identifier
 ;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot internal_reference
+;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Internal_Reference)
+		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
 ;+		(allowed-classes Conceptual_Object)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot internal_reference
-;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Internal_Reference)
 		(create-accessor read-write))
 	(single-slot definition
 ;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
@@ -9577,16 +9577,16 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot element_flag
-;+		(comment "The element flag attribute indicates whether or not the class is defined as a xs:element in XML Schema.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot dd_association
 ;+		(comment "The local_association_attribute association provides a relationship to an attribute.")
 		(type INSTANCE)
 ;+		(allowed-classes DD_Association DD_Association_External DD_Associate_External_Class XSChoice%23)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot element_flag
+;+		(comment "The element flag attribute indicates whether or not the class is defined as a xs:element in XML Schema.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Band_Bin "The Band_Bin class specifies the characteristics of an individual spectral band in a spectral qube."
@@ -9607,13 +9607,23 @@
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot scaling_factor
+;+		(comment "The scaling_factor attribute is the scaling factor to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 1.")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot detector_number
 ;+		(comment "The detector_number attribute provides the spectrometer detector number corresponding to a band of a spectral qube. Detector numbers are usually assigned consecutively from 1, in order of increasing wavelength.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot scaling_factor
-;+		(comment "The scaling_factor attribute is the scaling factor to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 1.")
+	(single-slot original_band
+;+		(comment "The original_band attribute of a spectral qube provides the sequence of band numbers in the qube relative to some original qube. In the original qube, the values are just consecutive integers beginning with 1. In a qube which contains a subset of the bands in the original qube, the values are the original sequence numbers from that qube.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot value_offset
+;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -9622,24 +9632,14 @@
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot value_offset
-;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
+	(single-slot center_wavelength
+;+		(comment "The center_wavelength attribute provides the wavelength or frequency describing the center of a bin along the band axis of a spectral qube. When describing data from a spectrometer, the value corresponds to the peak of the response function for a particular detector and%2For grating position.")
 		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot original_band
-;+		(comment "The original_band attribute of a spectral qube provides the sequence of band numbers in the qube relative to some original qube. In the original qube, the values are just consecutive integers beginning with 1. In a qube which contains a subset of the bands in the original qube, the values are the original sequence numbers from that qube.")
-		(type INTEGER)
-;+		(cardinality 0 1)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot band_number
 ;+		(comment "The band_number attribute provides a number corresponding to the band in the spectral qube. The band number is equivalent to the instrument band number.")
 		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot center_wavelength
-;+		(comment "The center_wavelength attribute provides the wavelength or frequency describing the center of a bin along the band axis of a spectral qube. When describing data from a spectrometer, the value corresponds to the peak of the response function for a particular detector and%2For grating position.")
-		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -9697,12 +9697,12 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot xpath
+	(single-slot classSteward
+;+		(comment "The classSteward attribute provides the name of the steward for this rule.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot classSteward
-;+		(comment "The classSteward attribute provides the name of the steward for this rule.")
+	(single-slot xpath
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -9735,11 +9735,11 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot assertMsg
+	(single-slot assertStmt
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot assertStmt
+	(single-slot assertMsg
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -9751,14 +9751,14 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot testValArr
+;+		(comment "The testValArr attribute provides the values for the assert statement.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot attrTitle
 ;+		(comment "The attrTitle attribute provides the name of the attribute to be used for display.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot testValArr
-;+		(comment "The testValArr attribute provides the values for the assert statement.")
-		(type STRING)
 		(create-accessor read-write))
 	(single-slot %3ANAME
 		(type STRING)
@@ -9772,16 +9772,16 @@
 ;+		(comment "The rule_assign attribute provides an assignment statement for a schematron rule.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot rule_statement
 ;+		(comment "The rule_statement association is a relationship to DD_Rule_Statement")
 		(type INSTANCE)
 ;+		(allowed-classes DD_Rule_Statement)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot dd_attribute_reference
 ;+		(comment "The dd_attribute_reference association is a relationship to DD_Attribute_Reference.")
@@ -9855,13 +9855,13 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot aip_lidvid
-;+		(comment "The aip_lidvid attribute provides the logical_identifier plus version_id, which uniquely identifies a Archival Information Package.")
+	(single-slot manifest_url
+;+		(comment "The manifest url provides the URL to the manifest file.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot manifest_url
-;+		(comment "The manifest url provides the URL to the manifest file.")
+	(single-slot aip_lidvid
+;+		(comment "The aip_lidvid attribute provides the logical_identifier plus version_id, which uniquely identifies a Archival Information Package.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -9875,30 +9875,30 @@
 (defclass Property_Map "The Property Map class defines a table consisting of a set of data elements and their values. The data elements in this table are considered to be locally defined and not subject to standards except for nomenclature rules."
 	(is-a TNDO_Supplemental)
 	(role concrete)
+	(single-slot identifier
+;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(multislot has_Property_Map_Entry
 ;+		(comment "The has_Property_Map_Entry association is a relationship to property map entry.")
 		(type INSTANCE)
 ;+		(allowed-classes Property_Map_Entry)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot identifier
-;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot title
 ;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot instance_id
+;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot model_object_type
 ;+		(comment "The model_object_type attribute provides a classification for a modeled object.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot instance_id
-;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
-		(type STRING)
 		(create-accessor read-write))
 	(single-slot model_object_id
 ;+		(comment "The model_object_id attribute provides the unique identifier of a class, attribute, or value that is defined in the information model.")
@@ -9996,16 +9996,16 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot external_reference_extended
-;+		(comment "The external_reference_extended association is a relationship to external_reference_extended.")
-		(type INSTANCE)
-;+		(allowed-classes External_Reference_Extended)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot internal_reference
 ;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
 		(type INSTANCE)
 ;+		(allowed-classes Internal_Reference)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot external_reference_extended
+;+		(comment "The external_reference_extended association is a relationship to external_reference_extended.")
+		(type INSTANCE)
+;+		(allowed-classes External_Reference_Extended)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot local_internal_reference
@@ -10058,16 +10058,16 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot external_reference_extended
-;+		(comment "The external_reference_extended association is a relationship to external_reference_extended.")
-		(type INSTANCE)
-;+		(allowed-classes External_Reference_Extended)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot internal_reference
 ;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
 		(type INSTANCE)
 ;+		(allowed-classes Internal_Reference)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot external_reference_extended
+;+		(comment "The external_reference_extended association is a relationship to external_reference_extended.")
+		(type INSTANCE)
+;+		(allowed-classes External_Reference_Extended)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot local_internal_reference
@@ -10104,16 +10104,16 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot external_reference_extended
-;+		(comment "The external_reference_extended association is a relationship to external_reference_extended.")
-		(type INSTANCE)
-;+		(allowed-classes External_Reference_Extended)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot internal_reference
 ;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
 		(type INSTANCE)
 ;+		(allowed-classes Internal_Reference)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot external_reference_extended
+;+		(comment "The external_reference_extended association is a relationship to external_reference_extended.")
+		(type INSTANCE)
+;+		(allowed-classes External_Reference_Extended)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot local_internal_reference
@@ -10207,15 +10207,15 @@
 		(type INSTANCE)
 ;+		(allowed-classes LIDVID_ID_Reference_From)
 		(create-accessor read-write))
-	(single-slot virtual_reference_type
-;+		(comment "The virtual_reference_type attribute provides the name of an association between two objects.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot lidvid_refernce_to
 ;+		(comment "The lidvid_refernce_to provides the identifier of the ending object in a  one directional relationship.")
 		(type INSTANCE)
 ;+		(allowed-classes LIDVID_ID_Reference_To)
+		(create-accessor read-write))
+	(single-slot virtual_reference_type
+;+		(comment "The virtual_reference_type attribute provides the name of an association between two objects.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Virtual_Reference "The Virtual_Reference class defines a one directional relationship by referencing an existing product or product component."
@@ -10235,28 +10235,28 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot virtual_reference_type
-;+		(comment "The virtual_reference_type attribute provides the name of an association between two objects.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot lidvid_refernce_to
 ;+		(comment "The lidvid_refernce_to provides the identifier of the ending object in a  one directional relationship.")
 		(type INSTANCE)
 ;+		(allowed-classes LIDVID_ID_Reference_To)
+		(create-accessor read-write))
+	(single-slot virtual_reference_type
+;+		(comment "The virtual_reference_type attribute provides the name of an association between two objects.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass LID_ID_Reference "The LID_ID_Reference class defines a one directional relationship by referencing an existing product and an optional product component."
 	(is-a TNDO_Supplemental)
 	(role concrete)
+	(multislot id_reference
+;+		(comment "The id_reference provides the identifier of an object in a one  directional relationship.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot lid_reference
 ;+		(comment "The lid_reference attribute provides the logical_identifier for a  product.")
 		(type STRING)
 		(default "logical_identifier")
-		(create-accessor read-write))
-	(multislot id_reference
-;+		(comment "The id_reference provides the identifier of an object in a one  directional relationship.")
-		(type STRING)
 		(create-accessor read-write)))
 
 (defclass LID_ID_Reference_To "The LID_ID_Reference_To class identifies the ending object of a one directional relationship by referencing an existing product and an optional product component."
@@ -10270,14 +10270,14 @@
 (defclass LIDVID_ID_Reference "The LIDVID_ID_Reference class defines a one directional relationship by referencing an existing product and an optional product component."
 	(is-a TNDO_Supplemental)
 	(role concrete)
+	(multislot id_reference
+;+		(comment "The id_reference provides the identifier of an object in a one  directional relationship.")
+		(type STRING)
+		(create-accessor read-write))
 	(multislot lidvid_reference
 ;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
 		(type STRING)
 		(default "logical_identifier::version_id")
-		(create-accessor read-write))
-	(multislot id_reference
-;+		(comment "The id_reference provides the identifier of an object in a one  directional relationship.")
-		(type STRING)
 		(create-accessor read-write)))
 
 (defclass LIDVID_ID_Reference_To "The LIDVID_ID_Reference_To class identifies the ending object of a one directional relationship by referencing an existing product and an optional product component."
@@ -10353,15 +10353,15 @@
 ;+		(value "English" "Russian")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot preferred_flag
-;+		(comment "The preferred_flag indicates whether this entry is  preferred over all other entries.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot source
 ;+		(comment "The bibliographic_reference association is a relationship to bibliographic reference.")
 		(type INSTANCE)
 ;+		(allowed-classes External_Reference_Extended)
+		(create-accessor read-write))
+	(single-slot preferred_flag
+;+		(comment "The preferred_flag indicates whether this entry is  preferred over all other entries.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Terminological_Entry_SKOS "The terminological_entry_SKOS class provides terms and definitions for a SKOS ontology."
@@ -10388,16 +10388,16 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot instance_id
+;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot model_object_type
 ;+		(comment "The model_object_type attribute provides a classification for a modeled object.")
 		(type STRING)
 ;+		(value "Attribute" "Class" "Nuance" "Keyword" "Value")
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot instance_id
-;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot referenced_identifier
 ;+		(comment "The referenced identifier attribute provides the identifier of the entify being referenced.")
@@ -10410,15 +10410,15 @@
 ;+		(value "PDS4" "PDS3" "VICAR")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot model_object_id
-;+		(comment "The model_object_id attribute provides the unique identifier of a class, attribute, or value that is defined in the information model.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot steward_id
 ;+		(comment "The steward_id attribute provides the abbreviation of the organization that manages the set of registered attributes and classes.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot model_object_id
+;+		(comment "The model_object_id attribute provides the unique identifier of a class, attribute, or value that is defined in the information model.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot description
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
@@ -10439,13 +10439,13 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot value_begin_date
-;+		(comment "The value_begin_date attribute provides the first date on which the permissible value is in effect.")
+	(single-slot value
+;+		(comment "The value attribute provides a single, allowed numerical or character string value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot value
-;+		(comment "The value attribute provides a single, allowed numerical or character string value.")
+	(single-slot value_begin_date
+;+		(comment "The value_begin_date attribute provides the first date on which the permissible value is in effect.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -10481,15 +10481,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot constant_value
-;+		(comment "The constant value attribute provides the value to be used if an attribute is static.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot dd_attribute_reference
 ;+		(comment "The dd_attribute_reference association is a relationship to DD_Attribute_Reference.")
 		(type INSTANCE)
 ;+		(allowed-classes DD_Attribute_Reference)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot constant_value
+;+		(comment "The constant value attribute provides the value to be used if an attribute is static.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot dd_class_reference
@@ -10577,13 +10577,13 @@
 (defclass Tracking_Detail "The Tracking Detail class is a single status record."
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
-	(single-slot archive_status_note
-;+		(comment "The archive status note attribute provides a comment about the archive status.")
+	(single-slot modification_date
+;+		(comment "The modification_date attribute provides date the modifications were completed")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot modification_date
-;+		(comment "The modification_date attribute provides date the modifications were completed")
+	(single-slot archive_status_note
+;+		(comment "The archive status note attribute provides a comment about the archive status.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -10629,16 +10629,11 @@
 	(single-slot unit_of_measure_type
 ;+		(comment "The unit_of_measure_type attribute identifies the class from which the attribute being defined in this data dictionary draws its possible expressions for units.")
 		(type STRING)
-;+		(value "Units_of_Amount_Of_Substance" "Units_of_Angle" "Units_of_Angular_Velocity" "Units_of_Area" "Units_of_Frequency" "Units_of_Length" "Units_of_Mass" "Units_of_Misc" "Units_of_None" "Units_of_Optical_Path_Length" "Units_of_Pressure" "Units_of_Radiance" "Units_of_Rates" "Units_of_Map_Scale" "Units_of_Solid_Angle" "Units_of_Storage" "Units_of_Temperature" "Units_of_Time" "Units_of_Velocity" "Units_of_Voltage" "Units_of_Volume" "Units_of_Acceleration" "Units_of_Frame_Rate" "Units_of_Spectral_Irradiance" "Units_of_Spectral_Radiance" "Units_of_Wavenumber" "Units_of_Current" "Units_of_Pixel_Scale_Linear" "Units_of_Pixel_Scale_Angular" "Units_of_Pixel_Resolution_Linear" "Units_of_Pixel_Resolution_Angular" "Units_of_Pixel_Resolution_Map" "Units_of_Pixel_Scale_Map" "Units_of_Energy" "Units_of_Force" "Units_of_Gmass")
+;+		(value "Units_of_Amount_Of_Substance" "Units_of_Angle" "Units_of_Angular_Velocity" "Units_of_Area" "Units_of_Frequency" "Units_of_Length" "Units_of_Mass" "Units_of_Misc" "Units_of_None" "Units_of_Optical_Path_Length" "Units_of_Pressure" "Units_of_Radiance" "Units_of_Rates" "Units_of_Map_Scale" "Units_of_Solid_Angle" "Units_of_Storage" "Units_of_Temperature" "Units_of_Time" "Units_of_Velocity" "Units_of_Voltage" "Units_of_Volume" "Units_of_Acceleration" "Units_of_Frame_Rate" "Units_of_Spectral_Irradiance" "Units_of_Spectral_Radiance" "Units_of_Wavenumber" "Units_of_Current" "Units_of_Pixel_Scale_Linear" "Units_of_Pixel_Scale_Angular" "Units_of_Pixel_Resolution_Linear" "Units_of_Pixel_Resolution_Angular" "Units_of_Pixel_Resolution_Map" "Units_of_Pixel_Scale_Map" "Units_of_Energy" "Units_of_Force" "Units_of_Gmass" "Units_of_Power")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot formation_rule
 ;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -10647,6 +10642,11 @@
 		(type STRING)
 ;+		(value "ASCII_Boolean" "ASCII_Date_YMD" "ASCII_Integer" "ASCII_Real" "ASCII_AnyURI" "ASCII_Date_DOY" "ASCII_Date_Time_DOY_UTC" "ASCII_Date_Time_YMD_UTC" "ASCII_LID" "ASCII_LIDVID" "ASCII_MD5_Checksum" "ASCII_Short_String_Collapsed" "ASCII_Text_Preserved" "ASCII_Short_String_Preserved" "ASCII_Time" "ASCII_VID" "ASCII_DOI" "ASCII_Numeric_Base2" "ASCII_Numeric_Base16" "ASCII_NonNegative_Integer" "ASCII_File_Specification_Name" "ASCII_Directory_Path_Name" "ASCII_LIDVID_LID" "ASCII_File_Name" "ASCII_Numeric_Base8" "ASCII_Text_Collapsed" "UTF8_Short_String_Collapsed" "UTF8_Short_String_Preserved" "UTF8_Text_Preserved" "Vector_Cartesian_3" "Vector_Cartesian_3_Acceleration" "Vector_Cartesian_3_Position" "Vector_Cartesian_3_Velocity" "Vector_Cartesian_3_Pointing" "ASCII_Date_Time_DOY" "ASCII_Date_Time_YMD" "ASCII_BibCode" "UTF8_Text_Collapsed")
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot maximum_value
 ;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
@@ -10658,13 +10658,13 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -10692,13 +10692,13 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_occurrences
-;+		(comment "The maximum occurrences attribute indicates the number of times something may occur. It is also called the maximum cardinality. The asterisk character is used as a value to indicate that no upper bound exists.")
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+	(single-slot maximum_occurrences
+;+		(comment "The maximum occurrences attribute indicates the number of times something may occur. It is also called the maximum cardinality. The asterisk character is used as a value to indicate that no upper bound exists.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -10720,7 +10720,7 @@
 	(single-slot unit_of_measure_type
 ;+		(comment "The unit_of_measure_type attribute identifies the class from which the attribute being defined in this data dictionary draws its possible expressions for units.")
 		(type STRING)
-;+		(value "Units_of_Amount_Of_Substance" "Units_of_Angle" "Units_of_Angular_Velocity" "Units_of_Area" "Units_of_Frequency" "Units_of_Length" "Units_of_Mass" "Units_of_Misc" "Units_of_None" "Units_of_Optical_Path_Length" "Units_of_Pressure" "Units_of_Radiance" "Units_of_Rates" "Units_of_Map_Scale" "Units_of_Solid_Angle" "Units_of_Storage" "Units_of_Temperature" "Units_of_Time" "Units_of_Velocity" "Units_of_Voltage" "Units_of_Volume" "Units_of_Frame_Rate" "Units_of_Wavenumber" "Units_of_Spectral_Radiance" "Units_of_Spectral_Irradiance" "Units_of_Current" "Units_of_Pixel_Scale_Linear" "Units_of_Pixel_Scale_Angular" "Units_of_Pixel_Resolution_Linear" "Units_of_Pixel_Resolution_Angular" "Units_of_Acceleration" "Units_of_Pixel_Resolution_Map" "Units_of_Pixel_Scale_Map" "Units_of_Energy" "Units_of_Force" "Units_of_Gmass")
+;+		(value "Units_of_Amount_Of_Substance" "Units_of_Angle" "Units_of_Angular_Velocity" "Units_of_Area" "Units_of_Frequency" "Units_of_Length" "Units_of_Mass" "Units_of_Misc" "Units_of_None" "Units_of_Optical_Path_Length" "Units_of_Pressure" "Units_of_Radiance" "Units_of_Rates" "Units_of_Map_Scale" "Units_of_Solid_Angle" "Units_of_Storage" "Units_of_Temperature" "Units_of_Time" "Units_of_Velocity" "Units_of_Voltage" "Units_of_Volume" "Units_of_Frame_Rate" "Units_of_Wavenumber" "Units_of_Spectral_Radiance" "Units_of_Spectral_Irradiance" "Units_of_Current" "Units_of_Pixel_Scale_Linear" "Units_of_Pixel_Scale_Angular" "Units_of_Pixel_Resolution_Linear" "Units_of_Pixel_Resolution_Angular" "Units_of_Acceleration" "Units_of_Pixel_Resolution_Map" "Units_of_Pixel_Scale_Map" "Units_of_Energy" "Units_of_Force" "Units_of_Gmass" "Units_of_Power")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot value_data_type
@@ -11864,18 +11864,13 @@
 (defclass Character_Data_Type "The Character Data Type class is the parent class for data types used to classify the values of attributes in class descriptions, i.e., product labels and character digital objects."
 	(is-a Data_Type)
 	(role abstract)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -11884,8 +11879,8 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -11895,13 +11890,18 @@
 ;+		(value "UTF-8")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -11920,15 +11920,15 @@
 ;+		(value "xsd:anyURI")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_encoding
@@ -11956,27 +11956,27 @@
 (defclass ASCII_Date "The ASCII_Date class indicates a date in either YMD or DOY format."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "YYYY-MM-DD/YYYY-DOY")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
+;+		(value "YYYY-MM-DD/YYYY-DOY")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -11994,27 +11994,27 @@
 (defclass ASCII_Date_DOY "The ASCII_Date_DOY class indicates a date in DOY format."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "YYYY-DOY")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
+;+		(value "YYYY-DOY")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -12032,21 +12032,16 @@
 (defclass ASCII_Date_Time "The ASCII_Date_Time class indicates a date in either YMD or DOY format and time."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "YYYY-MM-DDTHH:MM:SS.SSS(Z)/YYYY-DOYTHH:MM:SS.SSS(Z)")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
+;+		(value "YYYY-MM-DDTHH:MM:SS.SSS(Z)/YYYY-DOYTHH:MM:SS.SSS(Z)")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -12055,18 +12050,23 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_value
 ;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12080,21 +12080,16 @@
 (defclass ASCII_Date_Time_DOY "The ASCII_Date_Time_DOY class indicates a date in DOY format and time."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "YYYY-DOYTHH:MM:SS.SSSSSS(Z)")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
+;+		(value "YYYY-DOYTHH:MM:SS.SSSSSS(Z)")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -12103,18 +12098,23 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_value
 ;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12128,21 +12128,16 @@
 (defclass ASCII_Date_Time_YMD "The ASCII_Date_Time_YMD class indicates a date in YMD format and time."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "YYYY-MM-DDTHH:MM:SS.SSSSSS(Z)")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
+;+		(value "YYYY-MM-DDTHH:MM:SS.SSSSSS(Z)")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -12151,18 +12146,23 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_value
 ;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12176,21 +12176,16 @@
 (defclass ASCII_Date_Time_UTC "The ASCII_Date_Time_UTC class indicates a date and time in UTC format."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "YYYY-MM-DDTHH:MM:SS.SSSZ/YYYY-DOYTHH:MM:SS.SSSZ")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
+;+		(value "YYYY-MM-DDTHH:MM:SS.SSSZ/YYYY-DOYTHH:MM:SS.SSSZ")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -12199,18 +12194,23 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_value
 ;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12224,27 +12224,27 @@
 (defclass ASCII_Date_YMD "The ASCII_Date_YMD class indicates a date in YMD format."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "YYYY-MM-DD")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
+;+		(value "YYYY-MM-DD")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -12262,28 +12262,28 @@
 (defclass ASCII_Directory_Path_Name "The ASCII Directory Path Name class indicates a system directory path."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "dir1/dir2/")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
-;+		(value "1")
+;+		(value "dir1/dir2/")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -12296,28 +12296,28 @@
 (defclass ASCII_File_Name "The ASCII File Name class indicates a system file name."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "file_name.file_extension")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
-;+		(value "1")
+;+		(value "file_name.file_extension")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -12330,27 +12330,27 @@
 (defclass ASCII_DOI "The ASCII DOI class indicates a digital object identifier (DOI)."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "10.ssss/sss")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
+;+		(value "10.ssss/sss")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -12368,28 +12368,28 @@
 (defclass ASCII_File_Specification_Name "The ASCII File Specification Name class indicates a system file including directory path, file name, and file extension."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "dir1/dir2/file_name.file_extension")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
-;+		(value "1")
+;+		(value "dir1/dir2/file_name.file_extension")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -12408,13 +12408,13 @@
 ;+		(value "xsd:long")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot character_constraint
+;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot character_constraint
-;+		(comment "The character_constraint attribute limits the characters allowed.")
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12424,43 +12424,43 @@
 ;+		(value "9223372036854775807")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(value "-9223372036854775808")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass ASCII_MD5_Checksum "The ASCII MD5 Checksum class indicates a checksum computed by the Message-Digest algorithm 5 (MD5)."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "0123456789abcdef")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
-;+		(value "32")
+;+		(value "0123456789abcdef")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "32")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -12485,13 +12485,13 @@
 ;+		(value "xsd:unsignedLong")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot character_constraint
+;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot character_constraint
-;+		(comment "The character_constraint attribute limits the characters allowed.")
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12501,15 +12501,15 @@
 ;+		(value "18446744073709551615")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(value "0")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot pattern
@@ -12528,15 +12528,15 @@
 ;+		(value "xsd:hexBinary")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot character_constraint
+;+		(comment "The character_constraint attribute limits the characters allowed.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot minimum_characters
 ;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot character_constraint
-;+		(comment "The character_constraint attribute limits the characters allowed.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_value
@@ -12544,15 +12544,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_characters
 ;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "255")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot pattern
@@ -12570,16 +12570,16 @@
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_value
@@ -12587,15 +12587,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_characters
 ;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "255")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot pattern
@@ -12614,16 +12614,16 @@
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -12648,13 +12648,13 @@
 ;+		(value "xsd:double")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot character_constraint
+;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot character_constraint
-;+		(comment "The character_constraint attribute limits the characters allowed.")
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12664,15 +12664,15 @@
 ;+		(value "1.7976931348623157e308")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(value "-1.7976931348623157e308")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot pattern
@@ -12691,16 +12691,16 @@
 ;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_value
@@ -12708,15 +12708,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_characters
 ;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "255")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12729,16 +12729,16 @@
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_value
@@ -12746,15 +12746,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_characters
 ;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "255")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12767,16 +12767,16 @@
 ;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -12794,16 +12794,16 @@
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_value
@@ -12811,13 +12811,13 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -12825,21 +12825,16 @@
 (defclass ASCII_Time "The ASCII_Time class indicates a time value."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "HH:MM:SS.SSS")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
+;+		(value "HH:MM:SS.SSS")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -12848,18 +12843,23 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_value
 ;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12873,22 +12873,16 @@
 (defclass ASCII_VID "The ASCII_VID class indicates a version identifier."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "M.n")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
-;+		(value "3")
+;+		(value "M.n")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -12897,8 +12891,19 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "3")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_value
 ;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12906,11 +12911,6 @@
 ;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "100")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot pattern
@@ -12929,15 +12929,15 @@
 ;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot character_constraint
+;+		(comment "The character_constraint attribute limits the characters allowed.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot minimum_characters
 ;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot character_constraint
-;+		(comment "The character_constraint attribute limits the characters allowed.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_value
@@ -12945,15 +12945,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_characters
 ;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "255")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12966,15 +12966,15 @@
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot character_constraint
+;+		(comment "The character_constraint attribute limits the characters allowed.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot minimum_characters
 ;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot character_constraint
-;+		(comment "The character_constraint attribute limits the characters allowed.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_value
@@ -12982,15 +12982,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_characters
 ;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "255")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -13003,15 +13003,15 @@
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot character_constraint
+;+		(comment "The character_constraint attribute limits the characters allowed.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot minimum_characters
 ;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot character_constraint
-;+		(comment "The character_constraint attribute limits the characters allowed.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_value
@@ -13019,13 +13019,13 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -13039,16 +13039,16 @@
 ;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -13071,16 +13071,16 @@
 (defclass ASCII_Date_Time_YMD_UTC "The ASCII_Date_Time_YMD_UTC class indicates a date (in YMD format) and time in UTC."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "YYYY-MM-DDTHH:MM:SS.SSSSSSZ")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
+		(type STRING)
+;+		(value "YYYY-MM-DDTHH:MM:SS.SSSSSSZ")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -13099,16 +13099,16 @@
 (defclass ASCII_Date_Time_DOY_UTC "The ASCII_Date_Time_DOY_UTC class indicates a date (in DOY format) and time in UTC."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "YYYY-DOYTHH:MM:SS.SSSSSSZ")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
+		(type STRING)
+;+		(value "YYYY-DOYTHH:MM:SS.SSSSSSZ")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -13133,16 +13133,16 @@
 ;+		(value "xsd:ID")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -13161,16 +13161,16 @@
 ;+		(value "xsd:IDREF")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -13183,16 +13183,16 @@
 (defclass ASCII_BibCode "The ASCII BibCode class indicates a bibliographic code from the Astrophysics Data System."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "YYYYJJJJJVVVVMPPPPA")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
+		(type STRING)
+;+		(value "YYYYJJJJJVVVVMPPPPA")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -13233,16 +13233,16 @@
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -13255,22 +13255,16 @@
 (defclass ASCII_LID "The ASCII_LID class indicates a logical identifier."
 	(is-a ASCII_String_Base_255)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "urn:xxx:yyy:zzzz")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
-;+		(value "1")
+;+		(value "urn:xxx:yyy:zzzz")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -13279,8 +13273,19 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot maximum_value
 ;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -13288,11 +13293,6 @@
 ;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "255")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot pattern
@@ -13305,28 +13305,28 @@
 (defclass ASCII_LIDVID "The ASCII_LIDVID class indicates a logical identifier and version identifier."
 	(is-a ASCII_String_Base_255)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "urn:xxx:yyy:zzzz::M.n")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
-;+		(value "1")
+;+		(value "urn:xxx:yyy:zzzz::M.n")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters
@@ -13345,28 +13345,28 @@
 (defclass ASCII_LIDVID_LID "The ASCII_LIDVID_LID class indicates a logical identifier and version identifier or simply the logical identfier."
 	(is-a ASCII_String_Base_255)
 	(role concrete)
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
-		(type STRING)
-;+		(value "urn:xxx:yyy:zzzz/urn:xxx:yyy:zzzz::M.n")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
 		(type STRING)
-;+		(value "1")
+;+		(value "urn:xxx:yyy:zzzz/urn:xxx:yyy:zzzz::M.n")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
 ;+		(comment "The character_constraint attribute limits the characters allowed.")
 		(type STRING)
 ;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_characters


### PR DESCRIPTION
CCB-339	add Units_of_Power with SI watts as option - Bugfix

@rchenatjpl Fixed the following

1.	Line 528 is sch:rule context="DD_Value_Domain/pds:unit_of_measure_type" role="warning"
but should be sch:rule context="pds:DD_Value_Domain/pds:unit_of_measure_type" role="warning"

2.	Lines 532,534,588,590 are missing 'Units_of_Power'

https://pds-jira.jpl.nasa.gov/browse/CCB-339

Add Units_of_Power as a new subclass of Unit_of_Measure. Available values for <unit_id> would be [,prefix]watt and dBm (dB with respect to one milliwatt).

Resolves #443
Refs CCB-339

