### PR TITLE
Issue #507 : Bug generating BepiColombo SERENA dictionary

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/SchemaFileDefn.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/SchemaFileDefn.java
@@ -52,6 +52,7 @@ public class SchemaFileDefn {
 	String nameSpaceIdNCLC;		// no colon, lower cased
 	String nameSpaceIdNCUC;		// no colon, upper cased
 	String nameSpaceId;			// colon, lower cased
+	String nameSpaceIdNCDir;		// colon, lower cased, underscores replace by slashes, urn:esa:psa:
 	
 	// nameSpace URL
 	String nameSpaceURL;
@@ -131,6 +132,7 @@ public class SchemaFileDefn {
 		labelVersionId = "0.0";
 		stewardId = "TBD_stewardId";
 		nameSpaceIdNC = id;
+		nameSpaceIdNCDir = nameSpaceIdNC;
 		nameSpaceIdNCLC = nameSpaceIdNC.toLowerCase();
 		nameSpaceIdNCUC = nameSpaceIdNC.toUpperCase();
 		nameSpaceId = nameSpaceIdNCLC + ":";
@@ -192,6 +194,7 @@ public class SchemaFileDefn {
 		nameSpaceIdNCLC = nameSpaceIdNC.toLowerCase();
 		nameSpaceIdNCUC = nameSpaceIdNC.toUpperCase();
 		nameSpaceId = nameSpaceIdNCLC + ":";
+		nameSpaceIdNCDir = nameSpaceIdNC;
 		return;
 	}
 	
@@ -202,6 +205,9 @@ public class SchemaFileDefn {
 		modelShortName = lSchemaFileDefn.modelShortName;
 		sysBundleName = lSchemaFileDefn.sysBundleName;
 		regAuthId = lSchemaFileDefn.regAuthId;
+		if (urnPrefix.compareTo("urn:esa:psa:") == 0) {
+			nameSpaceIdNCDir = nameSpaceIdNCDir.replace('_','/');
+		}
 		return;
 	}
 	

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
@@ -277,12 +277,13 @@ class WriteDOMSchematron extends Object {
 			// namespaces required: ldd
 			String governanceDirectory = "";
 			if (lSchemaFileDefn.isMission && ! DMDocument.disciplineMissionFlag) governanceDirectory = lSchemaFileDefn.governanceLevel.toLowerCase() +  "/";
-			prSchematron.println("  <sch:ns uri=\"" + lSchemaFileDefn.nameSpaceURL + governanceDirectory + lSchemaFileDefn.nameSpaceIdNC + "/v" + lSchemaFileDefn.ns_version_id + "\" prefix=\"" + lSchemaFileDefn.nameSpaceIdNC + "\"/>");
+			prSchematron.println("  <sch:ns uri=\"" + lSchemaFileDefn.nameSpaceURL + governanceDirectory + lSchemaFileDefn.nameSpaceIdNCDir + "/v" + lSchemaFileDefn.ns_version_id + "\" prefix=\"" + lSchemaFileDefn.nameSpaceIdNC + "\"/>");
 			// namespaces required: all other LDD discipline levels referenced; no mission level allowed
 			for (Iterator<String> i = DMDocument.LDDImportNameSpaceIdNCArr.iterator(); i.hasNext();) {
 				String lNameSpaceIdNC = (String) i.next();
 				String lVersionNSId = "TBD_lVersionNSId";
 				String lNameSpaceURL = "TBD_lNameSpaceURL";
+				String lNameSpaceIdNCDIR = "TBD_lNameSpaceIdNCDIR";
 				// omit this LDD schema file's namespace; namespace used as targetNamespace above
 				if (lNameSpaceIdNC.compareTo(lSchemaFileDefn.nameSpaceIdNC) == 0) continue;
 				
@@ -291,6 +292,7 @@ class WriteDOMSchematron extends Object {
 				if (lSchemaFileDefnExternal != null) {
 					lVersionNSId = lSchemaFileDefnExternal.ns_version_id;
 					lNameSpaceURL = lSchemaFileDefnExternal.nameSpaceURL;
+					lNameSpaceIdNCDIR = lSchemaFileDefnExternal.nameSpaceIdNCDir;
 				} else {
 					
 					// next try config.properties
@@ -298,13 +300,15 @@ class WriteDOMSchematron extends Object {
 					if (lSchemaFileDefnExternal != null) {
 						lVersionNSId = lSchemaFileDefnExternal.ns_version_id;
 						lNameSpaceURL = lSchemaFileDefnExternal.nameSpaceURL;
+						lNameSpaceIdNCDIR = lSchemaFileDefnExternal.nameSpaceIdNCDir;
 					} else {
 						lVersionNSId = DMDocument.masterPDSSchemaFileDefn.ns_version_id;
 						lNameSpaceURL = DMDocument.masterPDSSchemaFileDefn.nameSpaceURL;
+						lNameSpaceIdNCDIR = DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNCDir;
 						DMDocument.registerMessage ("1>warning " + "config.properties file entry is missing for namespace id:" + lNameSpaceIdNC);
 					}
 				}
-				prSchematron.println("  <sch:ns uri=\"" + lNameSpaceURL + lNameSpaceIdNC + "/v" + lVersionNSId + "\" prefix=\"" + lNameSpaceIdNC + "\"/>");
+				prSchematron.println("  <sch:ns uri=\"" + lNameSpaceURL + lNameSpaceIdNCDIR + "/v" + lVersionNSId + "\" prefix=\"" + lNameSpaceIdNC + "\"/>");
 			}
 		}
 	}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/XML4LabelSchemaDOM.java
@@ -271,17 +271,16 @@ class XML4LabelSchemaDOM extends Object {
 		// write namespace statements
 		if (lSchemaFileDefn.nameSpaceIdNC.compareTo(DMDocument.masterNameSpaceIdNCLC) == 0) {
 			// namespaces required: pds - latest version
-			prXML.println("    targetNamespace=\"" + lSchemaFileDefn.nameSpaceURL + lSchemaFileDefn.nameSpaceIdNC + "/v" + lSchemaFileDefn.ns_version_id + "\"");
-			prXML.println("    xmlns:" + lSchemaFileDefn.nameSpaceIdNC + "=\"" + lSchemaFileDefn.nameSpaceURL + lSchemaFileDefn.nameSpaceIdNC + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id + "\"");
+			prXML.println("    targetNamespace=\"" + lSchemaFileDefn.nameSpaceURL + lSchemaFileDefn.nameSpaceIdNCDir + "/v" + lSchemaFileDefn.ns_version_id + "\"");
+			prXML.println("    xmlns:" + lSchemaFileDefn.nameSpaceIdNC + "=\"" + lSchemaFileDefn.nameSpaceURL + lSchemaFileDefn.nameSpaceIdNCDir + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id + "\"");
 		} else {
 			// namespaces required: ldd - latest version
 			String governanceDirectory = "";
 			if (lSchemaFileDefn.isMission && ! DMDocument.disciplineMissionFlag) governanceDirectory = lSchemaFileDefn.governanceLevel.toLowerCase() +  "/";
-			prXML.println("    targetNamespace=\"" + lSchemaFileDefn.nameSpaceURL + governanceDirectory + lSchemaFileDefn.nameSpaceIdNC + "/v" + lSchemaFileDefn.ns_version_id + "\"");
-			prXML.println("    xmlns:" + lSchemaFileDefn.nameSpaceIdNC + "=\"" + lSchemaFileDefn.nameSpaceURL + governanceDirectory + lSchemaFileDefn.nameSpaceIdNC + "/v" + lSchemaFileDefn.ns_version_id + "\"");
+			prXML.println("    targetNamespace=\"" + lSchemaFileDefn.nameSpaceURL + governanceDirectory + lSchemaFileDefn.nameSpaceIdNCDir + "/v" + lSchemaFileDefn.ns_version_id + "\"");
+			prXML.println("    xmlns:" + lSchemaFileDefn.nameSpaceIdNC + "=\"" + lSchemaFileDefn.nameSpaceURL + governanceDirectory + lSchemaFileDefn.nameSpaceIdNCDir + "/v" + lSchemaFileDefn.ns_version_id + "\"");
 
 			// namespaces required: pds - latest version
-//			prXML.println("    xmlns:" + lSchemaFileDefn.nameSpaceIdNC + "=\"" + lSchemaFileDefn.nameSpaceURL + lSchemaFileDefn.nameSpaceIdNC + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id + "\"");
 			prXML.println("    xmlns:" + DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC + "=\"" + DMDocument.masterPDSSchemaFileDefn.nameSpaceURL + DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id + "\"");
 
 			// namespaces required: all other discipline levels referenced; no mission level allowed
@@ -290,6 +289,7 @@ class XML4LabelSchemaDOM extends Object {
 					String lNameSpaceIdNC = (String) i.next();
 					String lVersionNSId = "TBD_lVersionNSId";
 					String lNameSpaceURL = "TBD_lNameSpaceURL";
+					String lNameSpaceIdNCDIR = "TBD_lNameSpaceIdNCDIR";
 					
 					// omit this LDD schema file's namespace; namespace used as targetNamespace above
 					if (lNameSpaceIdNC.compareTo(lSchemaFileDefn.nameSpaceIdNC) == 0) continue;
@@ -299,6 +299,7 @@ class XML4LabelSchemaDOM extends Object {
 					if (lSchemaFileDefnExternal != null) {
 						lVersionNSId = lSchemaFileDefnExternal.ns_version_id;
 						lNameSpaceURL = lSchemaFileDefnExternal.nameSpaceURL;
+						lNameSpaceIdNCDIR = lSchemaFileDefnExternal.nameSpaceIdNCDir;
 					} else {
 						
 						// next try config.properties
@@ -306,13 +307,15 @@ class XML4LabelSchemaDOM extends Object {
 						if (lSchemaFileDefnExternal != null) {
 							lVersionNSId = lSchemaFileDefnExternal.ns_version_id;
 							lNameSpaceURL = lSchemaFileDefnExternal.nameSpaceURL;
+							lNameSpaceIdNCDIR = lSchemaFileDefnExternal.nameSpaceIdNCDir;
 						} else {
 							lVersionNSId = DMDocument.masterPDSSchemaFileDefn.ns_version_id;
 							lNameSpaceURL = DMDocument.masterPDSSchemaFileDefn.nameSpaceURL;
+							lNameSpaceIdNCDIR = DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNCDir;
 							DMDocument.registerMessage ("1>warning " + "config.properties file entry is missing for namespace id:" + lNameSpaceIdNC);
 						}
 					}
-					prXML.println("    xmlns:" + lNameSpaceIdNC + "=\"" + lNameSpaceURL + lNameSpaceIdNC + "/v" + lVersionNSId + "\"");
+					prXML.println("    xmlns:" + lNameSpaceIdNC + "=\"" + lNameSpaceURL + lNameSpaceIdNCDIR + "/v" + lVersionNSId + "\"");
 				}
 			}
 		}
@@ -329,6 +332,7 @@ class XML4LabelSchemaDOM extends Object {
 			// imports required: all other LDD discipline levels referenced; no mission level allowed
 			for (Iterator<String> i = DMDocument.LDDImportNameSpaceIdNCArr.iterator(); i.hasNext();) {
 				String lNameSpaceIdNC = (String) i.next();
+				String lNameSpaceIdNCDIR = "TBD_lNameSpaceIdNCDIR";
 				if (lNameSpaceIdNC.compareTo(DMDocument.masterLDDSchemaFileDefn.nameSpaceIdNCLC) == 0) continue;
 				
 				// get info for XML schema namespace declaration; first try LDD 
@@ -339,11 +343,11 @@ class XML4LabelSchemaDOM extends Object {
 						lLDDSchemaFileDefn = DMDocument.masterPDSSchemaFileDefn;
 					}
 				}
-				
+				lNameSpaceIdNCDIR = lLDDSchemaFileDefn.nameSpaceIdNCDir;
 				String lSchemaLocationFileName2 = "TBD_lSchemaLocation";
 				if (lLDDSchemaFileDefn != null) lSchemaLocationFileName2 = lLDDSchemaFileDefn.relativeFileNameXMLSchema2;
-				prXML.println("    <" + pNS + "import namespace=\"" + lLDDSchemaFileDefn.nameSpaceURL + lNameSpaceIdNC + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id
-						+ "\" schemaLocation=\"" + lLDDSchemaFileDefn.nameSpaceURLs + lNameSpaceIdNC + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id + "/" + lSchemaLocationFileName2 + "\"/>");
+				prXML.println("    <" + pNS + "import namespace=\"" + lLDDSchemaFileDefn.nameSpaceURL + lNameSpaceIdNCDIR + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id
+						+ "\" schemaLocation=\"" + lLDDSchemaFileDefn.nameSpaceURLs + lNameSpaceIdNCDIR + "/v" + DMDocument.masterPDSSchemaFileDefn.ns_version_id + "/" + lSchemaLocationFileName2 + "\"/>");						
 			}
 		}
 		


### PR DESCRIPTION
Issue #507 : Bug generating BepiColombo SERENA dictionary

LDDTool creates namespaces using the namespace id as defined in the Ingest_LDD file. However for PSA namespaces, the namespace id needs to be converted from a single string, to a list of directories. For example the namespace id "bc_mpo_srn" must be replaced with "bc/mpo/srn" for use in the namespace.

		http://psa.esa.int/psa/bc/mpo/srn/v1
		 - instead of - 
		http://psa.esa.int/psa/bc_mpo_srn/v1 

Resolves #507

Testing: See attached zip.
input files: Ingest_PDS4_PSA_BC_MPO_SRN_1000.xml
output files:PDS4_BC_MPO_SRN_1J00_1000.xsd
                  PDS4_BC_MPO_SRN_1J00_1000.sch


[Issue507.zip](https://github.com/NASA-PDS/pds4-information-model/files/9687281/Issue507.zip)
