### PR TITLE
Issue #459 : LDDTool is not combining Schematron Contexts

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GenDOMRules.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GenDOMRules.java
@@ -139,10 +139,9 @@ class GenDOMRules extends Object {
 			} else {
 				lXPath = lAttr.xPath;
 			}
-			String lRuleId = lXPath;
-			DOMRule lRule = DOMInfoModel.masterDOMRuleIdMap.get(lRuleId);
+			DOMRule lRule = DOMInfoModel.masterDOMRuleIdMap.get(lXPath);
 			if (lRule == null) {
-				lRule = new DOMRule(lRuleId);
+				lRule = new DOMRule(lXPath);
 				DOMInfoModel.masterDOMRuleIdMap.put(lRule.identifier, lRule);			
 				DOMInfoModel.masterDOMRuleArr.add(lRule);
 				lRule.setRDFIdentifier();
@@ -240,15 +239,14 @@ class GenDOMRules extends Object {
 	public void addClassSchematronRuleEnumeratedChildOfAssocExtrnClass (DOMAttr lInheritedDOMAttr, DOMClass lParentDOMClass, DOMClass lChildDOMClass) {	
 		// for each attribute, write out the rule
 		String lXpath = lChildDOMClass.nameSpaceIdNC + ":" + lChildDOMClass.title  + "/" + lInheritedDOMAttr.lddUserAttribute.classNameSpaceIdNC + ":" + lInheritedDOMAttr.lddUserAttribute.attrParentClass.title  + "/" + lInheritedDOMAttr.lddUserAttribute.nameSpaceIdNC + ":" + lInheritedDOMAttr.lddUserAttribute.title  + "";
-		String lRuleId = lXpath;
-		DOMRule lRule = DOMInfoModel.masterDOMRuleIdMap.get(lRuleId);
+		DOMRule lRule = DOMInfoModel.masterDOMRuleIdMap.get(lXpath);
 		if (lRule == null) {
-			lRule = new DOMRule(lRuleId);
+			lRule = new DOMRule(lXpath);
 			DOMInfoModel.masterDOMRuleIdMap.put(lRule.identifier, lRule);			
 			DOMInfoModel.masterDOMRuleArr.add(lRule);
 			lRule.setRDFIdentifier();
 			DOMInfoModel.masterDOMRuleMap.put(lRule.rdfIdentifier, lRule);
-			lRule.xpath = lRuleId;
+			lRule.xpath = lXpath;
 			lRule.attrTitle = "TBD_AttrTitle";		
 			lRule.attrNameSpaceNC = "TBD_attrNameSpaceNC";		
 			lRule.classTitle = lChildDOMClass.title;		
@@ -332,16 +330,16 @@ class GenDOMRules extends Object {
 		// create rules for the boolean attributes
 		for (Iterator <DOMClass> i = lBooleanClassArr.iterator(); i.hasNext();) {
 			DOMClass lClass = (DOMClass) i.next();
-			String lRuleId = lClass.nameSpaceId + lClass.title;
-			DOMRule lRule = DOMInfoModel.masterDOMRuleIdMap.get(lRuleId);
+			String lXpath = lClass.nameSpaceId + lClass.title;
+			DOMRule lRule = DOMInfoModel.masterDOMRuleIdMap.get(lXpath);
 			if (lRule == null) {
-				lRule = new DOMRule(lRuleId);
+				lRule = new DOMRule(lXpath);
 				DOMInfoModel.masterDOMRuleIdMap.put(lRule.identifier, lRule);			
 				DOMInfoModel.masterDOMRuleArr.add(lRule);
 				lRule.setRDFIdentifier();
 				DOMInfoModel.masterDOMRuleMap.put(lRule.rdfIdentifier, lRule);
 				
-				lRule.xpath = lRuleId;
+				lRule.xpath = lXpath;
 				lRule.attrTitle = "TBD_AttrTitle";		
 				lRule.attrNameSpaceNC = "TBD_attrNameSpaceNC";		
 				lRule.classTitle = lClass.title;		
@@ -462,15 +460,15 @@ class GenDOMRules extends Object {
 		ArrayList <String> lDiscNameFacet2Arr = new ArrayList <String> ();
 		
 		// set up the Primary Result Summary rule
-		String lRuleId = "pds:Primary_Result_Summary/pds:Science_Facets";
-		DOMRule lRule = DOMInfoModel.masterDOMRuleIdMap.get(lRuleId);
-		lRule = new DOMRule(lRuleId);
+		String lXpath = "pds:Primary_Result_Summary/pds:Science_Facets";
+		DOMRule lRule = DOMInfoModel.masterDOMRuleIdMap.get(lXpath);
+		lRule = new DOMRule(lXpath);
 		DOMInfoModel.masterDOMRuleIdMap.put(lRule.identifier, lRule);		
 		DOMInfoModel.masterDOMRuleArr.add(lRule);
 		lRule.setRDFIdentifier();
 		DOMInfoModel.masterDOMRuleMap.put(lRule.rdfIdentifier, lRule);
 		
-		lRule.xpath = lRuleId;
+		lRule.xpath = lXpath;
 		lRule.attrTitle = "discipline_name";		
 		lRule.attrNameSpaceNC = DMDocument.masterNameSpaceIdNCLC;		
 		lRule.classTitle = "Science_Facets";		
@@ -585,15 +583,15 @@ class GenDOMRules extends Object {
 		}
 		
 		// set up the Primary Result Summary rule
-		lRuleId = "pds:Primary_Result_Summary/pds:Science_Facets/pds:subfacet1";
-		lRule = DOMInfoModel.masterDOMRuleIdMap.get(lRuleId);
-		lRule = new DOMRule(lRuleId);
+		lXpath = "pds:Primary_Result_Summary/pds:Science_Facets/pds:subfacet1";
+		lRule = DOMInfoModel.masterDOMRuleIdMap.get(lXpath);
+		lRule = new DOMRule(lXpath);
 		DOMInfoModel.masterDOMRuleIdMap.put(lRule.identifier, lRule);		
 		DOMInfoModel.masterDOMRuleArr.add(lRule);
 		lRule.setRDFIdentifier();
 		DOMInfoModel.masterDOMRuleMap.put(lRule.rdfIdentifier, lRule);
 		
-		lRule.xpath = lRuleId;
+		lRule.xpath = lXpath;
 		lRule.attrTitle = "subfacet1";		
 		lRule.attrNameSpaceNC = DMDocument.masterNameSpaceIdNCLC;		
 		lRule.classTitle = "Science_Facets";		
@@ -605,15 +603,15 @@ class GenDOMRules extends Object {
 		lAssert.assertStmt = "name() = 'pds:Primary_Result_Summary/pds:Science_Facets/pds:subfacet1'";	
 		lAssert.assertMsg =  "pds:subfacet1 should not be used. No values have been provided.";
 		
-		lRuleId = "pds:Primary_Result_Summary/pds:Science_Facets/pds:subfacet2";
-		lRule = DOMInfoModel.masterDOMRuleIdMap.get(lRuleId);
-		lRule = new DOMRule(lRuleId);
+		lXpath = "pds:Primary_Result_Summary/pds:Science_Facets/pds:subfacet2";
+		lRule = DOMInfoModel.masterDOMRuleIdMap.get(lXpath);
+		lRule = new DOMRule(lXpath);
 		DOMInfoModel.masterDOMRuleIdMap.put(lRule.identifier, lRule);		
 		DOMInfoModel.masterDOMRuleArr.add(lRule);
 		lRule.setRDFIdentifier();
 		DOMInfoModel.masterDOMRuleMap.put(lRule.rdfIdentifier, lRule);
 		
-		lRule.xpath = lRuleId;
+		lRule.xpath = lXpath;
 		lRule.attrTitle = "subfacet2";		
 		lRule.attrNameSpaceNC = DMDocument.masterNameSpaceIdNCLC;		
 		lRule.classTitle = "Science_Facets";		
@@ -644,17 +642,17 @@ class GenDOMRules extends Object {
 					if (lDOMAttr.unit_of_measure_type == null || lDOMAttr.unit_of_measure_type.indexOf("TBD") == 0) continue;				
 					String lUnitsValueString = lDOMAttr.getUnits(true);
 					if (lUnitsValueString == null) continue;					
-					String lRuleId = lClass.nameSpaceId + lClass.title + "/" + lClass.nameSpaceId + lDOMAttr.title;
-					DOMRule lRule = DOMInfoModel.masterDOMRuleIdMap.get(lRuleId);
+					String lXpath = lClass.nameSpaceId + lClass.title + "/" + lClass.nameSpaceId + lDOMAttr.title;
+					DOMRule lRule = DOMInfoModel.masterDOMRuleIdMap.get(lXpath);
 					if (lRule == null) {
-						lRule = new DOMRule(lRuleId);		
+						lRule = new DOMRule(lXpath);		
 						DOMInfoModel.masterDOMRuleIdMap.put(lRule.identifier, lRule);			
 						DOMInfoModel.masterDOMRuleArr.add(lRule);
 						lRule.setRDFIdentifier();
 						DOMInfoModel.masterDOMRuleMap.put(lRule.rdfIdentifier, lRule);
 						
-						lRule.xpath = lRuleId;
-						lRule.attrTitle = lDOMAttr.title;		
+						lRule.xpath = lXpath;
+						lRule.attrTitle = lDOMAttr.title;
 						lRule.attrNameSpaceNC = lDOMAttr.nameSpaceIdNC;		
 						lRule.classTitle = lClass.title;		
 						lRule.classNameSpaceNC = lClass.nameSpaceIdNC;	

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -1157,7 +1157,6 @@ public class LDDDOMParser extends Object
 	}
 	
 	private void getRule (SchemaFileDefn lSchemaFileDefn, Element docEle) {	
-		String lValue = "";
 		ArrayList <String> lValueArr = new ArrayList <String> ();
 
 		//get a nodelist of <DD_Class> elements
@@ -1166,12 +1165,19 @@ public class LDDDOMParser extends Object
 			for(int i = 0 ; i < n2.getLength();i++) {
 				//get the elements
 				Element el = (Element)n2.item(i);
-				lValue = getTextValue(el,"local_identifier");	
-				String lLocalIdentifier = "TBD_lLocalIdentifier";	
-				if (! (lValue == null || (lValue.indexOf("TBD") == 0))) {
-					lLocalIdentifier = lValue;
-				}				
-				DOMRule lDOMRule = new DOMRule (lLocalIdentifier);	
+				String lLocalIdentifier = "TBD_lLocalIdentifier";
+				String lValue1 = getTextValue(el,"local_identifier");	
+				if (! (lValue1 == null || (lValue1.indexOf("TBD") == 0))) {
+					lLocalIdentifier = lValue1;
+				}
+				
+				String lContext = "TBD_lContext";	
+				String lValue2 = getTextValue(el,"rule_context");
+				if (! (lValue2 == null || (lValue2.indexOf("TBD") == 0))) {
+					lContext = lValue2;
+				}
+					
+				DOMRule lDOMRule = new DOMRule (lContext);	
 				lDOMRule.setRDFIdentifier();	
 
 				if ((DOMRule) ruleMap.get(lDOMRule.rdfIdentifier) == null) {
@@ -1179,12 +1185,10 @@ public class LDDDOMParser extends Object
 					ruleArr.add(lDOMRule);					
 					lDOMRule.nameSpaceIdNC = lSchemaFileDefn.nameSpaceIdNC;
 					lDOMRule.attrNameSpaceNC = lSchemaFileDefn.nameSpaceIdNC;
+					lDOMRule.attrTitle= "Rule";
 					lDOMRule.classNameSpaceNC = lSchemaFileDefn.nameSpaceIdNC;
 					lDOMRule.classSteward = lSchemaFileDefn.stewardId;
-					lValue = getTextValue(el,"rule_context");
-					if (! (lValue == null || (lValue.indexOf("TBD") == 0))) {
-						lDOMRule.xpath = lValue;
-					}
+					lDOMRule.xpath = lContext;
 					
 					// get the let assign values
 					lValueArr = getXMLValueArr ("rule_assign", el);
@@ -1200,32 +1204,28 @@ public class LDDDOMParser extends Object
 						DOMAssert lDOMAssertDefn = new DOMAssert ("Rule");
 						lDOMRule.assertArr.add(lDOMAssertDefn);
 						
-						lValue = getTextValue(lElement,"rule_type");
-						if (! (lValue == null || (lValue.indexOf("TBD") == 0))) {
-							if (lValue.compareTo("Assert") == 0) lDOMAssertDefn.assertType = "RAW";
-							else if (lValue.compareTo("Assert Every") == 0) lDOMAssertDefn.assertType = "EVERY";
-							else if (lValue.compareTo("Assert If") == 0) lDOMAssertDefn.assertType = "IF";
-							else if (lValue.compareTo("Report") == 0) lDOMAssertDefn.assertType = "REPORT";
+						String lValue3 = getTextValue(lElement,"rule_type");
+						if (! (lValue3 == null || (lValue3.indexOf("TBD") == 0))) {
+							if (lValue3.compareTo("Assert") == 0) lDOMAssertDefn.assertType = "RAW";
+							else if (lValue3.compareTo("Assert Every") == 0) lDOMAssertDefn.assertType = "EVERY";
+							else if (lValue3.compareTo("Assert If") == 0) lDOMAssertDefn.assertType = "IF";
+							else if (lValue3.compareTo("Report") == 0) lDOMAssertDefn.assertType = "REPORT";
 						}
-//						System.out.println("debug getRule lAssertDefn.assertType:" + lAssertDefn.assertType);
 						
-						lValue = getTextValue(lElement,"rule_test");
-						if (! (lValue == null || (lValue.indexOf("TBD") == 0))) {
-							lDOMAssertDefn.assertStmt = lValue;
+						String lValue4 = getTextValue(lElement,"rule_test");
+						if (! (lValue4 == null || (lValue4.indexOf("TBD") == 0))) {
+							lDOMAssertDefn.assertStmt = lValue4;
 						}
-//						System.out.println("debug getRule lAssertDefn.assertStmt:" + lAssertDefn.assertStmt);
 						
-						lValue = getTextValue(lElement,"rule_message");
-						if (! (lValue == null || (lValue.indexOf("TBD") == 0))) {
-							lDOMAssertDefn.assertMsg = lValue;
+						String lValue5 = getTextValue(lElement,"rule_message");
+						if (! (lValue5 == null || (lValue5.indexOf("TBD") == 0))) {
+							lDOMAssertDefn.assertMsg = lValue5;
 						}
-//						System.out.println("debug getRule lAssertDefn.assertMsg:" + lAssertDefn.assertMsg);
 
-						lValue = getTextValue(lElement,"rule_description");
-						if (! (lValue == null || (lValue.indexOf("TBD") == 0))) {
-							lDOMAssertDefn.specMesg = lValue;
+						String lValue6 = getTextValue(lElement,"rule_description");
+						if (! (lValue6 == null || (lValue6.indexOf("TBD") == 0))) {
+							lDOMAssertDefn.specMesg = lValue6;
 						}
-//						System.out.println("debug getRule lAssertDefn.specMesg:" + lAssertDefn.specMesg);
 							
 						// get the statement values
 						lValueArr = getXMLValueArr ("rule_value", lElement);
@@ -1233,7 +1233,6 @@ public class LDDDOMParser extends Object
 							lDOMAssertDefn.testValArr = lValueArr;
 						}
 					}
-//					System.out.println("debug getRule lRule.assertArr.size():" + lRule.assertArr.size());
 				}
 			}
 		}


### PR DESCRIPTION
Issue #459 : LDDTool is not combining Schematron Contexts correctly when adding to an auto-generated context

A bug was found where a schematron rule from an Ingest_LDD file was being written separately instead of being combined with an existing (common) schematron rule for Units of Measure. The bug has been fixed. Before and after files are attached.

The fix consists of merging the assert statement

  <sch:assert test="@unit = 'arcsec'">
    <title>rule_units_rollover_fwhm/Rule</title>
    The rollover_fwhm must have unit = 'arcsec'.</sch:assert>

into the following rule.

sch:pattern
<sch:rule context="survey:Rollover/survey:rollover_fwhm">
<sch:assert test="@Unit = 'arcsec'">
<title>rule_units_rollover_fwhm/Rule</title>
The rollover_fwhm must have unit = 'arcsec'.</sch:assert>
<sch:assert test="@Unit = ('arcmin', 'arcsec', 'deg', 'hr', 'mrad', 'rad')">
<title>survey:Rollover/survey:rollover_fwhm/survey:rollover_fwhm</title>
The attribute @Unit must be equal to one of the following values 'arcmin', 'arcsec', 'deg', 'hr', 'mrad', 'rad'.</sch:assert>
</sch:rule>
</sch:pattern>

Resolves #459

