### PR TITLE
Issue #463  LDDTool 14 is not generating against past IM versions

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -143,7 +143,19 @@ public class DMDocument extends Object {
 	static boolean LDDNuanceFlag = false;				//
 	
 	// refactor into Protege switches
-	static boolean overWriteClass = true;				// use dd11179.pins class disp, isDeprecated, and versionId to overwrite Master DOMClasses, DOMAttrs, and DOMPermvalues
+	/*
+	 Possibilities re: refactoring fix.
+	 1) Check buildIMVersionId, if less than 1.18.0.0, then process MDPTNConfig, else use protege.
+	 	a) currently lISO11179DOMMDR.OverwriteClassFrom11179DataDict is only used for IMTool runs, not LDDTool runs.
+==>  	b) currently all IM version prior to 1.18.0.0 do not have object classes
+	 2) lISO11179DOMMDR.OverwriteClassFrom11179DataDict requires "Object Classes" in protege
+	 3) Removing MDPTNConfig requires that "I" and "N"  classes be included in protege as "Object Classes"
+	 4) ProtPontDOMModel is currently ignoring "I" and "N" classes
+	 	a) this means that dd11179_GenPClass.pins does not include "I" and "N" classes
+	 */
+	
+// 555	static boolean overWriteClass = true;				// use dd11179.pins class disp, isDeprecated, and versionId to overwrite Master DOMClasses, DOMAttrs, and DOMPermvalues
+	static boolean overWriteClass = false;				// use dd11179.pins class disp, isDeprecated, and versionId to overwrite Master DOMClasses, DOMAttrs, and DOMPermvalues
 	static boolean useMDPTNConfig = true;				// ProtPontDOMModel; get disposition for the class from MDPTNConfigClassDisp
 	static boolean overWriteDeprecated = false;			// use dd11179.pins isDeprecated to overwrite DMDocument.deprecatedObjects2
 	

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -304,7 +304,9 @@ public class GetDOMModel extends Object {
 		// 017b - overwrite master classes from the 11179 DD
 		//     - either import from JSON 11179 file or overwrite from 11179 dictionary
 		//		Overwrite is needed to set classes and attribute defined in protege but not in JSON11179 ???
-		lISO11179DOMMDR.OverwriteClassFrom11179DataDict();
+// 555
+		if (!DMDocument.LDDToolFlag)
+			lISO11179DOMMDR.OverwriteClassFrom11179DataDict();
 		
 		// 018 - overwrite any LDD attributes from the cloned USER attributes
 		//       this is not really needed since the definitions are in the external class

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
@@ -138,7 +138,7 @@ class ProtPontDOMModel extends DOMInfoModel{
 							// class is "hidden" ignore it and do not print warning
 
 							// *** added ***
-							if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue;   // omit %3ACLIPS_TOP_LEVEL_SLOT_CLASS
+/*							if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue;   // omit %3ACLIPS_TOP_LEVEL_SLOT_CLASS
 							lClass.isInactive = true;
 							classNameSpaceIdNC = lClass.nameSpaceIdNC;  // global needed for parser
 							parsedClassMap.put(lClass.rdfIdentifier, lClass);
@@ -146,7 +146,7 @@ class ProtPontDOMModel extends DOMInfoModel{
 							String token1 = (String) tokenIter.next();
 							if (token1.compareTo("(") != 0) {
 								lClass.definition = DOMInfoModel.unEscapeProtegeString(token1);
-							}
+							} */
 							// *** end of added ***
 						
 						} else {	// disposition exists but not clear why, print warning 
@@ -154,14 +154,15 @@ class ProtPontDOMModel extends DOMInfoModel{
 								DMDocument.registerMessage ("1>warning " + "Class omitted from build - Class Identifier:" + lClass.identifier);
 							}
 
-						  lClass.isInactive = true;
+							// *** added ***
+/* 555							lClass.isInactive = true;
 							classNameSpaceIdNC = lClass.nameSpaceIdNC;  // global needed for parser
 							parsedClassMap.put(lClass.rdfIdentifier, lClass);
 							isInParsedClassMap = true;
 							String token1 = (String) tokenIter.next();
 							if (token1.compareTo("(") != 0) {
 								lClass.definition = DOMInfoModel.unEscapeProtegeString(token1);
-							}
+							} */
 							// *** end of added ***
 
 						}
@@ -174,10 +175,8 @@ class ProtPontDOMModel extends DOMInfoModel{
 				}
 				
 				// get disposition for the class from dd11179
-//				if (DMDocument.overWriteClass) {
-//				if (false) {
-				if (true) {
-					lClass.getDOMClassDisposition2 ();
+				if (DMDocument.overWriteClass) {
+					lClass.getDOMClassDisposition2 ();	// from protege (new)
 					if (! isInParsedClassMap) {
 					parsedClassMap.put(lClass.rdfIdentifier, lClass);
 					}


### PR DESCRIPTION
Issue #463  LDDTool 14 is not generating against past versions of the IM correctly

The refactoring of Object Class dispositions to the Protege file is not reflected in past versions of the IM. 

To fix the problem, LDDTool runs using past versions of the IM no longer use the Protege files for the class disposition. 

Resolves #463

