### PR TITLE
Issue #580 : LDDTool not including permissible value in DD DocBook file.

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMAttr.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMAttr.java
@@ -96,6 +96,7 @@ public class DOMAttr extends ISOClassOAIS11179 {
   boolean isExposed; // the attribute is to be exposed in XML Schema - i.e., defined using
                      // xs:Element
   boolean isAssociatedExternalAttr; // the attribute was defined using DD_Associate_External_Class
+  boolean isExtendedAttribute; 	// indicate that attribute was defined using getAttributesExternal
 
   DOMProp hasDOMPropInverse; // the owning DOMProp of this Class
   ArrayList<DOMProp> domPermValueArr;
@@ -191,6 +192,7 @@ public class DOMAttr extends ISOClassOAIS11179 {
     isCharDataType = true;
     isExposed = false;
     isAssociatedExternalAttr = false; // the attribute was defined using DD_Associate_External_Class
+	isExtendedAttribute = false;
 
     hasDOMPropInverse = null;
     domPermValueArr = new ArrayList<>();


### PR DESCRIPTION
LDDTool is not including permissible value in the Data Dictionary DocBook file. The problem only occurs with Type_List style Ingest_LDDs. The problem had not yet appeared in any PDS LDDs but was found in a different project using the same software.

Resolves #580

