### PR TITLE
Issue #467 : Add flags to support generation of TTL/OWL files 

### DIFF
--- a/model-dmdocument/pom.xml
+++ b/model-dmdocument/pom.xml
@@ -174,6 +174,14 @@
             <artifactId>javax.json-api</artifactId>
             <version>1.1.4</version>
         </dependency>
+        
+		<!-- https://mvnrepository.com/artifact/com.googlecode.json-simple/json-simple -->
+		<dependency>
+    		<groupId>com.googlecode.json-simple</groupId>
+    		<artifactId>json-simple</artifactId>
+    		<version>1.1.1</version>
+		</dependency>
+
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ClassAttrPropClassification.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ClassAttrPropClassification.java
@@ -1,0 +1,657 @@
+// Copyright 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+// * Neither the name of Caltech nor its operating division, the Jet Propulsion
+// Laboratory, nor the names of its contributors may be used to endorse or
+// promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package gov.nasa.pds.model.plugin; 
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.TreeMap;
+
+public class ClassAttrPropClassification {
+	
+	// Class properties
+	TreeMap <String, ClassPropertiesOWL> classPropertiesIdOWLMap = new TreeMap <String, ClassPropertiesOWL> ();
+	TreeMap <String, String> classTitleAliasMap = new TreeMap <String, String> ();
+	ArrayList <String> nameSpaceIdNCArr = new ArrayList <String>  ();
+	static String masterNameSpaceIdNC = "TBD_masterNameSpaceIdNC";
+	
+	ArrayList <ClassPropertiesOWL> classPropertiesOWLDebugArr = new ArrayList <ClassPropertiesOWL> ();
+	
+	// Relationship Properties
+	ArrayList <RelationshipProperties> relationshipPropertiesArr = new ArrayList <RelationshipProperties> ();
+
+	// all selected classes and all selected class identifiers
+	ArrayList <String> selectedClassIdArr = new ArrayList <String> ();
+	ArrayList <DOMClass> selectedClassArr = new ArrayList <DOMClass> ();
+	
+	TreeMap <String, String> relNameToClassNameMap  = new TreeMap <String, String> ();
+
+	// Constructor - Initialize ClassAttrPropClassification based on input indicator
+	public ClassAttrPropClassification (String lClassificationId) {
+			
+		if (lClassificationId.compareTo("PDS4.All.Products.Class.Prop") == 0) {
+//			System.out.println("\ndebug ClassAttrPropClassification - PDS4.All.Products.Class.Prop");
+			// get All Products, Classes, and Properties for OWL/TTL		
+//			getAllPropertiesForSelectedClasses ("pds", setPDS4ProductsClassPropTitles_All_Small(), true);
+			getAllPropertiesForSelectedClasses ("pds", setPDS4ProductsClassPropTitles_All(), true);
+		} else if (lClassificationId.compareTo("PDS4.LDD.All") == 0) {
+			// get all class from a stack of LDDs	
+			getPDS4LDDAll ();
+		} else if (lClassificationId.compareTo("TNDO_Identified") == 0) {
+			// get all Tagged Non_Digital Object (Context)	
+			getTNDOIdentified ();
+		} else if (lClassificationId.compareTo("EIMEntity") == 0) {
+			// get EIM Entities 	
+//			getEIMEntity ("eim");
+			getAllPropertiesForSelectedClasses ("eim", setEIMEnityTitles(), true);
+		} else if (lClassificationId.compareTo("OAISIF") == 0) {
+//			System.out.println("\ndebug ClassAttrPropClassification - OAISIF");
+			// get OAIS-IF entities	
+			getAllPropertiesForSelectedClasses ("oais", setOAISIFProductPropTitles (), true);
+//			getOAISIF ("oais");
+		}
+		
+		// get relational properties of classes - owned and inherited associations.
+// 220518		getRelationships (lClassificationId);   // inits getRelationships -  used by WriteDOMRDFTTLFilePDS4 - duplicate of lClassProperties.getProperties(lSelectedClass)
+		
+		// set up aliases
+		classTitleAliasMap.put("product_data_object", "has_Data_Object");
+	}
+	
+	
+	// start of classification types - each has its own selection code
+	public boolean getAllPropertiesForSelectedClasses (String nameSpaceId, ArrayList <String> selectedClassesTitleArr, boolean isRecursive) {
+
+		// set the master namespace for the TTL file; used by WriteDOMRDFTTLFile
+		masterNameSpaceIdNC = nameSpaceId;
+		
+		// get the initial selected class titles
+		ArrayList <DOMClass> initialDOMClassesArr = getInitialDOMClassesArr(nameSpaceId, selectedClassesTitleArr);
+
+		// from the initial DOMClasses get all DOMClasses - the union of initial as well as member DOMClasses
+		selectedClassArr.addAll(initialDOMClassesArr);
+		for (DOMClass lDOMClass : initialDOMClassesArr) {
+			getMemberOfMembersDOMClassesArr (lDOMClass, 0);
+		}
+		
+		// get the class properties
+		for (DOMClass lDOMClass : selectedClassArr) {
+//			getClassProperties (lDOMClass, new ArrayList <String> (), 0);
+			getClassProperties (lDOMClass);
+		}
+		
+		if (selectedClassArr.size() > 0) return true;
+		return false;
+	}	
+
+	// get the members of members DOMClasses
+	public void getMemberOfMembersDOMClassesArr(DOMClass lDOMClass, int count) {
+//		if (count < 1) System.out.println("");
+//		System.out.println("debug -------START-----count:" + count + "--" + lDOMClass.identifier + "_start");
+
+		for (DOMClass lMemberfDOMClass : getMembersOfDOMClassArr(lDOMClass)) {
+			if (lMemberfDOMClass.isInactive) continue;
+			if (lMemberfDOMClass.isDeprecated) continue;
+			if (! selectedClassIdArr.contains(lMemberfDOMClass.identifier)) {
+				selectedClassIdArr.add(lMemberfDOMClass.identifier);
+				selectedClassArr.add(lMemberfDOMClass);
+				getMemberOfMembersDOMClassesArr(lMemberfDOMClass, count++);
+			}
+		}
+//		System.out.println("debug -------END-----count:" + count + "--" + lDOMClass.identifier + "_end");
+		return;
+	}
+
+	// get all member DOMClasses from a single DOMClass
+	public ArrayList <DOMClass> getMembersOfDOMClassArr (DOMClass lDOMClass) {
+		ArrayList <DOMClass> memberDOMClassesArr = new ArrayList <DOMClass> ();
+		ArrayList <String> memberDOMClassesIdArr = new ArrayList <String> ();
+		ArrayList <DOMProp> allAssocArr = new ArrayList <DOMProp> ();
+		if (lDOMClass.ownedAssocArr != null && lDOMClass.ownedAssocArr.size() > 0) allAssocArr.addAll(lDOMClass.ownedAssocArr);
+		if (lDOMClass.inheritedAssocArr != null && lDOMClass.inheritedAssocArr.size() > 0) allAssocArr.addAll(lDOMClass.inheritedAssocArr);
+		if (allAssocArr != null && allAssocArr.size() > 0) {
+			for (DOMProp lDOMProp : allAssocArr) {
+				if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMClass) {					
+					DOMClass lDOMMemberClass = (DOMClass) lDOMProp.hasDOMObject;
+					if (! memberDOMClassesIdArr.contains(lDOMMemberClass.identifier)) {
+						memberDOMClassesIdArr.add(lDOMMemberClass.identifier);
+						memberDOMClassesArr.add(lDOMMemberClass);
+					}
+				}
+			}
+		}
+		return memberDOMClassesArr;
+	}
+	
+	// get the initial DOMClasses from the Class title array
+	public ArrayList <DOMClass> getInitialDOMClassesArr (String nameSpaceId, ArrayList <String> lClassesTitleArr) {
+		ArrayList <DOMClass> initialDOMClassesArr = new ArrayList <DOMClass> ();
+		for (String lClassTitle : lClassesTitleArr) {
+			DOMClass lDOMClass = getClassFromClassTitle (nameSpaceId, lClassTitle);
+			if (lDOMClass != null)
+				initialDOMClassesArr.add(getClassFromClassTitle (nameSpaceId, lClassTitle));
+			else
+				System.out.println("ERROR - Failed find selected class -ClassAttrPropClassification- lClassTitle:" + lClassTitle);
+		}
+		return initialDOMClassesArr;
+	}
+	
+	// get the DOMClass from the Class title
+	public DOMClass getClassFromClassTitle (String nameSpaceId, String lClassTitle) {
+		return getClassFromClassId (DOMInfoModel.getClassIdentifier(nameSpaceId, lClassTitle));
+	}	
+	
+	// get the DOMClass from the Class Identifier
+	public DOMClass getClassFromClassId (String lClassId) {
+
+		// get the class from the master DOM CLass Identifier Map
+		DOMClass lSelectedClass = DOMInfoModel.masterDOMClassIdMap.get(lClassId);
+		if (lSelectedClass != null) {
+			if (lSelectedClass.isInactive) return null;
+			if (lSelectedClass.isDeprecated) return null;
+			return lSelectedClass;
+
+		} else {
+			System.out.println("ERROR - Failed to find selected class -  lClassId:" + lClassId);
+		}
+		return null;
+	}
+	
+	// get the class properties
+	public boolean getClassProperties (DOMClass lDOMClass) {
+//		System.out.println("debug getClassProperties lDOMClass.identifier:" + lDOMClass.identifier);
+
+		// create the Class Properties OWL class
+		ClassPropertiesOWL lClassPropertiesOWL = new ClassPropertiesOWL (lDOMClass);
+		
+		// add to the maps; duplicates are overridden
+		classPropertiesIdOWLMap.put(lClassPropertiesOWL.identifier, lClassPropertiesOWL);
+		
+		// collect new namespaces for RDF namespace declarations
+		if (! nameSpaceIdNCArr.contains(lClassPropertiesOWL.nameSpaceIdNC))
+			nameSpaceIdNCArr.add(lClassPropertiesOWL.nameSpaceIdNC);
+				
+		// initialize the Class Property Class Array - ClassPropertiesOWL.theClassPropClassArr
+		lClassPropertiesOWL.getAssociatedClasses(lDOMClass);
+				
+		// initialize the Class Property Attribute Array - ClassPropertiesOWL.theClassPropAttrArr
+		lClassPropertiesOWL.getAssociatedAttributes(lDOMClass);
+				
+		// get the class subclass of relationship
+		lClassPropertiesOWL.getSubClassOf (lDOMClass);
+								
+		// initialize the components Of Class Array - ClassPropertiesOWL.componentOfClassArr
+		// same as getAssociatedClasses but creates new ClassPropertiesOWL for each component class
+		getAssociatedClassesPlus (lClassPropertiesOWL, lDOMClass);
+
+		return true;
+	}
+	
+	// get classes associated with the selected class; create new ClassPropertiesOWL
+	public void getAssociatedClassesPlus (ClassPropertiesOWL lSelectedClassPropertiesOWL, DOMClass lSelectedClass) {
+
+		// scan for all associated classes of the selected class
+		ArrayList <DOMProp> allAssocArr = new ArrayList <DOMProp> ();
+		if (lSelectedClass.ownedAssocArr != null && lSelectedClass.ownedAssocArr.size() > 0) allAssocArr.addAll(lSelectedClass.ownedAssocArr);
+		if (lSelectedClass.inheritedAssocArr != null && lSelectedClass.inheritedAssocArr.size() > 0) allAssocArr.addAll(lSelectedClass.inheritedAssocArr);
+		if (allAssocArr != null && allAssocArr.size() > 0) {
+			for (Iterator <DOMProp> j = allAssocArr.iterator(); j.hasNext();) {
+				DOMProp lDOMProp = (DOMProp) j.next();
+				if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMClass) {					
+					DOMClass lDOMMemberClass = (DOMClass) lDOMProp.hasDOMObject;
+					if (lDOMMemberClass.isInactive) continue;
+					if (lDOMMemberClass.isDeprecated) continue;
+					
+					// create the Class Properties OWL class
+					ClassPropertiesOWL lClassPropertiesOWL = new ClassPropertiesOWL (lDOMMemberClass);
+					lSelectedClassPropertiesOWL.theComponentOfClassArr.add(lClassPropertiesOWL);
+					
+					// debug
+					classPropertiesOWLDebugArr.add(lClassPropertiesOWL);
+					
+					// add to the maps, not needed since we recurse down the associated member classes in each parent class
+					// classPropertiesIdOWLMap.put(lClassPropertiesOWL.identifier, lClassPropertiesOWL);
+
+					// collect new namespaces for RDF namespace declarations
+					if (! nameSpaceIdNCArr.contains(lClassPropertiesOWL.nameSpaceIdNC))
+						nameSpaceIdNCArr.add(lClassPropertiesOWL.nameSpaceIdNC);
+					
+					// init the class properties array
+					lClassPropertiesOWL.getAssociatedClasses(lDOMMemberClass); //  used by WriteNeo4J - duplicate of getRelationships (lClassificationId);
+
+					// init the class attribute array
+					lClassPropertiesOWL.getAssociatedAttributes(lDOMMemberClass);
+					
+					// get the class subclass of relationship
+					lClassPropertiesOWL.getSubClassOf (lDOMMemberClass);
+				}
+			}
+		}
+		return;
+	}
+	
+	public ArrayList <String> setPDS4ProductsClassPropTitles_All_Small () {
+		ArrayList <String> selectedClassesTitleArr = new ArrayList <String> ();
+		selectedClassesTitleArr.add ("Agency");
+		selectedClassesTitleArr.add ("Context_Area");
+//		selectedClassesTitleArr.add ("Product_Collection");
+		return selectedClassesTitleArr;
+	}	
+	
+	public ArrayList <String> setPDS4ProductsClassPropTitles_All () {
+		ArrayList <String> selectedClassesTitleArr = new ArrayList <String> ();
+		selectedClassesTitleArr.add ("Product_Context");
+		selectedClassesTitleArr.add ("Agency");
+		selectedClassesTitleArr.add ("Airborne");
+		selectedClassesTitleArr.add ("Facility");
+		selectedClassesTitleArr.add ("Instrument");
+		selectedClassesTitleArr.add ("Instrument_Host");
+		selectedClassesTitleArr.add ("Investigation");
+		selectedClassesTitleArr.add ("Node");
+		selectedClassesTitleArr.add ("Other");
+		selectedClassesTitleArr.add ("PDS_Affiliate");
+		selectedClassesTitleArr.add ("PDS_Guest");
+		selectedClassesTitleArr.add ("Resource");
+		selectedClassesTitleArr.add ("Target");
+		selectedClassesTitleArr.add ("Telescope");
+		selectedClassesTitleArr.add ("Observing_System");
+//		selectedClassesTitleArr.add ("Service");
+//		selectedClassesTitleArr.add ("Product_AIP");
+		selectedClassesTitleArr.add ("Product_Ancillary");
+//		selectedClassesTitleArr.add ("Product_Attribute_Definition");
+		selectedClassesTitleArr.add ("Product_Browse");
+		selectedClassesTitleArr.add ("Product_Bundle");
+//		selectedClassesTitleArr.add ("Product_Class_Definition");
+		selectedClassesTitleArr.add ("Product_Collection");
+		selectedClassesTitleArr.add ("Product_Context");
+//		selectedClassesTitleArr.add ("Product_DIP");
+//		selectedClassesTitleArr.add ("Product_DIP_Deep_Archive");
+//		selectedClassesTitleArr.add ("Product_Data_Set_PDS3");
+		selectedClassesTitleArr.add ("Product_Document");
+		selectedClassesTitleArr.add ("Product_File_Repository");
+		selectedClassesTitleArr.add ("Product_File_Text");
+//		selectedClassesTitleArr.add ("Product_Instrument_Host_PDS3");
+//		selectedClassesTitleArr.add ("Product_Instrument_PDS3");
+		selectedClassesTitleArr.add ("Product_Metadata_Supplemental");
+//		selectedClassesTitleArr.add ("Product_Mission_PDS3");
+//		selectedClassesTitleArr.add ("Product_Native");
+		selectedClassesTitleArr.add ("Product_Observational");
+//		selectedClassesTitleArr.add ("Product_Proxy_PDS3");
+//		selectedClassesTitleArr.add ("Product_SIP");
+//		selectedClassesTitleArr.add ("Product_SIP_Deep_Archive");
+		selectedClassesTitleArr.add ("Product_SPICE_Kernel");
+//		selectedClassesTitleArr.add ("Product_Service");
+//		selectedClassesTitleArr.add ("Product_Software");
+//		selectedClassesTitleArr.add ("Product_Subscription_PDS3");
+//		selectedClassesTitleArr.add ("Product_Target_PDS3");
+		selectedClassesTitleArr.add ("Product_Thumbnail");
+//		selectedClassesTitleArr.add ("Product_Update");
+//		selectedClassesTitleArr.add ("Product_Volume_PDS3");
+//		selectedClassesTitleArr.add ("Product_Volume_Set_PDS3");
+		selectedClassesTitleArr.add ("Product_XML_Schema");
+//		selectedClassesTitleArr.add ("Product_Zipped");
+		selectedClassesTitleArr.add ("Ingest_LDD");
+		return selectedClassesTitleArr;
+	}
+	
+	public ArrayList <String> setPDS4ProductsClassPropTitles_Allxxx () {
+		ArrayList <String> selectedClassesTitleArr = new ArrayList <String> ();
+		selectedClassesTitleArr.add ("Product_Context");
+		selectedClassesTitleArr.add ("Agency");
+		selectedClassesTitleArr.add ("Airborne");
+		selectedClassesTitleArr.add ("Facility");
+		selectedClassesTitleArr.add ("Instrument");
+		selectedClassesTitleArr.add ("Instrument_Host");
+		selectedClassesTitleArr.add ("Investigation");
+		selectedClassesTitleArr.add ("Node");
+		selectedClassesTitleArr.add ("Other");
+		selectedClassesTitleArr.add ("PDS_Affiliate");
+		selectedClassesTitleArr.add ("PDS_Guest");
+		selectedClassesTitleArr.add ("Resource");
+		selectedClassesTitleArr.add ("Target");
+		selectedClassesTitleArr.add ("Telescope");
+		selectedClassesTitleArr.add ("Observing_System");
+		selectedClassesTitleArr.add ("Service");
+		selectedClassesTitleArr.add ("Product_AIP");
+		selectedClassesTitleArr.add ("Product_Ancillary");
+		selectedClassesTitleArr.add ("Product_Attribute_Definition");
+		selectedClassesTitleArr.add ("Product_Browse");
+		selectedClassesTitleArr.add ("Product_Bundle");
+		selectedClassesTitleArr.add ("Product_Class_Definition");
+		selectedClassesTitleArr.add ("Product_Collection");
+		selectedClassesTitleArr.add ("Product_Context");
+		selectedClassesTitleArr.add ("Product_DIP");
+		selectedClassesTitleArr.add ("Product_DIP_Deep_Archive");
+		selectedClassesTitleArr.add ("Product_Data_Set_PDS3");
+		selectedClassesTitleArr.add ("Product_Document");
+		selectedClassesTitleArr.add ("Product_File_Repository");
+		selectedClassesTitleArr.add ("Product_File_Text");
+		selectedClassesTitleArr.add ("Product_Instrument_Host_PDS3");
+		selectedClassesTitleArr.add ("Product_Instrument_PDS3");
+		selectedClassesTitleArr.add ("Product_Metadata_Supplemental");
+		selectedClassesTitleArr.add ("Product_Mission_PDS3");
+		selectedClassesTitleArr.add ("Product_Native");
+		selectedClassesTitleArr.add ("Product_Observational");
+		selectedClassesTitleArr.add ("Product_Proxy_PDS3");
+		selectedClassesTitleArr.add ("Product_SIP");
+		selectedClassesTitleArr.add ("Product_SIP_Deep_Archive");
+		selectedClassesTitleArr.add ("Product_SPICE_Kernel");
+		selectedClassesTitleArr.add ("Product_Service");
+		selectedClassesTitleArr.add ("Product_Software");
+		selectedClassesTitleArr.add ("Product_Subscription_PDS3");
+		selectedClassesTitleArr.add ("Product_Target_PDS3");
+		selectedClassesTitleArr.add ("Product_Thumbnail");
+		selectedClassesTitleArr.add ("Product_Update");
+		selectedClassesTitleArr.add ("Product_Volume_PDS3");
+		selectedClassesTitleArr.add ("Product_Volume_Set_PDS3");
+		selectedClassesTitleArr.add ("Product_XML_Schema");
+		selectedClassesTitleArr.add ("Product_Zipped");
+		selectedClassesTitleArr.add ("Ingest_LDD");
+		return selectedClassesTitleArr;
+	}
+	
+	// start of classification types - each has its own selection code
+	public ArrayList <String>  setOAISIFProductPropTitles () {
+		ArrayList <String> selectedClassesTitleArr = new ArrayList <String> ();
+		selectedClassesTitleArr.add ("Information_Object");
+		selectedClassesTitleArr.add ("Access_Rights_Information");
+		selectedClassesTitleArr.add ("Content_Information");
+		selectedClassesTitleArr.add ("Context_Information");
+		selectedClassesTitleArr.add ("Fixity_Information");
+		selectedClassesTitleArr.add ("Packaged_Information");
+		selectedClassesTitleArr.add ("Provenance_Information");
+		selectedClassesTitleArr.add ("Reference_Information");
+		selectedClassesTitleArr.add ("Representation_Information");
+		selectedClassesTitleArr.add ("Preservation_Description_Information");
+		selectedClassesTitleArr.add ("Archival_Information_Package");
+		selectedClassesTitleArr.add ("Dissemination_Information_Package");
+		selectedClassesTitleArr.add ("Submission_Information_Package");
+		selectedClassesTitleArr.add ("Data_Object");
+		selectedClassesTitleArr.add ("Content_Data_Object");
+		selectedClassesTitleArr.add ("Semantic_Information");
+		selectedClassesTitleArr.add ("Structure_Information");
+		return selectedClassesTitleArr;
+	}	
+	
+	// start of classification types - each has its own selection code
+	public ArrayList <String>  setEIMEnityTitles () {
+		ArrayList <String> selectedClassesTitleArr = new ArrayList <String> ();
+		selectedClassesTitleArr.add ("Entity");
+		selectedClassesTitleArr.add ("Artifact");
+		selectedClassesTitleArr.add ("Authority");
+		selectedClassesTitleArr.add ("BillOfMaterials");
+		selectedClassesTitleArr.add ("Costs");
+		selectedClassesTitleArr.add ("Domain");
+		selectedClassesTitleArr.add ("Facility");
+		selectedClassesTitleArr.add ("Format");
+		selectedClassesTitleArr.add ("Hardware");
+		selectedClassesTitleArr.add ("Instrument");
+		selectedClassesTitleArr.add ("Instrument_Host");
+		selectedClassesTitleArr.add ("Investigation");
+		selectedClassesTitleArr.add ("Mission");
+		selectedClassesTitleArr.add ("Organization");
+		selectedClassesTitleArr.add ("Person");
+		selectedClassesTitleArr.add ("Research");
+		selectedClassesTitleArr.add ("Role");
+		selectedClassesTitleArr.add ("Service");
+		selectedClassesTitleArr.add ("Work_Activity");
+		selectedClassesTitleArr.add ("Vendor");
+		selectedClassesTitleArr.add ("Model");
+		selectedClassesTitleArr.add ("Data");
+		selectedClassesTitleArr.add ("Document");
+		selectedClassesTitleArr.add ("Project");
+		selectedClassesTitleArr.add ("Task");
+		return selectedClassesTitleArr;
+	}
+	
+	// **********************************************************************************************
+	//	Everything below here needs conversion to getAllPropertiesForSelectedClasses
+	// **********************************************************************************************
+	
+	// everything
+	public boolean getPDS4LDDAll () {
+		// classes to be selected are identified.
+		int classCount = 0;
+		for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
+			DOMClass lSelectedClass = (DOMClass) i.next();	
+			if (lSelectedClass.isInactive) continue;
+			if ((lSelectedClass.isUSERClass || lSelectedClass.isVacuous)) continue;
+			if (lSelectedClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue;
+			if ((lSelectedClass.isUnitOfMeasure || lSelectedClass.isDataType)) continue;
+			if (lSelectedClass.isDeprecated) continue;
+			
+//			System.out.println("debug getPDS4LDDAll lSelectedClass.identifier:" + lSelectedClass.identifier);
+			
+			// a class selected for processing; create a ClassProperties class
+			selectedClassArr.add(lSelectedClass);
+//			if (classCount++ > 250) { break; };
+		}
+		
+		if (selectedClassArr.size() > 0) return true;
+		return false;
+	}
+	
+	// start of classification types - each has its own selecion code
+	public boolean getTNDOIdentified () {
+		// classes to be selected are identified by title.
+		ArrayList <String> selectedClassesTitleArr = new ArrayList <String> ();
+		selectedClassesTitleArr.add ("TNDO_Identified");
+		selectedClassesTitleArr.add ("Campaign");
+		selectedClassesTitleArr.add ("Invoice");
+		selectedClassesTitleArr.add ("Person");
+		selectedClassesTitleArr.add ("Site");
+		selectedClassesTitleArr.add ("Treatment");
+		selectedClassesTitleArr.add ("Designer");
+		selectedClassesTitleArr.add ("Doctor");
+		selectedClassesTitleArr.add ("Patient");
+		selectedClassesTitleArr.add ("Laboratory");
+		selectedClassesTitleArr.add ("Office");
+
+		
+		// using the titles get the DOMClass
+		for (Iterator<String> i = selectedClassesTitleArr.iterator(); i.hasNext();) {
+			String lClassName = (String) i.next();
+			String lClassId = DOMInfoModel.getClassIdentifier("pds", lClassName);
+			DOMClass lSelectedClass = DOMInfoModel.masterDOMClassIdMap.get(lClassId);
+			if (lSelectedClass != null) {
+				if (lSelectedClass.isInactive) continue;
+				// get the class properties
+				selectedClassArr.add (lSelectedClass);
+			}
+		}
+		if (selectedClassArr.size() > 0) return true;
+		return false;
+	}	
+	
+	// start of classification types - each has its own selecion code
+	// *** deprecate ***
+	public boolean getEIMEntity (String namespaceid) {
+		// classes to be selected are identified by title.
+		ArrayList <String> selectedClassesTitleArr = new ArrayList <String> ();
+		
+		  selectedClassesTitleArr.add ("Entity");
+		  selectedClassesTitleArr.add ("Artifact");
+		  selectedClassesTitleArr.add ("Authority");
+		  selectedClassesTitleArr.add ("BillOfMaterials");
+		  selectedClassesTitleArr.add ("Costs");
+		  selectedClassesTitleArr.add ("Domain");
+		  selectedClassesTitleArr.add ("Facility");
+		  selectedClassesTitleArr.add ("Format");
+		  selectedClassesTitleArr.add ("Hardware");
+		  selectedClassesTitleArr.add ("Instrument");
+		  selectedClassesTitleArr.add ("Instrument_Host");
+		  selectedClassesTitleArr.add ("Investigation");
+		  selectedClassesTitleArr.add ("Mission_Objective");
+		  selectedClassesTitleArr.add ("Mission_PerformingElement"); 
+		  selectedClassesTitleArr.add ("Mission_Product");
+		  selectedClassesTitleArr.add ("Organization");
+		  selectedClassesTitleArr.add ("People");
+		  selectedClassesTitleArr.add ("Research");
+		  selectedClassesTitleArr.add ("Role");
+		  selectedClassesTitleArr.add ("Service");
+		  selectedClassesTitleArr.add ("Work_Activity");
+		
+		// using the titles get the DOMClass
+		for (Iterator<String> i = selectedClassesTitleArr.iterator(); i.hasNext();) {
+			String lClassName = (String) i.next();
+//			String lClassId = DOMInfoModel.getClassIdentifier("eim", lClassName);
+			String lClassId = DOMInfoModel.getClassIdentifier(namespaceid, lClassName);
+			DOMClass lSelectedClass = DOMInfoModel.masterDOMClassIdMap.get(lClassId);
+			if (lSelectedClass != null) {
+				if (lSelectedClass.isInactive) continue;
+				// get the class properties
+				selectedClassArr.add (lSelectedClass);
+			}
+		}
+		if (selectedClassArr.size() > 0) return true;
+		return false;
+	}
+	
+	public boolean getPDS4ClassesAll () {
+		int classCount = 0;
+		for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
+			DOMClass lClass = (DOMClass) i.next();	
+			if (lClass.isInactive) continue;
+			if ((lClass.isUSERClass || lClass.isVacuous)) continue;
+			if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue;
+			if ((lClass.isUnitOfMeasure || lClass.isDataType)) continue;
+			if (lClass.isDeprecated) continue;
+			selectedClassArr.add(lClass);
+//			if (classCount++ > 250) { break; };
+		}
+		if (selectedClassArr.size() > 0) return true;
+		return false;
+	}	
+	
+	// for Context products, get the values of reference_type for Internal_Reference {Reference_List, ...}
+	// *** to be continued ***
+	public void getRelationships (String lClassificationId) {
+		if (lClassificationId.compareTo("PDS4.All.Products.Class.Prop") == 0) {
+			getRelationshipsPDS4AllProductsClassProp();
+		} else if (lClassificationId.compareTo("PDS4.LDD.All") == 0) {
+			getRelationshipsPDS4AllProductsClassProp();
+			getRelationshipsFromOwnedAssoc();
+		}  else if (lClassificationId.compareTo("OAISIF") == 0) {
+//			getRelationshipsFromOwnedAssoc();
+		}
+	}	
+	
+	// the relationships defined using Internal_Reference
+	public void getRelationshipsPDS4AllProductsClassProp () {
+		for (Iterator <DOMRule> i = DOMInfoModel.masterDOMRuleArr.iterator(); i.hasNext();) {
+			DOMRule lDOMRule = (DOMRule) i.next();
+			if (lDOMRule.xpath.indexOf("Internal_Reference") < 0) continue;
+			for (Iterator <DOMAssert> j = lDOMRule.assertArr.iterator(); j.hasNext();) {
+				DOMAssert lAssert = (DOMAssert) j.next();	
+				for (Iterator<String> k = lAssert.testValArr.iterator(); k.hasNext();) {
+					String lTestValueString = (String) k.next();
+					RelationshipProperties lRelationshipProperties = new RelationshipProperties (lTestValueString, classPropertiesIdOWLMap);					
+					if (lRelationshipProperties.lidvid != null) {
+						relationshipPropertiesArr.add(lRelationshipProperties);
+
+					}
+				}
+			}
+		}
+	}		
+
+	// get the relationships defined in the IM (owned associations)
+	public void getRelationshipsFromOwnedAssoc () {
+	for (Iterator <DOMClass> i = selectedClassArr.iterator(); i.hasNext();) {
+			DOMClass lDOMClass = (DOMClass) i.next();
+			
+			// change to allow both owned and inherited associated components to be included
+			ArrayList <DOMProp> allAssocArr = new ArrayList <DOMProp> ();
+			if (lDOMClass.ownedAssocArr != null && lDOMClass.ownedAssocArr.size() > 0) allAssocArr.addAll(lDOMClass.ownedAssocArr);
+			if (lDOMClass.inheritedAssocArr != null && lDOMClass.inheritedAssocArr.size() > 0) allAssocArr.addAll(lDOMClass.inheritedAssocArr);
+			if (allAssocArr != null && allAssocArr.size() > 0) {
+				for (Iterator <DOMProp> j = allAssocArr.iterator(); j.hasNext();) {
+					DOMProp lDOMProp = (DOMProp) j.next();
+					if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMClass) {					
+						DOMClass lDOMMemberClass = (DOMClass) lDOMProp.hasDOMObject;
+						RelationshipProperties lRelationshipProperties = new RelationshipProperties (lDOMClass, lDOMProp, lDOMMemberClass, classPropertiesIdOWLMap);					
+						if (lRelationshipProperties.lidvid != null) {
+							relationshipPropertiesArr.add(lRelationshipProperties);
+						}
+					}
+				}
+			}
+		}
+	}
+	
+// ======= public procedures =======
+	
+	
+	// get the master namespace
+	static public String getMasterNameSpaceIdNC () {
+		return masterNameSpaceIdNC;
+	}
+	
+	public ArrayList <DOMClass> getSelectedClassArr () {
+		if (selectedClassArr.size() > 0) return selectedClassArr;
+		return null;
+	}
+	
+	// get classProperties
+	public ArrayList <ClassPropertiesOWL> getClassPropertiesOWL () {
+		ArrayList <ClassPropertiesOWL> classPropertiesOWLArr = new ArrayList <ClassPropertiesOWL> (classPropertiesIdOWLMap.values());
+		return classPropertiesOWLArr;
+	}
+	
+	
+	// get a classProperties
+	public ClassPropertiesOWL getClassPropertyOWL (String identifier) {
+		ClassPropertiesOWL lClassPropertiesOWL = classPropertiesIdOWLMap.get(identifier);
+		return lClassPropertiesOWL;
+	}
+	
+	// get Relationship Properties
+	public ArrayList <RelationshipProperties> getRelationshipProperties () {
+		return relationshipPropertiesArr;
+	}
+		
+	// get alias
+	public String getTitleAlias (String lTitle) {
+		String lAlias = classTitleAliasMap.get(lTitle);
+		if (lAlias == null) lAlias = lTitle;
+		return lAlias;
+	}
+	
+	// dump ClassAttrPropClassification
+	public  void dump (int id) {
+		ArrayList <ClassPropertiesOWL> lClassPropertiesOWLArr = getClassPropertiesOWL ();
+		ArrayList <String> lClassPropertyIdArr = new ArrayList <String> ();
+		for (ClassPropertiesOWL lClassPropertiesOWL: lClassPropertiesOWLArr) {
+			lClassPropertyIdArr.add(lClassPropertiesOWL.identifier);
+		}
+//		System.out.println("debug ClassAttrPropClassification - Dump:" + id + " -  lClassPropertyIdArr:" + lClassPropertyIdArr);
+	}
+
+}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ClassPropAttr.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ClassPropAttr.java
@@ -1,0 +1,43 @@
+// Copyright 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+// * Neither the name of Caltech nor its operating division, the Jet Propulsion
+// Laboratory, nor the names of its contributors may be used to endorse or
+// promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package gov.nasa.pds.model.plugin; 
+
+class ClassPropAttr extends Object{
+	DOMClass fromClass;
+	DOMAttr toAttr;
+	DOMProp property;	
+	
+	public ClassPropAttr (DOMClass lFromClass, DOMProp lProperty, DOMAttr lToAttr) {
+		fromClass = lFromClass;
+		toAttr = lToAttr;
+		property = lProperty;
+	}
+}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ClassPropClass.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ClassPropClass.java
@@ -1,0 +1,43 @@
+// Copyright 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+// * Neither the name of Caltech nor its operating division, the Jet Propulsion
+// Laboratory, nor the names of its contributors may be used to endorse or
+// promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package gov.nasa.pds.model.plugin; 
+
+class ClassPropClass extends Object{
+	DOMClass fromClass;
+	DOMClass toClass;
+	DOMProp property;	
+	
+	public ClassPropClass (DOMClass lFromClass, DOMProp lProperty, DOMClass lToClass) {
+		fromClass = lFromClass;
+		toClass = lToClass;
+		property = lProperty;
+	}
+}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ClassPropertiesBase.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ClassPropertiesBase.java
@@ -1,0 +1,113 @@
+// Copyright 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+// * Neither the name of Caltech nor its operating division, the Jet Propulsion
+// Laboratory, nor the names of its contributors may be used to endorse or
+// promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package gov.nasa.pds.model.plugin;
+
+// class properties
+class ClassPropertiesBase extends Object{
+	
+	static final String lidPrefix = "";
+	static final String prodIdPrefix = "0001_NASA_PDS_1:";
+	static final String datatypePropertyAttributeOf = "<http://ontology.pds.nasa.gov/pds/0001_nasa_pds_1/attributeof>";
+	static final String objectPropertyComponentOf = "<http://ontology.pds.nasa.gov/pds/urn/nasa/pds/0001_nasa_pds_1/componentof>";
+	static final String objectPropertyComponentOfP1 = "0001_nasa_pds_1-pds-componentof";
+	static final String objectPropertySubclassPrefix = "0001_nasa_pds_1";
+	
+	String iri;
+	String lidvid;
+	String lid;
+	String vid = "1.x";
+	String identifier;		// Class properties identifier not Class identifier; 
+	String versionId;
+	String rdfIdentifier;
+	String nameSpaceIdNC;
+	String title;
+	String type;
+	String definition;
+	String subClassOfTitle;	
+	DOMClass theClass;
+	
+	// flag for oaisif (fuseki - no slashs in LIDVID) vs pds4 (graphdb - slashes)
+	static boolean isFuseki = false;
+
+	public ClassPropertiesBase () {
+		iri = "TBD_iri";
+		identifier = "TBD_identifier";
+		versionId = "TBD_versionId";
+		rdfIdentifier = "TBD_rdfIdentifier";
+		nameSpaceIdNC = "TBD_nameSpaceIdNCr";
+		title = "TBD_title";  													
+		type = "TBD_type";  													
+		definition = "TBD_definition";
+		subClassOfTitle = "TBD_subClassOfTitle";
+	}
+	
+	// Format the iri
+	static public String formValueIRI(String lString) {
+		String stringCleaned = formValue(lString).toLowerCase();
+		if (! isFuseki) {
+			stringCleaned = DOMInfoModel.replaceString (stringCleaned, ":", "/");
+		}		
+		stringCleaned = "<http://ontology.pds.nasa.gov/pds/" + stringCleaned + ">";
+		return stringCleaned;
+	}
+	
+	// Format the LID and LIDVID
+	static public String formValueLID(String lString) {
+		String stringLower = formValue(lString).toLowerCase();
+		String stringCleaned = DOMInfoModel.replaceString (stringLower, "::", "-v");		
+		return stringCleaned;
+	}	
+	
+	// Format the string
+	static public String formValue(String lString) {
+		String rString = lString;
+		if (rString == null) rString = "null";
+		if (rString.indexOf("TBD") == 0) rString = "null";
+		rString = escapeTTLChar(rString);
+		return rString;
+	}
+	
+	static String escapeTTLChar (String aString) {
+		if (aString == null) return "TBD_string";
+		String lString = aString;
+		lString = DOMInfoModel.replaceString (lString, "'", "\\'");  
+		lString = DOMInfoModel.replaceString (lString, "\"", "\\\"");  
+//		lString = DOMInfoModel.replaceString (lString, "\\", "\\\\");  // escape of backslash must be first
+//		lString = DOMInfoModel.replaceString (lString, "\"", "\\\"");
+//		lString = DOMInfoModel.replaceString (lString, "/", "\\/");
+//		lString = DOMInfoModel.replaceString (lString, "\b", "\\b");
+//		lString = DOMInfoModel.replaceString (lString, "\f", "\\f");
+//		lString = DOMInfoModel.replaceString (lString, "\n", "\\n");
+//		lString = DOMInfoModel.replaceString (lString, "\r", "\\r");
+//		lString = DOMInfoModel.replaceString (lString, "\t", "\\t");
+		return lString;
+	}
+}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ClassPropertiesOWL.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ClassPropertiesOWL.java
@@ -1,0 +1,192 @@
+// Copyright 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+// * Neither the name of Caltech nor its operating division, the Jet Propulsion
+// Laboratory, nor the names of its contributors may be used to endorse or
+// promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package gov.nasa.pds.model.plugin; 
+
+import java.util.ArrayList;
+import java.util.Iterator;
+
+// class properties
+class ClassPropertiesOWL extends ClassPropertiesBase{
+
+	DOMClass subClassOf;
+	String subClassOfTitle;
+	String subClassOfNameSpaceIdNC;
+	String subClassOfID;
+	String subClassOfLID;
+	String subClassOfLIDVID;
+	String subClassOfIRI;
+	String subClassOf2Title;
+	String subClassOf2NameSpaceIdNC;
+							
+//	String sequenceId;							
+//	DOMClass theClass;
+	ClassPropClass theClassSubClassOf = null;
+	ArrayList <ClassPropClass> theClassPropClassArr = new ArrayList <ClassPropClass> ();
+	ArrayList <ClassPropAttr> theClassPropAttrArr = new ArrayList <ClassPropAttr> ();
+	ArrayList <ClassPropertiesOWL> theComponentOfClassArr = new ArrayList <ClassPropertiesOWL> ();
+	
+	// Constructor - for regular classes
+	public ClassPropertiesOWL (DOMClass lClass) {
+		
+		// set the class attributes including the subclass; specifically subClassOfLIDVID
+		identifier = lClass.identifier + "_" + DOMInfoModel.getNextUId();
+		versionId = lClass.versionId;
+		theClass = lClass;
+		theClass.identifier = lClass.identifier;
+		rdfIdentifier = lClass.rdfIdentifier;
+		nameSpaceIdNC = lClass.nameSpaceIdNC;
+		title = formValue(lClass.title);  													
+		type = "TBD_type";
+		subClassOfTitle = "TBD_subClassOfTitle";
+		subClassOfNameSpaceIdNC = "TBD_subClassOfNameSpaceIdNC";
+		subClassOfID = "TBD_subClassOfID";
+		subClassOfLID = "TBD_subClassOfLID";
+		subClassOfLIDVID = "TBD_subClassOfLIDVID";
+		subClassOfIRI = "TBD_subClassOfIRI";
+		subClassOf2Title = "TBD_subClassOf2Title";	// the title of the subClassOf of the subClassOf
+		subClassOf2NameSpaceIdNC = "TBD_subClassO2fNameSpaceIdNC";
+		definition = formValue(lClass.definition);
+		
+		// get the subClassOf
+		subClassOf = DOMInfoModel.masterDOMUserClass; // Default
+		if (lClass.subClassOf != null) subClassOf = lClass.subClassOf;
+		subClassOfTitle = formValue(subClassOf.title);
+		subClassOfNameSpaceIdNC = subClassOf.nameSpaceIdNC;
+		subClassOfID = subClassOf.identifier;
+		
+		// get the subClassOf of the subClassOf; needed for subclass LID
+		DOMClass lSubClassOf2 = DOMInfoModel.masterDOMUserClass; // Default
+		if (subClassOf.subClassOf != null) {
+			lSubClassOf2 = subClassOf.subClassOf;
+		}
+		subClassOf2Title = formValue(lSubClassOf2.title);
+		subClassOf2NameSpaceIdNC = lSubClassOf2.nameSpaceIdNC;
+		
+		// get the subClassOf LID and LIDVID
+		String lSubClassOfLID = lidPrefix + prodIdPrefix + subClassOf2NameSpaceIdNC + ":" + subClassOf2Title + ":" + subClassOfNameSpaceIdNC + ":" + subClassOfTitle;
+		if (subClassOf2Title.compareTo(subClassOfTitle) == 0) {   // check for user:user:
+			lSubClassOfLID = lidPrefix + prodIdPrefix + subClassOfNameSpaceIdNC + ":" + subClassOfTitle;
+		} 
+		subClassOfLID = formValueLID(lSubClassOfLID);
+		subClassOfLIDVID = formValueLID(lSubClassOfLID + "::" + vid);
+		subClassOfIRI = formValueIRI(lSubClassOfLID);
+
+		// get the class LID and LIDVID
+		lid = formValueLID(lidPrefix + prodIdPrefix + subClassOfNameSpaceIdNC + ":" + subClassOfTitle + ":" + nameSpaceIdNC + ":"+ lClass.title);
+		lidvid = formValueLID(lid + "::" + vid);
+		iri = formValueIRI(lid);
+		return;
+	}
+
+	// Constructor - for permissible values
+	public ClassPropertiesOWL (DOMPermValDefn lDOMPermVal, ClassPropertiesOWL lClassProperties) {
+		identifier = lClassProperties.theClass.identifier + "." + lDOMPermVal.value + "_" + DOMInfoModel.getNextUId();
+		nameSpaceIdNC = lClassProperties.nameSpaceIdNC;
+		type = "TBD_type";
+		subClassOfTitle = formValue(lClassProperties.title);
+		subClassOfID = lClassProperties.theClass.identifier;
+		subClassOfLIDVID = lClassProperties.lidvid;
+		title = formValue(lDOMPermVal.value);  													
+		definition = formValue(lDOMPermVal.value_meaning);
+		String lSubClassName = formValue(lDOMPermVal.value.toLowerCase());
+		lSubClassName = DOMInfoModel.replaceString (lSubClassName, " ", "_");
+		lid = formValueLID(lClassProperties.lid + lSubClassName);
+		lidvid = formValueLID(lid + "::" + vid);
+		iri = formValueIRI(lid);
+		return;
+	}
+	
+	// get generalization relationship
+	public void getSubClassOf (DOMClass lDOMClass) {
+		ClassPropClass lClassPropClass;
+		if (lDOMClass.subClassOf != null) {
+			DOMClass lSuperClass = lDOMClass.subClassOf;
+			lClassPropClass = new ClassPropClass (lDOMClass, null, lSuperClass);
+		} else {
+			lClassPropClass = new ClassPropClass (lDOMClass, null, null);
+		}
+		theClassSubClassOf = lClassPropClass;
+		return;
+	}	
+	
+	// get the class's associated attributes; initialize the Class Property Attribute Array - theClassPropAttrArr
+	public void getAssociatedAttributes (DOMClass lDOMClass) {
+		// change to allow both owned and inherited associated components to be included
+		ArrayList <DOMProp> allAttrArr = new ArrayList <DOMProp> ();
+		if (lDOMClass.ownedAttrArr != null && lDOMClass.ownedAttrArr.size() > 0) allAttrArr.addAll(lDOMClass.ownedAttrArr);
+		if (lDOMClass.inheritedAttrArr != null && lDOMClass.inheritedAttrArr.size() > 0) allAttrArr.addAll(lDOMClass.inheritedAttrArr);
+		if (allAttrArr != null && allAttrArr.size() > 0) {
+			for (Iterator<DOMProp> j = allAttrArr.iterator(); j.hasNext();) {
+				DOMProp lDOMProp = (DOMProp) j.next();
+				if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMAttr) {
+					DOMAttr lDOMAttr = (DOMAttr) lDOMProp.hasDOMObject;
+					ClassPropAttr lClassPropClass = new ClassPropAttr (lDOMClass, lDOMProp, lDOMAttr);
+					theClassPropAttrArr.add(lClassPropClass);
+				}
+			}
+		}
+		return;
+	}
+	
+	// get the class's associated component classes; initialize the Class Property Class Array - theClassPropClassArr
+	public void getAssociatedClasses (DOMClass lDOMClass) {
+		// change to allow both owned and inherited associated components to be included
+		ArrayList <DOMProp> allAssocArr = new ArrayList <DOMProp> ();
+		if (lDOMClass.ownedAssocArr != null && lDOMClass.ownedAssocArr.size() > 0) allAssocArr.addAll(lDOMClass.ownedAssocArr);
+		if (lDOMClass.inheritedAssocArr != null && lDOMClass.inheritedAssocArr.size() > 0) allAssocArr.addAll(lDOMClass.inheritedAssocArr);
+		if (allAssocArr != null && allAssocArr.size() > 0) {
+			for (Iterator<DOMProp> j = allAssocArr.iterator(); j.hasNext();) {
+				DOMProp lDOMProp = (DOMProp) j.next();
+				if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMClass) {
+					DOMClass lMethodClass = (DOMClass) lDOMProp.hasDOMObject;
+					ClassPropClass lClassPropClass = new ClassPropClass (lDOMClass, lDOMProp, lMethodClass);
+					theClassPropClassArr.add(lClassPropClass);
+				}
+			}
+		}
+		return;
+	}
+	
+	// get the ClassPropClassArr
+	public ArrayList <ClassPropClass> getTheClassPropClassArr () {
+		return theClassPropClassArr;
+	}
+	
+	// get the ClassPropAttrArr
+	public ArrayList <ClassPropAttr> getTheClassPropAttrArr () {
+		return theClassPropAttrArr;
+	}
+	
+	// get the ClassPropAttrArr
+	public ArrayList <ClassPropertiesOWL> getTheComponentOfClassArr () {
+		return theComponentOfClassArr;
+	}
+}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -178,8 +178,11 @@ public class DMDocument extends Object {
   static boolean exportJSONFileAllFlag = false; // LDDTool, set by -6 option
   static boolean exportSpecFileFlag = false;
   static boolean exportDDFileFlag = false;
-  static boolean importJSONAttrFlag = false; // non PDS processing - not currently used
+  static boolean exportTermMapFileFlag = false;
   static boolean exportOWLFileFlag = false;
+  static boolean exportCustomFileFlag = false;
+  
+  static boolean importJSONAttrFlag = false; // non PDS processing - not currently used
   static boolean pds4ModelFlag = false; // set in config.properties files (read by WriteDOMDocBook
                                         // to exclude PDS3 from generated DD)
   static boolean printNamespaceFlag = false; // print the configured namespaces to the log
@@ -1490,25 +1493,20 @@ public class DMDocument extends Object {
      * .action(Arguments.storeTrue()) .help("Element Definition (Attribute)");
      */
 
-    parser.addArgument("-1", "--IM Spec").dest("1").type(Boolean.class).nargs(1)
-        .action(Arguments.storeTrue()).help("Write the Information Model Specification for an LDD");
+	parser.addArgument("-1", "--IM Spec").dest("1").type(Boolean.class).nargs(1)
+        .action(Arguments.storeTrue())
+        .help("Write the Information Model Specification for an LDD");
+	
+    parser.addArgument("-T", "--TermMap").dest("T").type(Boolean.class).nargs(1)
+        .action(Arguments.storeTrue()).help("Terminological mapping to alternate names");
 
-    // The following are hidden and temporarily deprecated
+    parser.addArgument("-O", "--OWL") .dest("O") .type(Boolean.class) .nargs(1)
+        .action(Arguments.storeTrue()) .help("OWL/RDF output in TTL format");
 
-    /*
-     * parser.addArgument("-4", "--Import JSON") .dest("4") .type(Boolean.class) .nargs(1)
-     * .action(Arguments.storeTrue()) .help("Import JSON Attribute File");
-     */
+    parser.addArgument("-C", "--Custom") .dest("C") .type(Boolean.class) .nargs(1)
+        .action(Arguments.storeTrue()) .help("Customized processing and reporting");
 
-    /*
-     * parser.addArgument("-5", "--Export OWL") .dest("5") .type(Boolean.class) .nargs(1)
-     * .action(Arguments.storeTrue()) .help("Export OWL File");
-     */
-
-    /*
-     * parser.addArgument("-6", "--Export JSON All") .dest("6") .type(Boolean.class) .nargs(1)
-     * .action(Arguments.storeTrue()) .help("Export JSON Attribute File - All");
-     */
+     // The following are hidden and temporarily deprecated
 
     /*
      * parser.addArgument("-f", "--Check") .dest("f") .type(Boolean.class) .nargs(1)
@@ -1654,18 +1652,22 @@ public class DMDocument extends Object {
       dmProcessState.setexportSpecFileFlag();
       exportSpecFileFlag = true;
     }
-    /*
-     * Boolean n4Flag = ns.getBoolean("4"); if (n4Flag) { dmProcessState.setimportJSONAttrFlag ();
-     * importJSONAttrFlag = true; }
-     */
-    /*
-     * Boolean n5Flag = ns.getBoolean("5"); if (n5Flag) { dmProcessState.setexportOWLFileFlag ();
-     * exportOWLFileFlag = true; }
-     */
-    /*
-     * Boolean n6Flag = ns.getBoolean("6"); if (n6Flag) { dmProcessState.setexportJSONFileAllFlag
-     * (); exportJSONFileAllFlag = true; }
-     */
+    Boolean TFlag = ns.getBoolean("T");
+    if (TFlag) {
+    	dmProcessState.setExportTermMapFileFlag ();
+    	exportTermMapFileFlag = true;
+    }
+    Boolean OFlag = ns.getBoolean("O");
+    if (OFlag) {
+    	dmProcessState.setExportOWLFileFlag ();
+    	exportOWLFileFlag = true;
+   	}
+    Boolean CFlag = ns.getBoolean("C");
+    if (CFlag) {
+    	dmProcessState.setExportCustomFileFlag();
+    	exportCustomFileFlag = true;
+    }
+
     /*
      * Boolean fFlag = ns.getBoolean("f"); if (fFlag) { dmProcessState.setcheckFileNameFlag (); }
      */

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMProcessState.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMProcessState.java
@@ -375,7 +375,21 @@ public class DMProcessState {
     processFlagMap.put("Check File Name Flag", 1210);
     return;
   }
+  
+  public void setExportTermMapFileFlag() {
+	  processFlagMap.put("ExportTermMapFileFlag", 1220);
+	  return;
+  }
+	        
+  public void setExportOWLFileFlag() {
+     processFlagMap.put("ExportOWLFileFlag", 1230);
+     return;
+  }
 
+  public void setExportCustomFileFlag() {
+      processFlagMap.put("ExportCustomFileFlag", 1240);
+      return;
+  }  
 
   // written files map
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModels.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModels.java
@@ -101,24 +101,11 @@ public class ExportModels extends Object {
     writeDOM11179DDRDFFile.printISO11179DDRDF(DMDocument.sTodaysDate);
     DMDocument.registerMessage("0>info " + "writeAllArtifacts - RDF Done");
 
-    // write the IM to RDF
-    // WriteDOMIMToRDF lWriteDOMIMToRDF = new WriteDOMIMToRDF ();
-    // lWriteDOMIMToRDF.domIMToRDFWriter (DMDocument.sTodaysDate);
-
-    // write the Lucid Ingest file
-    // WriteLucidMySQLFiles WriteLucidFiles = new WriteLucidMySQLFiles ();
-    // WriteLucidFiles.WriteLucidFile();
-
     // write the DOM PDS4 DD CSV file
     WriteDOMCSVFiles writeDOMCSVFiles = new WriteDOMCSVFiles();
     ArrayList<DOMClass> domSortClassArr = new ArrayList<>(DOMInfoModel.masterDOMClassMap.values());
     writeDOMCSVFiles.writeDOMCSVFile(domSortClassArr, DMDocument.masterPDSSchemaFileDefn, null);
     DMDocument.registerMessage("0>info " + "writeAllArtifacts - DD CSV Done");
-
-    // write the PDS4 CCSDS CSV file
-    // WriteDocCSV writeDocCSV = new WriteDocCSV ();
-    // writeDocCSV.writeDocCSV (DMDocument.masterPDSSchemaFileDefn);
-    // DMDocument.registerMessage ("0>info " + "writeAllArtifacts - CCSDS CSV Done");
 
     // write the 11179 DD pins file
     // WriteDOM11179DDPinsFile lWriteDOM11179DDPinsFile = new WriteDOM11179DDPinsFile ();
@@ -161,29 +148,21 @@ public class ExportModels extends Object {
         DMDocument.masterPDSSchemaFileDefn, DMDocument.sTodaysDate);
     DMDocument.registerMessage("0>info " + "writeAllDOMArtifacts - DOM Class Defn Done");
     DMDocument.registerMessage("0>info " + "writeAllDOMArtifacts - DOM Attr Defn Done");
+    
+	
+	// write the RDF/TTL file
+	String lClassificationType = "TBD_default";   // default
+	lClassificationType = "";   // default
+	lClassificationType = "PDS4.All.Products.Class.Prop"; // works
+//	lClassificationType = "EIMEntity";   // works
+//	lClassificationType = "PDS4.LDD.All";   
+//	lClassificationType = "OAISIF";
+	ClassAttrPropClassification lCAPC = new ClassAttrPropClassification (lClassificationType);
+	DMDocument.dmProcessState.setRelativeFileSpecSKOSTTL_DOM (DMDocument.masterPDSSchemaFileDefn);
+	WriteDOMRDFTTLFile writeDOMRDFTTLFile = new WriteDOMRDFTTLFile ();
+	writeDOMRDFTTLFile.writeDOMRDFTTLFile (lClassificationType, lCAPC);
+	DMDocument.registerMessage ("0>info " + "ExportModels - RDF/TTL Done");
 
-    // write the registry configuration files *** Reg needs conversion.
-    if (false) {
-      RegConfig regConfig = new RegConfig();
-      regConfig.writeRegRIM(DMDocument.sTodaysDate);
-      regConfig.writeRegRIM3(DMDocument.sTodaysDate);
-      regConfig.writeRegRIM4(DMDocument.sTodaysDate);
-    }
-    DMDocument.registerMessage("0>info " + "writeAllArtifacts - Regisry Config Done");
-
-    // write the standard id extract file
-    WriteDOMStandardIdExtract writeDOMStandardIdExtract = new WriteDOMStandardIdExtract();
-    writeDOMStandardIdExtract.writeExtractFile();
-    DMDocument.registerMessage("0>info " + "writeAllArtifacts - Standard Id Done");
-
-    // print out the histogram for the DEC concepts
-    /*
-     * System.out.println("\nConcept Histogram"); Set <String> set1 =
-     * MasterDOMInfoModel.metricConceptMap.keySet(); Iterator <String> iter1 = set1.iterator();
-     * while(iter1.hasNext()) { String lId = (String) iter1.next(); Integer lCount =
-     * MasterDOMInfoModel.metricConceptMap.get(lId); System.out.println("Descriptor: " + lId +
-     * "    Count: " + lCount); }
-     */
     return;
   }
 
@@ -217,9 +196,11 @@ public class ExportModels extends Object {
     }
 
     // write the custom files
-    // ExportModelsCustom lExportModelsCustom = new ExportModelsCustom ();
-    // lExportModelsCustom.writeArtifacts (DMDocument.LDDToolFlag,
-    // DMDocument.masterLDDSchemaFileDefn);
+    if (DMDocument.exportCustomFileFlag) {
+    	ExportModelsCustom lExportModelsCustom = new ExportModelsCustom ();
+    	lExportModelsCustom.writeArtifacts (DMDocument.LDDToolFlag,
+    			DMDocument.masterLDDSchemaFileDefn);
+    }
 
     // write the schema - new version 4
     DMDocument.dmProcessState.setRelativeFileSpecXMLSchema(DMDocument.masterLDDSchemaFileDefn);
@@ -261,6 +242,17 @@ public class ExportModels extends Object {
       writeDOMSpecification.printArtifacts();
       DMDocument.registerMessage("0>info " + "writeLDDArtifacts - Info Model Spec Done");
     }
+	
+	// write the RDF/TTL file
+	String lClassificationType = "TBD_default";   // default
+	lClassificationType = "";   // default
+	lClassificationType = ("PDS4.LDD.All");
+	DMDocument.dmProcessState.setRelativeFileSpecSKOSTTL_DOM (DMDocument.masterLDDSchemaFileDefn);
+	ClassAttrPropClassification lCAPC = new ClassAttrPropClassification (lClassificationType);
+	WriteDOMRDFTTLFile writeDOMRDFTTLFile = new WriteDOMRDFTTLFile ();
+	writeDOMRDFTTLFile.writeDOMRDFTTLFile (lClassificationType, lCAPC);
+	DMDocument.registerMessage ("0>info " + "ExportModelsCustom - RDF/TTL Done");
+
     return;
   }
 }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModels.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModels.java
@@ -92,9 +92,9 @@ public class ExportModels extends Object {
     DMDocument.registerMessage("0>info " + "writeAllArtifacts - DD DocBook Done");
 
     // write the custom files
-    // ExportModelsCustom lExportModelsCustom = new ExportModelsCustom ();
-    // lExportModelsCustom.writeArtifacts (DMDocument.LDDToolFlag,
-    // DMDocument.masterPDSSchemaFileDefn);
+    ExportModelsCustom lExportModelsCustom = new ExportModelsCustom ();
+    lExportModelsCustom.writeArtifacts (DMDocument.LDDToolFlag,
+        DMDocument.masterPDSSchemaFileDefn);
 
     // write the DOM RDF
     WriteDOM11179DDRDFFile writeDOM11179DDRDFFile = new WriteDOM11179DDRDFFile();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModelsCustom.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModelsCustom.java
@@ -32,13 +32,13 @@ package gov.nasa.pds.model.plugin;
 
 import java.util.*;
 
-/** Driver for getting document
+/** Driver for Customized Document Writers
  *
  */
 public class ExportModelsCustom extends Object {
 	
 	public ExportModelsCustom () {
-		
+		// noop
 	}
 
 /**********************************************************************************************************
@@ -50,27 +50,69 @@ public class ExportModelsCustom extends Object {
 						
 		// need to pass SchemaFileDefn to get namespace; set static for now.
 		// SchemaFileDefn lSchemaFileDefn;
-		String lNameSpaceIdNC = "pds";
 		
+//		System.out.println("debug ExportModelsCustom lLDDToolFlag:" + lLDDToolFlag);
+//		System.out.println("debug ExportModelsCustom DMDocument.exportDDFileFlag:" + DMDocument.exportDDFileFlag);
+//		System.out.println("debug ExportModelsCustom DMDocument.exportCustomFileFlag:" + DMDocument.exportCustomFileFlag);
 		
 		// write the doc book files - one per namespace id
 		if (lLDDToolFlag) {
-			if (DMDocument.exportDDFileFlag) {	
-				
-				System.out.println ("debug *** lWriteDOMDocBooks ***");
-				
+			if (DMDocument.exportDDFileFlag) {
 				DMDocument.dmProcessState.setRelativeFileSpecDDDocXML (DMDocument.masterLDDSchemaFileDefn);
-				WriteDOMDocBooks lWriteDOMDocBooks  = new WriteDOMDocBooks (); 
+				WriteDOMDocBookAnon lWriteDOMDocBooks  = new WriteDOMDocBookAnon (); 
 				lWriteDOMDocBooks.writeDocBooks(DMDocument.masterPDSSchemaFileDefn);
 				DMDocument.registerMessage ("0>info " + "writeLDDArtifacts - DD DocBooks - One Per LDD -  Done");
 			}
 		}
 		
+		// write the Terminological Mapping defined in the TermMap LDD to JSON
+		if (lLDDToolFlag) {
+			if (DMDocument.exportTermMapFileFlag) {
+				// write the terminological entry files
+				WriteDOMTermEntryJSON writeDOMTermEntryJSON = new WriteDOMTermEntryJSON ();
+				writeDOMTermEntryJSON.WriteDOMTermEntries (DMDocument.masterPDSSchemaFileDefn);
+				DMDocument.registerMessage ("0>info " + "WriteDOMTermEntryJSON -  Done");
+			}
+		}
+		
+	    // write the standard id extract file
+	    // WriteDOMStandardIdExtract writeDOMStandardIdExtract = new WriteDOMStandardIdExtract();
+		// writeDOMStandardIdExtract.writeExtractFile();
+		// DMDocument.registerMessage("0>info " + "writeAllArtifacts - Standard Id Done");
+		
+	    // write the registry configuration files *** Reg needs conversion.
+		//   RegConfig regConfig = new RegConfig();
+		//   regConfig.writeRegRIM(DMDocument.sTodaysDate);
+		//   regConfig.writeRegRIM3(DMDocument.sTodaysDate);
+		//   regConfig.writeRegRIM4(DMDocument.sTodaysDate);
+		// DMDocument.registerMessage("0>info " + "writeAllArtifacts - Regisry Config Done");
+		
+	    // write the IM to RDF
+	    // WriteDOMIMToRDF lWriteDOMIMToRDF = new WriteDOMIMToRDF ();
+	    // lWriteDOMIMToRDF.domIMToRDFWriter (DMDocument.sTodaysDate);
+
+	    // write the Lucid Ingest file
+	    // WriteLucidMySQLFiles WriteLucidFiles = new WriteLucidMySQLFiles ();
+	    // WriteLucidFiles.WriteLucidFile();
+
+	    // write the PDS4 CCSDS CSV file
+	    // WriteDocCSV writeDocCSV = new WriteDocCSV ();
+	    // writeDocCSV.writeDocCSV (DMDocument.masterPDSSchemaFileDefn);
+	    // DMDocument.registerMessage ("0>info " + "writeAllArtifacts - CCSDS CSV Done");
+
+	    // print out the histogram for the DEC concepts
+	    /*
+	     * System.out.println("\nConcept Histogram"); Set <String> set1 =
+	     * MasterDOMInfoModel.metricConceptMap.keySet(); Iterator <String> iter1 = set1.iterator();
+	     * while(iter1.hasNext()) { String lId = (String) iter1.next(); Integer lCount =
+	     * MasterDOMInfoModel.metricConceptMap.get(lId); System.out.println("Descriptor: " + lId +
+	     * "    Count: " + lCount); }
+	     */
+		
 		// write the new xmi file
 /*		if (! lLDDToolFlag) {
 			DMDocument.dmProcessState.setRelativeFileSpecUMLXMI (lSchemaFileDefn);
 			WriteUML25XMIFile lWriteUML25XMIFile = new WriteUML25XMIFile ();
-//			lWriteUML25XMIFile.writeXMIFile (configureClassesToWriteList_EIM_Entity_Titles (), DMDocument.sTodaysDate);
 			lWriteUML25XMIFile.writeXMIFile (configureClassesToWriteList_PDS4_Common (), DMDocument.sTodaysDate);			
 			DMDocument.registerMessage ("0>info " + "ExportModelsCustom - UML 25 XMI File - Common - Done");
 		} else {
@@ -80,34 +122,7 @@ public class ExportModelsCustom extends Object {
 			lWriteUML25XMIFile.writeXMIFile (lClassesToWrite, DMDocument.sTodaysDate);
 			DMDocument.registerMessage ("0>info " + "ExportModelsCustom - UML 25 XMI File - LDD - Done");
 		}
-		
-		// write the RDF/TTL file
-		String lClassificationType = "TBD_default";   // default
-		lClassificationType = "";   // default
-		if (! lLDDToolFlag) {
-			lClassificationType = "PDS4.All.Products.Class.Prop"; // works
-//			lClassificationType = "OAISIF";
-//			lClassificationType = "EIMEntity";   // works
-//			lClassificationType = "PDS4.LDD.All";   
-//			System.out.println("debug ExportModelsCustom lClassificationType:" + lClassificationType);
-			ClassAttrPropClassification lCAPC = new ClassAttrPropClassification (lClassificationType);
-			DMDocument.dmProcessState.setRelativeFileSpecSKOSTTL_DOM (lSchemaFileDefn);
-//			WriteDOMRDFTTLFileOAIS writeDOMRDFTTLFile = new WriteDOMRDFTTLFileOAIS ();
-//			writeDOMRDFTTLFile.writeDOMRDFTTLFile (lClassificationType, lCAPC);
-			WriteDOMRDFTTLFile writeDOMRDFTTLFile = new WriteDOMRDFTTLFile ();
-			writeDOMRDFTTLFile.writeDOMRDFTTLFile (lClassificationType, lCAPC);
-		
-		} else {
-			lClassificationType = ("PDS4.LDD.All");
-			DMDocument.dmProcessState.setRelativeFileSpecSKOSTTL_DOM (lSchemaFileDefn);
-			ClassAttrPropClassification lCAPC = new ClassAttrPropClassification (lClassificationType);
-//			WriteDOMRDFTTLFilePDS4 writeDOMRDFTTLFile = new WriteDOMRDFTTLFilePDS4 ();
-//			writeDOMRDFTTLFile.writeDOMRDFTTLFile (lClassificationType, lCAPC);
-			WriteDOMRDFTTLFile writeDOMRDFTTLFile = new WriteDOMRDFTTLFile ();
-			writeDOMRDFTTLFile.writeDOMRDFTTLFile (lClassificationType, lCAPC);
-		}
-		DMDocument.registerMessage ("0>info " + "ExportModelsCustom - RDF/TTL Done"); */
-		
+		*/
 		
 		// **** NEO4J *** write the Neo4J file
 /*		String lClassificationTypeNeo4J = "PDS4.All.Products.Class.Prop";   // default

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModelsCustom.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModelsCustom.java
@@ -1,0 +1,536 @@
+// Copyright 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+// * Neither the name of Caltech nor its operating division, the Jet Propulsion
+// Laboratory, nor the names of its contributors may be used to endorse or
+// promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package gov.nasa.pds.model.plugin;
+
+import java.util.*;
+
+/** Driver for getting document
+ *
+ */
+public class ExportModelsCustom extends Object {
+	
+	public ExportModelsCustom () {
+		
+	}
+
+/**********************************************************************************************************
+		write custom documents and files
+***********************************************************************************************************/
+
+	public void writeArtifacts (boolean lLDDToolFlag, SchemaFileDefn lSchemaFileDefn) throws java.io.IOException {	 
+		DMDocument.registerMessage ("0>info " + "ExportModelsCustom - Specification Done");
+						
+		// need to pass SchemaFileDefn to get namespace; set static for now.
+		// SchemaFileDefn lSchemaFileDefn;
+		String lNameSpaceIdNC = "pds";
+		
+		
+		// write the doc book files - one per namespace id
+		if (lLDDToolFlag) {
+			if (DMDocument.exportDDFileFlag) {	
+				
+				System.out.println ("debug *** lWriteDOMDocBooks ***");
+				
+				DMDocument.dmProcessState.setRelativeFileSpecDDDocXML (DMDocument.masterLDDSchemaFileDefn);
+				WriteDOMDocBooks lWriteDOMDocBooks  = new WriteDOMDocBooks (); 
+				lWriteDOMDocBooks.writeDocBooks(DMDocument.masterPDSSchemaFileDefn);
+				DMDocument.registerMessage ("0>info " + "writeLDDArtifacts - DD DocBooks - One Per LDD -  Done");
+			}
+		}
+		
+		// write the new xmi file
+/*		if (! lLDDToolFlag) {
+			DMDocument.dmProcessState.setRelativeFileSpecUMLXMI (lSchemaFileDefn);
+			WriteUML25XMIFile lWriteUML25XMIFile = new WriteUML25XMIFile ();
+//			lWriteUML25XMIFile.writeXMIFile (configureClassesToWriteList_EIM_Entity_Titles (), DMDocument.sTodaysDate);
+			lWriteUML25XMIFile.writeXMIFile (configureClassesToWriteList_PDS4_Common (), DMDocument.sTodaysDate);			
+			DMDocument.registerMessage ("0>info " + "ExportModelsCustom - UML 25 XMI File - Common - Done");
+		} else {
+			ArrayList <DOMClass> lClassesToWrite = configureClassesToWriteList_LDD_Proc ();
+			DMDocument.dmProcessState.setRelativeFileSpecUMLXMI (lSchemaFileDefn);
+			WriteUML25XMIFile lWriteUML25XMIFile = new WriteUML25XMIFile ();
+			lWriteUML25XMIFile.writeXMIFile (lClassesToWrite, DMDocument.sTodaysDate);
+			DMDocument.registerMessage ("0>info " + "ExportModelsCustom - UML 25 XMI File - LDD - Done");
+		}
+		
+		// write the RDF/TTL file
+		String lClassificationType = "TBD_default";   // default
+		lClassificationType = "";   // default
+		if (! lLDDToolFlag) {
+			lClassificationType = "PDS4.All.Products.Class.Prop"; // works
+//			lClassificationType = "OAISIF";
+//			lClassificationType = "EIMEntity";   // works
+//			lClassificationType = "PDS4.LDD.All";   
+//			System.out.println("debug ExportModelsCustom lClassificationType:" + lClassificationType);
+			ClassAttrPropClassification lCAPC = new ClassAttrPropClassification (lClassificationType);
+			DMDocument.dmProcessState.setRelativeFileSpecSKOSTTL_DOM (lSchemaFileDefn);
+//			WriteDOMRDFTTLFileOAIS writeDOMRDFTTLFile = new WriteDOMRDFTTLFileOAIS ();
+//			writeDOMRDFTTLFile.writeDOMRDFTTLFile (lClassificationType, lCAPC);
+			WriteDOMRDFTTLFile writeDOMRDFTTLFile = new WriteDOMRDFTTLFile ();
+			writeDOMRDFTTLFile.writeDOMRDFTTLFile (lClassificationType, lCAPC);
+		
+		} else {
+			lClassificationType = ("PDS4.LDD.All");
+			DMDocument.dmProcessState.setRelativeFileSpecSKOSTTL_DOM (lSchemaFileDefn);
+			ClassAttrPropClassification lCAPC = new ClassAttrPropClassification (lClassificationType);
+//			WriteDOMRDFTTLFilePDS4 writeDOMRDFTTLFile = new WriteDOMRDFTTLFilePDS4 ();
+//			writeDOMRDFTTLFile.writeDOMRDFTTLFile (lClassificationType, lCAPC);
+			WriteDOMRDFTTLFile writeDOMRDFTTLFile = new WriteDOMRDFTTLFile ();
+			writeDOMRDFTTLFile.writeDOMRDFTTLFile (lClassificationType, lCAPC);
+		}
+		DMDocument.registerMessage ("0>info " + "ExportModelsCustom - RDF/TTL Done"); */
+		
+		
+		// **** NEO4J *** write the Neo4J file
+/*		String lClassificationTypeNeo4J = "PDS4.All.Products.Class.Prop";   // default
+		if (! lLDDToolFlag) {
+			lClassificationTypeNeo4J = "PDS4.All.Products.Class.Prop";   // default
+//			lClassificationTypeNeo4J = "TNDO_Identified";   // default
+//			lClassificationTypeNeo4J = "EIMEntity";   // default
+//			lClassificationTypeNeo4J = "OAISIF";   // default
+			ClassAttrPropClassification lCAPC = new ClassAttrPropClassification (lClassificationTypeNeo4J);
+			DMDocument.dmProcessState.setRelativeFileSpecUMLXMI (lSchemaFileDefn);
+			WriteNeo4J lWriteNeo4J = new WriteNeo4J ();
+			lWriteNeo4J.writeNeo4JFile (lClassificationTypeNeo4J, lCAPC, DMDocument.sTodaysDate);
+			DMDocument.registerMessage ("0>info " + "ExportModelsCustom - " + lClassificationTypeNeo4J + " - Neo4J File Done");
+			
+		} else {
+			lClassificationTypeNeo4J = ("PDS4.LDD.All");
+			ClassAttrPropClassification lCAPC = new ClassAttrPropClassification (lClassificationTypeNeo4J);
+			DMDocument.dmProcessState.setRelativeFileSpecUMLXMI (lSchemaFileDefn);
+			WriteNeo4J lWriteNeo4J = new WriteNeo4J ();
+			lWriteNeo4J.writeNeo4JFile ("ObjectClassHierarchy", lCAPC, DMDocument.sTodaysDate);
+			DMDocument.registerMessage ("0>info " + "ExportModelsCustom - " + lClassificationTypeNeo4J + " - Neo4J File Done");
+		} */
+		
+		
+		// write the DOM RDF
+		/*
+		WriteDOM11179DDRDFFile writeDOM11179DDRDFFile = new WriteDOM11179DDRDFFile ();
+		writeDOM11179DDRDFFile.printISO11179DDRDF (DMDocument.sTodaysDate);
+		DMDocument.registerMessage ("0>info " + "ExportModelsCustom - RDF Done");
+		*/
+		
+		// write the IM to RDF
+		/*
+		WriteDOMIMToRDF lWriteDOMIMToRDF = new WriteDOMIMToRDF ();
+		lWriteDOMIMToRDF.domIMToRDFWriter (DMDocument.sTodaysDate);
+		*/
+		
+		// write the Lucid Ingest file
+		/*
+		WriteLucidMySQLFiles WriteLucidFiles = new WriteLucidMySQLFiles ();
+		WriteLucidFiles.WriteLucidFile();
+		*/
+		
+		// write the terminological entry files
+/*		WriteDOMTermEntryJSON writeDOMTermEntryJSON = new WriteDOMTermEntryJSON ();
+		writeDOMTermEntryJSON.WriteDOMTermEntries (DMDocument.masterPDSSchemaFileDefn);
+		DMDocument.registerMessage ("0>info " + "WriteDOMTermEntryJSON -  Done"); */
+
+		
+		// write the PDS4 CCSDS CSV file 
+		/*
+		WriteDocCSV writeDocCSV = new WriteDocCSV ();
+		writeDocCSV.writeDocCSV (DMDocument.masterPDSSchemaFileDefn);
+		DMDocument.registerMessage ("0>info " + "ExportModelsCustom - CCSDS CSV Done");
+		*/		
+				
+		// write the PDS4 CCSDS CSV file  - altDefinition
+/*		DMDocument.dmProcessState.setRelativeFileSpecCCSDSCSV (lSchemaFileDefn);
+		WriteCCSDSDoc writeCCSDSDoc = new WriteCCSDSDoc ();
+		writeCCSDSDoc.writeDocCSV (DMDocument.masterPDSSchemaFileDefn);
+		DMDocument.registerMessage ("0>info " + "ExportModelsCustom - CCSDS CSV Alt Definition Done");
+		
+		// write the LOD SKOS file
+		WriteLODSKOSFileDOM writeLODSKOSDOMFile = new WriteLODSKOSFileDOM ();
+		writeLODSKOSDOMFile.writeDOMSKOSFile (DMDocument.masterPDSSchemaFileDefn.relativeFileSpecSKOSTTL_DOM);
+		DMDocument.registerMessage ("0>info " + "ExportModelsCustom - SKOS Done"); */
+
+		// write the RDF/OWL file
+		
+/*		if (! lLDDToolFlag) {
+			WriteDOMRDFOWLFile writeDOMRDFOWLFile = new WriteDOMRDFOWLFile ();
+			writeDOMRDFOWLFile.writeOWLFile (configureClassesToWriteList_PDS4_Common (), DMDocument.masterPDSSchemaFileDefn.relativeFileSpecOWLRDF_DOM);
+			DMDocument.registerMessage ("0>info " + "ExportModelsCustom - RDF/OWL Done");
+		} else {
+			if (DMDocument.exportOWLFileFlag) {
+				ArrayList <DOMClass> lClassesToWrite = configureClassesToWriteList_PDS4_LDD ();
+				WriteDOMRDFOWLFile writeDOMRDFOWLFile = new WriteDOMRDFOWLFile ();
+				writeDOMRDFOWLFile.writeOWLFile (lClassesToWrite, DMDocument.masterPDSSchemaFileDefn.relativeFileSpecOWLRDF_DOM);
+				DMDocument.registerMessage ("0>info " + "ExportModelsCustom - RDF/OWL Done");
+			}
+		} */
+
+		// write the 11179 DOM DD Class Definition XML Files
+		/*
+		WriteDDProductDOMClassDefinitions writeDDProductDOMClassDefinitions = new WriteDDProductDOMClassDefinitions ();
+		writeDDProductDOMClassDefinitions.writeDDProductDOMClassDefnFiles(DMDocument.masterPDSSchemaFileDefn, DMDocument.sTodaysDate);
+		DMDocument.registerMessage ("0>info " + "writeAllDOMArtifacts - DOM Class Defn Done");
+		DMDocument.registerMessage ("0>info " + "writeAllDOMArtifacts - DOM Attr Defn Done");
+		*/
+			
+		return;
+	}
+	
+	// configured lists
+	
+	// PDS Common Dictionary --- set namespace below ---
+	public ArrayList <DOMClass> configureClassesToWriteList_PDS4_Common () {
+		// Dans entity list
+		ArrayList <DOMClass> classesToWrite = new ArrayList <DOMClass> ();
+
+		for (Iterator <DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
+			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
+			if ((lClass.isUSERClass || lClass.isUnitOfMeasure || lClass.isDataType || lClass.isVacuous)) continue;
+			if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue;
+			if (! (lClass.nameSpaceIdNC.compareTo("pds") == 0)) continue;
+			if (lClass.identifier.indexOf("PDS3") > -1) continue;
+			classesToWrite.add (lClass);
+		}
+		return classesToWrite;
+	}
+	
+	// PDS Common Context --- set namespace below ---
+	public ArrayList <DOMClass> configureClassesToWriteList_PDS4_Common_Contextxxx () {
+		ArrayList <String> classTitlesToWrite = new ArrayList <String> ();
+		ArrayList <DOMClass> classesToWrite = new ArrayList <DOMClass> ();
+		classTitlesToWrite.add ("Product_Context");
+		classTitlesToWrite.add ("Agency");
+		classTitlesToWrite.add ("Airborne");
+		classTitlesToWrite.add ("Facility");
+		classTitlesToWrite.add ("Instrument");
+		classTitlesToWrite.add ("Instrument_Host");
+		classTitlesToWrite.add ("Investigation");
+		classTitlesToWrite.add ("Node");
+		classTitlesToWrite.add ("Other");
+		classTitlesToWrite.add ("PDS_Affiliate");
+		classTitlesToWrite.add ("PDS_Guest");
+		classTitlesToWrite.add ("Resource");
+		classTitlesToWrite.add ("Target");
+		classTitlesToWrite.add ("Telescope");
+		for (Iterator<String> i = classTitlesToWrite.iterator(); i.hasNext();) {
+			String lClassName = (String) i.next();
+			String lClassId = DOMInfoModel.getClassIdentifier("pds", lClassName);
+			DOMClass lClass = DOMInfoModel.masterDOMClassIdMap.get(lClassId);
+			if (lClass != null) {
+				if (lClass.isInactive) continue;
+				classesToWrite.add (lClass);
+			}
+		}
+		return classesToWrite;
+	}
+	
+	// PDS LDD -- DISP - set namespace below - replace method name above ---
+	public ArrayList <DOMClass> configureClassesToWriteList_LDD_DISPxxx () {
+		// the entity list
+		ArrayList <DOMClass> classesToWrite = new ArrayList <DOMClass> ();
+
+		for (Iterator <DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
+			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
+			if ((lClass.isUSERClass || lClass.isUnitOfMeasure || lClass.isDataType || lClass.isVacuous)) continue;
+			if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue;
+			if (! (lClass.nameSpaceIdNC.compareTo("disp") == 0)) continue;
+			classesToWrite.add (lClass);
+		}
+		return classesToWrite;
+	}
+	
+	
+	// PDS LDD -- PROC - set namespace below - replace method name above ---
+	public ArrayList <DOMClass> configureClassesToWriteList_LDD_Proc () {
+		// the entity list
+		ArrayList <DOMClass> classesToWrite = new ArrayList <DOMClass> ();
+
+		for (Iterator <DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
+			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
+			if ((lClass.isUSERClass || lClass.isUnitOfMeasure || lClass.isDataType || lClass.isVacuous)) continue;
+			if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue;
+			if (! (lClass.nameSpaceIdNC.compareTo("proc") == 0)) continue;
+			classesToWrite.add (lClass);
+		}
+		return classesToWrite;
+	}	
+	
+	// PDS LDD -- Geom --- set namespace below ---
+	public ArrayList <DOMClass> configureClassesToWriteList_PDS4_LDD () {
+		// The entity list
+		ArrayList <DOMClass> classesToWrite = new ArrayList <DOMClass> ();
+
+		for (Iterator <DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
+			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
+			if ((lClass.isUSERClass || lClass.isUnitOfMeasure || lClass.isDataType || lClass.isVacuous)) continue;
+			if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue;
+			if (! (lClass.nameSpaceIdNC.compareTo("geom") == 0)) continue;
+			classesToWrite.add (lClass);
+		}
+		return classesToWrite;
+	}
+	
+	
+	// EIM Classes --- set namespace below ---
+	public ArrayList <DOMClass> configureClassesToWriteList_EIMxxx () {
+//		System.out.println("\ndebug configureClassesToWriteList_EIM");
+
+		ArrayList <String> classTitlesToWrite = new ArrayList <String> ();
+		ArrayList <DOMClass> classesToWrite = new ArrayList <DOMClass> ();
+
+		for (Iterator <DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
+			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
+			if ((lClass.isUSERClass || lClass.isUnitOfMeasure || lClass.isDataType || lClass.isVacuous)) continue;
+			if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue;
+			if (! (lClass.nameSpaceIdNC.compareTo("eim") == 0)) continue;
+			classesToWrite.add (lClass);
+		}
+		return classesToWrite;
+	}
+
+	
+	// Selecte EIM Classes --- set namespace below ---
+	public ArrayList <DOMClass> configureClassesToWriteList_EIM_Entity_Titles () {
+		ArrayList <String> classTitlesToWrite = new ArrayList <String> ();
+		ArrayList <DOMClass> classesToWrite = new ArrayList <DOMClass> ();
+		classTitlesToWrite.add ("Digital_Artifact");
+		classTitlesToWrite.add ("Bill_Of_Materials");
+		classTitlesToWrite.add ("Costs");
+		classTitlesToWrite.add ("Data");
+		classTitlesToWrite.add ("Digital_Artifact");
+		classTitlesToWrite.add ("Document");
+		classTitlesToWrite.add ("Domain");
+		classTitlesToWrite.add ("Facility");
+		classTitlesToWrite.add ("Hardware");
+		classTitlesToWrite.add ("Instrument");
+		classTitlesToWrite.add ("Mission");
+		classTitlesToWrite.add ("Model");
+		classTitlesToWrite.add ("Organization");
+		classTitlesToWrite.add ("Project");
+		classTitlesToWrite.add ("Research");
+		classTitlesToWrite.add ("Role");
+		classTitlesToWrite.add ("Task");
+		classTitlesToWrite.add ("Vendor");
+		classTitlesToWrite.add ("Hardware");
+		classTitlesToWrite.add ("Person");
+		classTitlesToWrite.add ("Service");
+		classTitlesToWrite.add ("Work_Activity");
+		classTitlesToWrite.add ("Program");
+		classTitlesToWrite.add ("Authority");
+		classTitlesToWrite.add ("Steward");
+		classTitlesToWrite.add ("Instrument_Host");
+		classTitlesToWrite.add ("ProjectOrWorkPackage");
+		classTitlesToWrite.add ("Work_Package");
+		classTitlesToWrite.add ("Spacecraft");
+		
+		for (Iterator<String> i = classTitlesToWrite.iterator(); i.hasNext();) {
+			String lClassName = (String) i.next();
+			String lClassId = DOMInfoModel.getClassIdentifier("eim", lClassName);
+			DOMClass lClass = DOMInfoModel.masterDOMClassIdMap.get(lClassId);
+			if (lClass != null) {
+				if (lClass.isInactive) continue;
+				classesToWrite.add (lClass);
+			}
+		}
+		return classesToWrite;
+	}
+	
+	// Selecte EIM Classes --- set namespace below ---
+	public ArrayList <DOMClass> configureClassesToWriteList_EIM_Titlesxxx () {
+		ArrayList <String> classTitlesToWrite = new ArrayList <String> ();
+		ArrayList <DOMClass> classesToWrite = new ArrayList <DOMClass> ();
+		classTitlesToWrite.add ("Access_Rights_Information");
+		classTitlesToWrite.add ("Archival_Information_Package");
+		classTitlesToWrite.add ("Artifact");
+		classTitlesToWrite.add ("Artifact_Type_Area");
+		classTitlesToWrite.add ("BillOfMaterials");
+		classTitlesToWrite.add ("Context_Information");
+		classTitlesToWrite.add ("Costs");
+		classTitlesToWrite.add ("Data_Object");
+		classTitlesToWrite.add ("Date_Time_Area");
+		classTitlesToWrite.add ("Digital_Object");
+		classTitlesToWrite.add ("Digital_Object_Handle");
+		classTitlesToWrite.add ("Dissemination_Information_Package");
+		classTitlesToWrite.add ("Document");
+		classTitlesToWrite.add ("Domain");
+		classTitlesToWrite.add ("Domain_Area");
+		classTitlesToWrite.add ("Entity");
+		classTitlesToWrite.add ("Facility");
+		classTitlesToWrite.add ("Fixity_Information");
+		classTitlesToWrite.add ("Format");
+		classTitlesToWrite.add ("Format_Type_Area");
+		classTitlesToWrite.add ("Hardware");
+		classTitlesToWrite.add ("Identification_Information");
+		classTitlesToWrite.add ("Information_Model");
+		classTitlesToWrite.add ("Information_Object");
+		classTitlesToWrite.add ("Information_Package");
+		classTitlesToWrite.add ("Information_Package_Collection");
+		classTitlesToWrite.add ("Instrument");
+		classTitlesToWrite.add ("Instrument_Host");
+		classTitlesToWrite.add ("Investigation");
+		classTitlesToWrite.add ("Mission");
+		classTitlesToWrite.add ("Model");
+		classTitlesToWrite.add ("Name_Type_List_Area");
+		classTitlesToWrite.add ("Native_Area");
+		classTitlesToWrite.add ("Organization");
+		classTitlesToWrite.add ("People");
+		classTitlesToWrite.add ("Project");
+		classTitlesToWrite.add ("Provenance_Information");
+		classTitlesToWrite.add ("Reference_Information");
+		classTitlesToWrite.add ("Reference_Information_Collection");
+		classTitlesToWrite.add ("Representation_Information");
+		classTitlesToWrite.add ("Research");
+		classTitlesToWrite.add ("Role");
+		classTitlesToWrite.add ("Science_Investigation_Area");
+		classTitlesToWrite.add ("Service");
+		classTitlesToWrite.add ("Submission_Information_Package");
+		classTitlesToWrite.add ("Task");
+		classTitlesToWrite.add ("Vendor");
+		classTitlesToWrite.add ("Work_Activity");
+
+/*		classTitlesToWrite.add ("Entify");
+		classTitlesToWrite.add ("Artifact");
+		classTitlesToWrite.add ("People");
+		classTitlesToWrite.add ("Mission");
+		classTitlesToWrite.add ("Instrument");
+		classTitlesToWrite.add ("Project");
+		classTitlesToWrite.add ("Data");
+		classTitlesToWrite.add ("Model");
+		classTitlesToWrite.add ("Document");
+		classTitlesToWrite.add ("Service");
+		classTitlesToWrite.add ("Facility");
+		classTitlesToWrite.add ("Costs");
+		classTitlesToWrite.add ("Organization");
+		classTitlesToWrite.add ("Vendor");
+		classTitlesToWrite.add ("Hardware");
+		classTitlesToWrite.add ("BillOfMaterials");
+		classTitlesToWrite.add ("Research");
+		classTitlesToWrite.add ("Concepts");
+		classTitlesToWrite.add ("Domain");
+		classTitlesToWrite.add ("Role");
+		classTitlesToWrite.add ("Steward"); */
+		
+		for (Iterator<String> i = classTitlesToWrite.iterator(); i.hasNext();) {
+			String lClassName = (String) i.next();
+			String lClassId = DOMInfoModel.getClassIdentifier("eim", lClassName);
+			DOMClass lClass = DOMInfoModel.masterDOMClassIdMap.get(lClassId);
+			if (lClass != null) {
+				if (lClass.isInactive) continue;
+				classesToWrite.add (lClass);
+			}
+		}
+		return classesToWrite;
+	}
+	
+	// OAISIF selected classes --- set namespace below ---
+	public ArrayList <DOMClass> configureClassesToWriteList_OAISIFxxx () {
+		ArrayList <String> classTitlesToWrite = new ArrayList <String> ();
+		ArrayList <DOMClass> classesToWrite = new ArrayList <DOMClass> ();
+
+		classTitlesToWrite.add ("Abstraction_Layer");
+		classTitlesToWrite.add ("Abstraction_Layer_Mapping");
+		classTitlesToWrite.add ("Abstraction_Layer_OAIS_DIP");
+		classTitlesToWrite.add ("Abstraction_Layer_OAIS_SIP");
+		classTitlesToWrite.add ("Abstraction_Layer_PDS4");
+
+		classTitlesToWrite.add ("Access");
+		classTitlesToWrite.add ("Access_Rights_Information");
+		classTitlesToWrite.add ("Access_Service");
+		classTitlesToWrite.add ("Access_Aid");
+		classTitlesToWrite.add ("Archival_Storage");
+		classTitlesToWrite.add ("Finding_Aid");
+		classTitlesToWrite.add ("Ordering_Aid");
+		classTitlesToWrite.add ("Retrieving_Aid");
+		classTitlesToWrite.add ("Archival_Information_Package");
+		classTitlesToWrite.add ("Consumer");
+		classTitlesToWrite.add ("Content_Information");
+		classTitlesToWrite.add ("Context_Information");
+		classTitlesToWrite.add ("Dissemination_Information_Package");
+		classTitlesToWrite.add ("External_Object");
+		classTitlesToWrite.add ("Fixity_Information");
+		classTitlesToWrite.add ("Functional_Entity");
+		classTitlesToWrite.add ("Information_Object");
+		classTitlesToWrite.add ("Information_Package");
+		classTitlesToWrite.add ("Ingest");
+		classTitlesToWrite.add ("Interaction_Pattern");
+		classTitlesToWrite.add ("Invoke");
+		classTitlesToWrite.add ("MessagedService");
+		classTitlesToWrite.add ("receiveMessage");
+		classTitlesToWrite.add ("sendMessage");
+		classTitlesToWrite.add ("Order_Agreement");
+		classTitlesToWrite.add ("Preservation_Description_Information");
+		classTitlesToWrite.add ("Producer");
+		classTitlesToWrite.add ("Progress");
+		classTitlesToWrite.add ("Protocol");
+		classTitlesToWrite.add ("Provenance_Information");
+		classTitlesToWrite.add ("PublishSubscribe");
+		classTitlesToWrite.add ("Reference_Information");
+		classTitlesToWrite.add ("Representation_Information");
+		classTitlesToWrite.add ("Request");
+		classTitlesToWrite.add ("Send");
+		classTitlesToWrite.add ("Service");
+		classTitlesToWrite.add ("Submission_Information_Package");
+		classTitlesToWrite.add ("Submit");	
+//		classTitlesToWrite.add ("putAccessRightsInformation");
+//		classTitlesToWrite.add ("putContextInformation");
+//		classTitlesToWrite.add ("putIdentificationInformation");
+//		classTitlesToWrite.add ("putFixityInformation");
+//		classTitlesToWrite.add ("putProvenanceInformation");
+//		classTitlesToWrite.add ("putPreservationDescriptionInformation");
+//		classTitlesToWrite.add ("putRepresentationInformation");
+//		classTitlesToWrite.add ("putReferenceInformation");
+//		classTitlesToWrite.add ("setPID");
+//		classTitlesToWrite.add ("setDataObject");
+//		classTitlesToWrite.add ("getDataObject");
+//		classTitlesToWrite.add ("getRepresentationInformation");
+//		classTitlesToWrite.add ("getReferenceInformation");
+//		classTitlesToWrite.add ("getPID");
+//		classTitlesToWrite.add ("getPreservationDescriptionInformation");
+//		classTitlesToWrite.add ("getProvenanceInformation");
+//		classTitlesToWrite.add ("getIdentificationInformation");
+//		classTitlesToWrite.add ("getFixityInformation");
+//		classTitlesToWrite.add ("getContextInformation");
+//		classTitlesToWrite.add ("getAccessRightsInformation");
+		
+		for (Iterator<String> i = classTitlesToWrite.iterator(); i.hasNext();) {
+			String lClassName = (String) i.next();
+			String lClassId = DOMInfoModel.getClassIdentifier("oais", lClassName);
+			DOMClass lClass = DOMInfoModel.masterDOMClassIdMap.get(lClassId);
+			if (lClass != null) {
+				if (lClass.isInactive) continue;
+				classesToWrite.add (lClass);
+			}
+		}
+		return classesToWrite;
+	}
+}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/RelationshipProperties.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/RelationshipProperties.java
@@ -1,0 +1,260 @@
+// Copyright 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+// * Neither the name of Caltech nor its operating division, the Jet Propulsion
+// Laboratory, nor the names of its contributors may be used to endorse or
+// promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package gov.nasa.pds.model.plugin; 
+
+import java.util.ArrayList;
+import java.util.TreeMap;
+
+class RelationshipProperties extends ClassPropertiesBase {
+		String fromClassID;
+		ClassPropertiesOWL fromClassProperties;
+		
+		String toClassID;
+		ClassPropertiesOWL toClassProperties; 
+		
+		TreeMap <String, String> relNameToClassNameMap  = new TreeMap <String, String> ();
+		
+		public RelationshipProperties (String referenceType, TreeMap <String, ClassPropertiesOWL> classPropertiesMap) {
+			lidvid = formValueLID(lid) + ":1.0";
+			
+			// initialize the relNameToClassNameMap
+			initRelNameToClassNameMap();
+			
+			// decode a reference_type value into {fromName, to, toName}
+			int validCount = 0;
+			ArrayList <String> lNameArr = decodeReferenceType (referenceType);
+			
+			if (lNameArr == null || lNameArr.size() != 3) {
+//				if (DMDocument.debugFlag) System.out.println("debug RelationshipProperties - invalid <reference_type> - referenceType:" + referenceType);
+				lidvid = null;
+				return;
+			}
+			validCount++;
+			
+			// handle fromName
+			String lName = lNameArr.get(0);
+			if (lName != null) {
+				String lClassID = relNameToClassNameMap.get(lName);
+				if (lClassID != null) {
+					ClassPropertiesOWL lClassProperties = classPropertiesMap.get(lClassID);
+					if (lClassProperties != null) {						
+						fromClassID = lClassID;
+						fromClassProperties = lClassProperties;
+						title = referenceType;
+						validCount++;
+					}
+				}
+			}
+			
+			// handle toName
+			lName = lNameArr.get(2);
+			if (lName != null) {
+				String lClassID = relNameToClassNameMap.get(lName);
+				if (lClassID != null) {
+					ClassPropertiesOWL lClassProperties = classPropertiesMap.get(lClassID);
+					if (lClassProperties != null) {
+						toClassID = lClassID;
+						toClassProperties = lClassProperties;
+						validCount++;
+					}
+				}
+			}
+
+			if (validCount == 3) {
+				lid = fromClassProperties.lid + ":" + title;
+				lidvid = formValueLID(lid) + ":1.0";
+			} else {
+// ***** FIX ****				if (DMDocument.debugFlag) System.out.println("debug RelationshipProperties - create relationship failed - validCount:" + validCount + "   referenceType:" + referenceType);
+				lidvid = null;
+			}			
+		}
+
+		public RelationshipProperties (DOMClass lDOMClass, DOMProp lDOMProp, DOMClass lDOMMemberClass, 	TreeMap <String, ClassPropertiesOWL> classPropertiesIdMap) {
+			identifier = "TBD_identifier";
+			type = "TBD_type";
+			subClassOfTitle = "TBD_subClassOfTitle";
+			title = "TBD_title";  													
+			definition = "TBD_definition";	
+			lid = "TBD_lid";
+			lidvid = formValueLID(lid) + ":1.0";
+			
+			String lClassID = lDOMClass.identifier;
+			ClassPropertiesOWL lClassPropertiesFrom = classPropertiesIdMap.get(lClassID);
+			if (lClassPropertiesFrom != null) {						
+				fromClassID = lClassID;
+				fromClassProperties = lClassPropertiesFrom;
+				title = lDOMProp.title;
+			} else {
+				fromClassID = "0001_NASA_PDS_1.pds.Other";
+				lClassPropertiesFrom = classPropertiesIdMap.get(fromClassID);
+				if (lClassPropertiesFrom == null) { 
+					System.out.println("debug RelationshipProperties -FAILED- fromClassID:" + fromClassID);
+				}
+				fromClassProperties = lClassPropertiesFrom;
+				title = "missing";
+			}
+			
+			lClassID = lDOMMemberClass.identifier;
+			ClassPropertiesOWL lClassPropertiesTo = classPropertiesIdMap.get(lDOMMemberClass.identifier);
+			if (lClassPropertiesTo != null) {
+				toClassID = lClassID;
+				toClassProperties = lClassPropertiesTo;
+			} else {
+				toClassID = "0001_NASA_PDS_1.pds.Other";
+				lClassPropertiesTo = classPropertiesIdMap.get(toClassID);
+				if (lClassPropertiesTo == null) { 
+					System.out.println("debug RelationshipProperties -FAILED- toClassID:" + toClassID);
+				}
+				toClassProperties = lClassPropertiesTo;
+			}
+			
+			lid = fromClassProperties.lid + ":" + title;
+			lidvid = formValueLID(lid) + "::1.0";	
+			
+//			System.out.println("\ndebug RelationshipProperties lDOMClass.identifier:" + lDOMClass.identifier);
+//			System.out.println("                             fromClassID:" + fromClassID + "   title:" + title + "   toClassID:" + toClassID);
+//			System.out.println("                             fromClassProperties.lidvid:" + fromClassProperties.lidvid + "   lidvid:" + lidvid + "   toClassProperties.lidvid:" + toClassProperties.lidvid);
+		}
+		
+		private ArrayList <String> decodeReferenceType (String referenceType) {
+//			investigation_to_instrument
+			ArrayList <String> lNameArr = new ArrayList <String> ();
+			
+			// check for "to" reference
+			int typeInd = referenceType.indexOf("_to_");
+			if (typeInd > -1) {
+				String lName = referenceType.substring(0, typeInd);
+				lNameArr.add(lName);
+				lNameArr.add("to");
+				lName = referenceType.substring(typeInd + 4, referenceType.length());
+				lNameArr.add(lName);
+				return lNameArr;
+			}
+			
+			// check for "has" reference
+			typeInd = referenceType.indexOf("_has_");
+			if (typeInd > -1) {
+				String lName = referenceType.substring(0, typeInd);
+				lNameArr.add(lName);
+				lNameArr.add("has");
+				lName = referenceType.substring(typeInd + 5, referenceType.length());
+				lNameArr.add(lName);
+				return lNameArr;
+			}
+			
+			// check for "by" reference
+			typeInd = referenceType.indexOf("_by_");
+			if (typeInd > -1) {
+				String lName = referenceType.substring(0, typeInd);
+				lNameArr.add(lName);
+				lNameArr.add("by");
+				lName = referenceType.substring(typeInd + 4, referenceType.length());
+				lNameArr.add(lName);
+				return lNameArr;
+			}	
+			
+			// check for "from" reference
+			typeInd = referenceType.indexOf("_from_");
+			if (typeInd > -1) {
+				String lName = referenceType.substring(0, typeInd);
+				lNameArr.add(lName);
+				lNameArr.add("from");
+				lName = referenceType.substring(typeInd + 6, referenceType.length());
+				lNameArr.add(lName);
+				return lNameArr;
+			}	
+			return lNameArr;
+		}
+		
+		// intialize
+		private void initRelNameToClassNameMap() {
+			relNameToClassNameMap.put("agency", "0001_NASA_PDS_1.pds.Agency");          
+			relNameToClassNameMap.put("airborne", "0001_NASA_PDS_1.pds.Airborne");
+			relNameToClassNameMap.put("facility", "0001_NASA_PDS_1.pds.Facility");
+			relNameToClassNameMap.put("instrument", "0001_NASA_PDS_1.pds.Instrument");
+			relNameToClassNameMap.put("instrument_host", "0001_NASA_PDS_1.pds.Instrument_Host");
+			relNameToClassNameMap.put("investigation", "0001_NASA_PDS_1.pds.Investigation");
+			relNameToClassNameMap.put("node", "0001_NASA_PDS_1.pds.Node");
+			relNameToClassNameMap.put("observing_system", "0001_NASA_PDS_1.pds.Observing_System");
+			relNameToClassNameMap.put("other", "0001_NASA_PDS_1.pds.Other");
+//			relNameToClassNameMap.put("PDS_Affiliate", "0001_NASA_PDS_1.pds.PDS_Affiliate");
+//			relNameToClassNameMap.put("PDS_Guest", "0001_NASA_PDS_1.pds.PDS_Guest");
+			relNameToClassNameMap.put("resource", "0001_NASA_PDS_1.pds.Resource");
+			relNameToClassNameMap.put("target", "0001_NASA_PDS_1.pds.Target");
+			relNameToClassNameMap.put("telescope", "0001_NASA_PDS_1.pds.Telescope");
+//			relNameToClassNameMap.put("Type_List_Area", "0001_NASA_PDS_1.pds.Type_List_Area");
+			
+			relNameToClassNameMap.put("ancillary", "0001_NASA_PDS_1.pds.Product_Ancillary"); 
+			relNameToClassNameMap.put("ancillary_data", "0001_NASA_PDS_1.pds.Product_Ancillary"); 
+			relNameToClassNameMap.put("associate", "0001_NASA_PDS_1.pds.Product"); 
+			relNameToClassNameMap.put("attribute", "0001_NASA_PDS_1.pds.Product_Attribute_Definition"); 
+			relNameToClassNameMap.put("browse", "0001_NASA_PDS_1.pds.Product_Browse"); 
+			relNameToClassNameMap.put("bundle", "0001_NASA_PDS_1.pds.Product_Bundle"); 
+			relNameToClassNameMap.put("calibrated_product", "0001_NASA_PDS_1.pds.Product_Observational"); 
+			relNameToClassNameMap.put("calibration", "0001_NASA_PDS_1.pds.Product_Metadata_Supplemental"); 
+			relNameToClassNameMap.put("calibration_document", "0001_NASA_PDS_1.pds.Product_Document"); 
+			relNameToClassNameMap.put("calibration_product", "0001_NASA_PDS_1.pds.Product_Observational"); 
+			relNameToClassNameMap.put("class", "0001_NASA_PDS_1.pds.Product_Class_Definition"); 
+			relNameToClassNameMap.put("collection", "0001_NASA_PDS_1.pds.Product_Collection"); 
+			relNameToClassNameMap.put("collection_curated", "0001_NASA_PDS_1.pds.Product_Collection"); 
+			relNameToClassNameMap.put("context", "0001_NASA_PDS_1.pds.Product_Context"); 
+			relNameToClassNameMap.put("data", "0001_NASA_PDS_1.pds.Product_Observational"); 
+			relNameToClassNameMap.put("data_archivist", "0001_NASA_PDS_1.pds.PDS_Affiliate"); 
+			relNameToClassNameMap.put("data_curated", "0001_NASA_PDS_1.pds.Product_Observational"); 
+			relNameToClassNameMap.put("derived_product", "0001_NASA_PDS_1.pds.Product_Observational"); 
+			relNameToClassNameMap.put("document", "0001_NASA_PDS_1.pds.Product_Document"); 
+			relNameToClassNameMap.put("errata", "0001_NASA_PDS_1.pds.Product_Document"); 
+			relNameToClassNameMap.put("geometry", "0001_NASA_PDS_1.pds.Product_Metadata_Supplemental"); 
+			relNameToClassNameMap.put("image", "0001_NASA_PDS_1.pds.Product_Observational"); 
+//			relNameToClassNameMap.put("instrument", "0001_NASA_PDS_1.pds.Product_Context"); 
+//			relNameToClassNameMap.put("instrument_host", "0001_NASA_PDS_1.pds.Product_Context"); 
+//			relNameToClassNameMap.put("investigation", "0001_NASA_PDS_1.pds.Product_Context"); 
+			relNameToClassNameMap.put("manager", "0001_NASA_PDS_1.pds.PDS_Affiliate"); 
+//			relNameToClassNameMap.put("node", "0001_NASA_PDS_1.pds.Product_Context"); 
+			relNameToClassNameMap.put("observatory", "0001_NASA_PDS_1.pds.Product_Context"); 
+			relNameToClassNameMap.put("operator", "0001_NASA_PDS_1.pds.PDS_Affiliate"); 
+			relNameToClassNameMap.put("package", "0001_NASA_PDS_1.pds.Product_AIP"); 
+			relNameToClassNameMap.put("package_compiled", "0001_NASA_PDS_1.pds.Product_AIP"); 
+			relNameToClassNameMap.put("personnel", "0001_NASA_PDS_1.pds.PDS_Affiliate"); 
+			relNameToClassNameMap.put("product", "0001_NASA_PDS_1.pds.Product_Observational"); 
+			relNameToClassNameMap.put("raw_product", "0001_NASA_PDS_1.pds.Product_Observational"); 
+//			relNameToClassNameMap.put("resource", "0001_NASA_PDS_1.pds.resource"); 
+			relNameToClassNameMap.put("service", "0001_NASA_PDS_1.pds.Product_Service"); 
+			relNameToClassNameMap.put("schema", "0001_NASA_PDS_1.pds.Product_XML_Schema"); 
+			relNameToClassNameMap.put("spice_kernel", "0001_NASA_PDS_1.pds.Product_SPICE_Kernel"); 
+//			relNameToClassNameMap.put("target", "0001_NASA_PDS_1.pds.Product_Context"); 
+//			relNameToClassNameMap.put("telescope", "0001_NASA_PDS_1.pds.Product_Context"); 
+			relNameToClassNameMap.put("thumbnail", "0001_NASA_PDS_1.pds.Product_Thumbnail"); 
+			relNameToClassNameMap.put("update", "0001_NASA_PDS_1.pds.Product_Update"); 
+			relNameToClassNameMap.put("zip", "0001_NASA_PDS_1.pds.Product_Zipped"); 
+			return;
+		}		
+	}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBookAnon.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBookAnon.java
@@ -32,9 +32,10 @@ package gov.nasa.pds.model.plugin;
 import java.io.*;
 import java.util.*;
 
-// Write the PDS4 Data Dictionary DocBook file. - Modified to write a DocBook file for each namespace id
+// Write the Data Dictionary DocBook file with PDS mentioned removed
+// Writes a DocBook file for each namespace id
 
-class WriteDOMDocBooks extends Object {
+class WriteDOMDocBookAnon extends Object {
 	// class structures
 	TreeMap <String, ClassClassificationDefnDOM> classClassificationMap;
 	ArrayList <ClassClassificationDefnDOM> classClassificationArr;	
@@ -51,7 +52,7 @@ class WriteDOMDocBooks extends Object {
 	
 // Insert zero-width space characters (&#x200B;) in text strings; form break points for the lines.
 	
-	public WriteDOMDocBooks () {
+	public WriteDOMDocBookAnon () {
 		// class structures
 		classClassificationMap = new TreeMap <String, ClassClassificationDefnDOM> ();
 		attrClassificationMap = new TreeMap <String, AttrClassificationDefnDOM> ();
@@ -214,7 +215,7 @@ class WriteDOMDocBooks extends Object {
 		String lLabelVersionId = "_" + DMDocument.masterPDSSchemaFileDefn.lab_version_id;
 		String lDOMLabelVersionId = lLabelVersionId;
 		lFileName = DMDocument.replaceString (lFileName, lLabelVersionId, lDOMLabelVersionId);
-        
+		
         // iterate over the namespace ids
 		for (SchemaFileDefn lSchemaFileDefnToWrite : lSchemaFileDefnToWriteArr) {
 			ClassClassificationDefnDOM lClassClassificationDefn = classClassificationMap.get(lSchemaFileDefnToWrite.nameSpaceIdNCLC);
@@ -236,11 +237,11 @@ class WriteDOMDocBooks extends Object {
         // write the sections
 			if (lClassClassificationDefn != null) {
 				if (lClassClassificationDefn.classArr.size() > 0)
-					writeClassSection (lClassClassificationDefn, prDocBook);
+					writeClassSection (lSchemaFileDefn, lClassClassificationDefn, prDocBook);
 			}
 			if (lAttrClassificationDefn != null) {
 				if (lAttrClassificationDefn.attrArr.size() > 0)
-					writeAttrSection (lAttrClassificationDefn, prDocBook);
+					writeAttrSection (lSchemaFileDefn, lAttrClassificationDefn, prDocBook);
 			}
         
         // write the Data Types and Units
@@ -251,102 +252,14 @@ class WriteDOMDocBooks extends Object {
 		return;
 	}
 	
-	
-//	print DocBook File
-/*	public void writeDocBook (SchemaFileDefn lSchemaFileDefn) throws java.io.IOException {
-		String lFileName = lSchemaFileDefn.relativeFileSpecDDDocXML;
-		String lLabelVersionId = "_" + DMDocument.masterPDSSchemaFileDefn.lab_version_id;
-		String lDOMLabelVersionId = lLabelVersionId;
-		lFileName = DMDocument.replaceString (lFileName, lLabelVersionId, lDOMLabelVersionId);
-		PrintWriter prDocBook = new PrintWriter(new OutputStreamWriter (new FileOutputStream(new File(lFileName)), "UTF-8"));
-		writeHeader (prDocBook);
-		
-		// write the Common dictionary
-		writeClassSection (DMDocument.masterNameSpaceIdNCLC,prDocBook);
-        writeAttrSection (DMDocument.masterNameSpaceIdNCLC, prDocBook);
-        
-        // write the LDDs
-		for (Iterator <SchemaFileDefn> i = lSchemaFileDefnToWriteArr.iterator(); i.hasNext();) {
-			SchemaFileDefn lSchemaFileDefnToWrite = (SchemaFileDefn) i.next();
-			if (lSchemaFileDefnToWrite.nameSpaceIdNCLC.compareTo(DMDocument.masterNameSpaceIdNCLC) == 0) continue; // skip master namespace
-			ClassClassificationDefnDOM lClassClassificationDefn = classClassificationMap.get(lSchemaFileDefnToWrite.nameSpaceIdNCLC);
-			if (lClassClassificationDefn != null) {
-				if (lClassClassificationDefn.classArr.size() > 0)
-					writeClassSection (lClassClassificationDefn, prDocBook);
-			}
-			AttrClassificationDefnDOM lAttrClassificationDefn = attrClassificationMap.get(lSchemaFileDefnToWrite.nameSpaceIdNCLC);
-			if (lAttrClassificationDefn != null) {
-				if (lAttrClassificationDefn.attrArr.size() > 0)
-					writeAttrSection (lAttrClassificationDefn, prDocBook);
-			}
-		}
-        
-        // write the Data Types and Units
-     	writeDataTypeSection (DMDocument.masterNameSpaceIdNCLC, prDocBook);
-    	writeUnitsSection (DMDocument.masterNameSpaceIdNCLC, prDocBook);
-		writeFooter (prDocBook);
-		prDocBook.close();
-		return;
-	}	*/
-	
-	private void writeClassSection (String lNameSpaceId, PrintWriter prDocBook) {
-        prDocBook.println("");	
-        prDocBook.println("      <!-- =====================Part2 Begin=========================== -->");
-        prDocBook.println("");
-		
-		ClassClassificationDefnDOM lClassClassificationDefn = classClassificationMap.get("pds.product");
-		if (lClassClassificationDefn != null) {
-			prDocBook.println("        <chapter>");
-			prDocBook.println("           <title>Product Classes in the common namespace.</title>");
-			prDocBook.println("           <para>These classes define the products.</para>");
-			for (Iterator <DOMClass> j = lClassClassificationDefn.classArr.iterator(); j.hasNext();) {
-				DOMClass lClass = (DOMClass) j.next();
-				writeClass (lClass, prDocBook);						
-			}
-			prDocBook.println("        </chapter>");
-	        prDocBook.println("");
-		}
-
-		lClassClassificationDefn = classClassificationMap.get("pds.support");
-		if (lClassClassificationDefn != null) {
-			prDocBook.println("        <chapter>");
-			prDocBook.println("           <title>Support classes in the common namespace.</title>");
-			prDocBook.println("           <para>The classes in this section are used by the product classes.</para>");
-			for (Iterator <DOMClass> j = lClassClassificationDefn.classArr.iterator(); j.hasNext();) {
-				DOMClass lClass = (DOMClass) j.next();
-				writeClass (lClass, prDocBook);						
-			}
-			prDocBook.println("        </chapter>");
-	        prDocBook.println("");
-
-		}
-		
-		if (! DMDocument.importJSONAttrFlag) {  // if a JSON run, dont write the following
-			lClassClassificationDefn = classClassificationMap.get("pds.ops");
-			if (lClassClassificationDefn != null) {
-				prDocBook.println("        <chapter>");
-				prDocBook.println("           <title>OPS catalog classes in the common namespace.</title>");
-				prDocBook.println("           <para>These classes support operations. </para>");
-				for (Iterator <DOMClass> j = lClassClassificationDefn.classArr.iterator(); j.hasNext();) {
-					DOMClass lClass = (DOMClass) j.next();
-					writeClass (lClass, prDocBook);						
-				}
-				prDocBook.println("        </chapter>");
-				prDocBook.println("");
-			}
-		}
-		
-        prDocBook.println("      <!-- =====================Part2 End=========================== -->");
-        prDocBook.println("");
-	}
-	
-	private void writeClassSection (ClassClassificationDefnDOM lClassClassificationDefn, PrintWriter prDocBook) {
+	private void writeClassSection (SchemaFileDefn lSchemaFileDefn, ClassClassificationDefnDOM lClassClassificationDefn, PrintWriter prDocBook) {
         prDocBook.println("");	
         prDocBook.println("      <!-- ===================== LDD Class Begin =========================== -->");
         prDocBook.println("");
 		
 		prDocBook.println("        <chapter>");
-		prDocBook.println("           <title>Classes in the " + lClassClassificationDefn.namespaceId + " namespace.</title>");
+//		prDocBook.println("           <title>Classes in the " + lClassClassificationDefn.namespaceId + " namespace.</title>");
+		prDocBook.println("           <title>Classes in the " + lSchemaFileDefn.lddName + " dictionary.</title>");
 		prDocBook.println("           <para>These classes comprise the namespace.</para>");
 		for (Iterator <DOMClass> j = lClassClassificationDefn.classArr.iterator(); j.hasNext();) {
 			DOMClass lClass = (DOMClass) j.next();
@@ -359,13 +272,14 @@ class WriteDOMDocBooks extends Object {
         prDocBook.println("");
 	}	
 		
-	private void writeAttrSection (AttrClassificationDefnDOM lAttrClassificationDefn, PrintWriter prDocBook) {
+	private void writeAttrSection (SchemaFileDefn lSchemaFileDefn, AttrClassificationDefnDOM lAttrClassificationDefn, PrintWriter prDocBook) {
 		prDocBook.println("");	
 		prDocBook.println("      <!-- ===================== LDD Attribute Begin =========================== -->");
 		prDocBook.println("");
 
 		prDocBook.println("        <chapter>");
-		prDocBook.println("           <title>Attributes in the " + lAttrClassificationDefn.namespaceId + " namespace.</title>");
+//		prDocBook.println("           <title>Attributes in the " + lAttrClassificationDefn.namespaceId + " namespace.</title>");
+		prDocBook.println("           <title>Attributes in the " + lSchemaFileDefn.lddName  + " dictionary.</title>");
 		prDocBook.println("           <para>These attributes are used by the classes in the " + lAttrClassificationDefn.namespaceId + " namespace. </para>");
 		for (Iterator <DOMAttr> j = lAttrClassificationDefn.attrArr.iterator(); j.hasNext();) {
 			DOMAttr lAttr = (DOMAttr) j.next();
@@ -400,7 +314,6 @@ class WriteDOMDocBooks extends Object {
         prDocBook.println("            <thead>");
         prDocBook.println("                <row>");
         prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">" + getPrompt("Name: ") + getValue(lClass.title) + lRegistrationStatusInsert + "</entry>");
-//        prDocBook.println("                    <entry>" + getPrompt("Version Id: ") + getValue("1.0.0.0") + "</entry>");        
         prDocBook.println("                    <entry>" + getPrompt("Version Id: ") + getValue(lClass.versionId) + "</entry>");
         prDocBook.println("                </row>");
         prDocBook.println("            </thead>");
@@ -617,7 +530,6 @@ class WriteDOMDocBooks extends Object {
 	    prDocBook.println("                <row>");
 	    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">" + getPrompt("Name: ") + getAttrAnchor(lAttr) + getValue(lAttr.title) + lRegistrationStatusInsert + "</entry>");
 	    prDocBook.println("                    <entry>" + getPrompt("Version Id: ") + getValue("1.0.0.0") + "</entry>");
-//	    prDocBook.println("                    <entry>" + getPrompt("Version Id: ") + getValue(lAttr.versionId) + "</entry>");
 	    prDocBook.println("                </row>");
 	    prDocBook.println("            </thead>");
 	    prDocBook.println("            <tbody>");
@@ -625,20 +537,12 @@ class WriteDOMDocBooks extends Object {
 	    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">" + getPrompt("Description: ") + getValue(lAttr.definition) + "</entry>");
 	    prDocBook.println("                </row>");
 	    prDocBook.println("                <row>");
-//	    prDocBook.println("                    <entry>" + getPrompt("Namespace Id: ") + getValue(lAttr.attrNameSpaceIdNC) + "</entry>");
 	    prDocBook.println("                    <entry>" + getPrompt("Namespace Id: ") + getValue(lAttr.getNameSpaceIdNC ()) + "</entry>");
-//	    prDocBook.println("                    <entry>" + getPrompt("Steward: ") + getValue(lAttr.steward) + "</entry>");
 	    prDocBook.println("                    <entry>" + getPrompt("Steward: ") + getValue(lAttr.getSteward ()) + "</entry>");
-//	    prDocBook.println("                    <entry>" + getPrompt("Class Name: ") + getValueBreak(lAttr.className) + "</entry>");
-//	    prDocBook.println("                    <entry>" + getPrompt("Class Name: ") + getClassLink(lParentClass) + "</entry>");
 	    prDocBook.println("                    <entry>" + getPrompt("Class Name: ") + getClassLink(lAttr.attrParentClass) + "</entry>");
 	    prDocBook.println("                    <entry>" + getPrompt("Type: ") + getDataTypeLink(lAttr.valueType) + "</entry>");
 	    prDocBook.println("                </row>");
 	    prDocBook.println("                <row>");
-//	    prDocBook.println("                    <entry>" + getPrompt("Minimum Value: ") + getValueReplaceTBDWithNone(lAttr.minimum_value) + "</entry>");
-//	    prDocBook.println("                    <entry>" + getPrompt("Maximum Value: ") + getValueReplaceTBDWithNone(lAttr.maximum_value) + "</entry>");
-//	    prDocBook.println("                    <entry>" + getPrompt("Minimum Characters: ") + getValueReplaceTBDWithNone(lAttr.minimum_characters) + "</entry>");
-//	    prDocBook.println("                    <entry>" + getPrompt("Maximum Characters: ") + getValueReplaceTBDWithNone(lAttr.maximum_characters) + "</entry>");
 
 	    prDocBook.println("                    <entry>" + getPrompt("Minimum Value: ") + getValueReplaceTBDWithNone(lAttr.getMinimumValue (true, false)) + "</entry>");
 	    prDocBook.println("                    <entry>" + getPrompt("Maximum Value: ") + getValueReplaceTBDWithNone(lAttr.getMaximumValue (true, false)) + "</entry>");
@@ -758,7 +662,7 @@ class WriteDOMDocBooks extends Object {
 		}
 		
 		prDocBook.println("    <chapter>");
-		prDocBook.println("       <title>Data Types in the common namespace.</title>");
+		prDocBook.println("       <title>Data Types for the dictionary.</title>");
 		prDocBook.println("       <para>These classes define the data types. </para>");
 	
 //		Write the data types
@@ -980,41 +884,46 @@ class WriteDOMDocBooks extends Object {
 	}
 	
 	private void writeHeader (SchemaFileDefn lSchemaFileDefn, PrintWriter prDocBook) {
+		
 		prDocBook.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
 		prDocBook.println("<?xml-model href=\"http://www.oasis-open.org/docbook/xml/5.0/rng/docbook.rng\" schematypens=\"http://relaxng.org/ns/structure/1.0\"?>");
 		prDocBook.println("<book xmlns=\"http://docbook.org/ns/docbook\"");
 		prDocBook.println("    xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"5.0\">");
 		prDocBook.println("    <info>");
-		prDocBook.println("        <title>" + DMDocument.ddDocTitle + "</title>");
-		prDocBook.println("        <subtitle>Abridged - Versionxxx " + DMDocument.masterPDSSchemaFileDefn.ont_version_id + "</subtitle>");
-		prDocBook.println("        <author>");
-		prDocBook.println("            <orgname>" + DMDocument.ddDocTeam + "</orgname>");
-		prDocBook.println("        </author>");
-		prDocBook.println("        <releaseinfo>Information Model Version " + DMDocument.masterPDSSchemaFileDefn.ont_version_id + " on " + DMDocument.sTodaysDate + "</releaseinfo>");
-		prDocBook.println("        <releaseinfo>Data Dictionary: " + lSchemaFileDefn.lddName + "</releaseinfo>");
+		prDocBook.println("        <title>" + DMDocument.ddDocTitle + " - " + lSchemaFileDefn.lddName + "</title>");
+//		prDocBook.println("        <subtitle>Abridged - Version " + DMDocument.masterPDSSchemaFileDefn.ont_version_id + "</subtitle>");
+		prDocBook.println("        <subtitle>Version " + DMDocument.masterPDSSchemaFileDefn.ont_version_id + "</subtitle>");
+//		prDocBook.println("        <subtitle>Data Dictionary: " + lSchemaFileDefn.lddName + "</subtitle>");
+//		prDocBook.println("        <author>");
+//		prDocBook.println("            <orgname>" + DMDocument.ddDocTeam + "</orgname>");
+//		prDocBook.println("        </author>");
+//		prDocBook.println("        <releaseinfo>Information Model Version " + DMDocument.masterPDSSchemaFileDefn.ont_version_id + " on " + DMDocument.sTodaysDate + "</releaseinfo>");
+		prDocBook.println("        <releaseinfo>" + DMDocument.sTodaysDate + "</releaseinfo>");
+//		prDocBook.println("        <releaseinfo>Data Dictionary: " + lSchemaFileDefn.lddName + "</releaseinfo>");
 		prDocBook.println("        <date>" + DMDocument.sTodaysDate + "</date>");
 		prDocBook.println("    </info>");
 		prDocBook.println("        ");
 		prDocBook.println("        <chapter>");
 		prDocBook.println("            <title>Introduction</title>");
-		prDocBook.println("            <para>The Data Dictionary defines the organization and components of product labels. Components of a product label include classes and their attributes.</para>");
+// 333	prDocBook.println("            <para>The Data Dictionary defines the organization and components of product labels. Components of a product label include classes and their attributes.</para>");
+		prDocBook.println("            <para>This is the Enterprise 2.0 Data Dictionary for " + lSchemaFileDefn.lddName + ".</para>");
 		prDocBook.println("            <para>");
 		prDocBook.println("            </para>");
 		prDocBook.println("            <sect1>");
 		prDocBook.println("                <title>Audience</title>");
-		prDocBook.println("                <para>The Data Dictionary - Abridged - has been abstracted from the unabridged version with the needs of data providers and data end users in mind. It contains full definitions but not all the fine detail or repetition necessary to support the underlying Information Model.</para>");
+		prDocBook.println("                <para>This Data Dictionary is designed to be used by anyone who needs an enterprise-level or domain-level controlled vocabulary.</para>");
 		prDocBook.println("                <para>");
 		prDocBook.println("                </para>");
 		prDocBook.println("            </sect1>");
 		prDocBook.println("            <sect1>");
 		prDocBook.println("                <title>Acknowledgements</title>");
-		prDocBook.println("                <para>The Data Dictionary and the Information Model is a joint effort involving discipline experts functioning as a data design working group.</para>");
+		prDocBook.println("                <para>This Data Dictionary is a joint effort involving " + lSchemaFileDefn.lddName + " experts.</para>");
 		prDocBook.println("                <para>");
 		prDocBook.println("                </para>");
 		prDocBook.println("            </sect1>");
 		prDocBook.println("            <sect1>");
 		prDocBook.println("                <title>Scope</title>");
-		prDocBook.println("                <para>The Data Dictionary defines the common and discipline level classes and attributes used to create product labels. It also defines the meta-attributes (i.e. attributes about attributes) used to define attributes. This abridged version includes only one entry for each attribute where the unabridge version includes an entry for each use of an attribute in a class.</para>");
+		prDocBook.println("                <para>This Data Dictionary defines classes and attributes used in the " + lSchemaFileDefn.lddName + " domain and are proposed for use where interoperability based on common terms and definitions are desired.</para>");
 		prDocBook.println("                <para>");
 		prDocBook.println("                </para>");
 		prDocBook.println("            </sect1>");
@@ -1026,11 +935,6 @@ class WriteDOMDocBooks extends Object {
 		prDocBook.println("                    <itemizedlist>");
 		prDocBook.println("                        <listitem>");
 		prDocBook.println("                            <para>");
-		prDocBook.println("                                Information Model Specification - The Information Model is used as the source for class, attribute, and data type definitions. The model is presented in document format as the Information Model Specification.");
-		prDocBook.println("                            </para>");
-		prDocBook.println("                        </listitem>");
-		prDocBook.println("                        <listitem>");
-		prDocBook.println("                            <para>");
 		prDocBook.println("                                ISO/IEC 11179:3 Registry Metamodel and Basic Attributes Specification, 2003. - The ISO/IEC 11179 specification provides the schema for the data dictionary.");
 		prDocBook.println("                            </para>");
 		prDocBook.println("                        </listitem>");
@@ -1040,7 +944,7 @@ class WriteDOMDocBooks extends Object {
 			prDocBook.println("                    <itemizedlist>");
 			prDocBook.println("                        <listitem>");
 			prDocBook.println("                            <para>");
-			prDocBook.println("                                Planetary Science Data Dictionary - The online version of the PDS3 data dictionary was used as the source for a few data elements being carried over from the PDS3 data standards.");
+			prDocBook.println("                                Domain Source Documents - This data dictionary was derived from source documents in the domain.");
 			prDocBook.println("                            </para>");
 			prDocBook.println("                        </listitem>");
 			prDocBook.println("                        ");
@@ -1053,43 +957,72 @@ class WriteDOMDocBooks extends Object {
 		prDocBook.println("                <para>This document uses very specific engineering terminology to describe the various structures involved.  It is particularly important that readers who have absorbed the Standards Reference bear in mind that terms which are familiar in that context can have very different meanings in the present document. </para>");
 		prDocBook.println("                <para>Following are some definitions of essential terms used throughout this document.</para>");
 		prDocBook.println("                <itemizedlist>");
+
+		
 		prDocBook.println("                    <listitem>");
-		prDocBook.println("                        <para>An <emphasis role=\"italic\">attribute</emphasis> is a property or characteristic that provides a unit of information. For example, 'color' and 'length' are possible attributes. </para>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Artifact</emphasis> - An object made by a human being.</para>");
 		prDocBook.println("                    </listitem>");
+
 		prDocBook.println("                    <listitem>");
-		prDocBook.println("                        <para>A <emphasis role=\"italic\">class</emphasis> is a set of attributes (including a name) which defines a family.  A class is generic - a template from which individual members of the family may be constructed.");
-		prDocBook.println("                        </para>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Conceptual Object</emphasis> - Something which is neither digital or physical, but conceptual in nature such as a project.</para>");
 		prDocBook.println("                    </listitem>");
+
 		prDocBook.println("                    <listitem>");
-		prDocBook.println("                        <para>A <emphasis role=\"italic\">conceptual object</emphasis> is an object which is intangible (and, because it is intangible, does not fit into a digital archive).  Examples of 'conceptual objects' include the Cassini mission and NASA's strategic plan for solar system exploration.  Note that a PDF describing the Cassini mission is a digital object, not a conceptual object (nor a component of a conceptual object). </para>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Conceptual Data Object</emphasis> - A digital object that represents a concept.</para>");
 		prDocBook.println("                    </listitem>");
+
 		prDocBook.println("                    <listitem>");
-		prDocBook.println("                        <para>A <emphasis role=\"italic\">data element</emphasis> is a unit of data for which the definition, identification, representation and <emphasis role=\"italic\">permissible values</emphasis> are specified by means of a set of attributes. For example, the concept of a <emphasis role=\"italic\">calibration_lamp_state_flag</emphasis> is used to indicate whether the lamp used for onboard camera calibration was turned on or off during the capture of an image. The <emphasis role=\"italic\"> data element</emphasis> aspect of this concept is the named attribute (or data element)  <emphasis role=\"italic\">calibration_lamp_state_flag</emphasis>.</para>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Data</emphasis> - A representation of information in a formalized manner suitable for communication, interpretation, or processing. Examples of data include a sequence of bits, a table of numbers, the characters on a page, the recording of sounds, or a descriptive attributes of a moon rock specimen.</para>");
 		prDocBook.println("                    </listitem>");
+
 		prDocBook.println("                    <listitem>");
-		prDocBook.println("                        <para>A <emphasis role=\"italic\">data object</emphasis> is a physical, conceptual, or digital object.</para>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Data Artifact</emphasis> - A data object produced within, or generated from, a digital ecosystem.</para>");
 		prDocBook.println("                    </listitem>");
+
 		prDocBook.println("                    <listitem>");
-		prDocBook.println("                        <para>A <emphasis role=\"italic\">digital object</emphasis> is an object which is real data - for example, a binary image of a redwood tree or an ASCII table of atmospheric composition versus altitude.</para>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Data Object</emphasis> - A data object is either digital, physical, or conceptual. Examples of digital data objects include a time series or image. Examples of physical data objects are descriptions of such things as spacecraft, instruments, and facilities. Conceptual data objects include description of such things as projects and organizations.</para>");
 		prDocBook.println("                    </listitem>");
+
 		prDocBook.println("                    <listitem>");
-		prDocBook.println("                        <para><emphasis role=\"italic\">Formal</emphasis> as used in the definition of attributes that are names indicates that an established procedure was involved in creating the name.</para>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Data Repository</emphasis> - A digital store of managed JPL data artifacts that provides reliable, long-term access, now and in the future.</para>");
 		prDocBook.println("                    </listitem>");
+
 		prDocBook.println("                    <listitem>");
-		prDocBook.println("                        <para>A <emphasis role=\"italic\">unique identifier</emphasis> is a special type of identifier used to provide a reference number which is unique in a context.</para>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Digital Object</emphasis> - A sequence of digital bits, 0's and 1's.</para>");
 		prDocBook.println("                    </listitem>");
+
 		prDocBook.println("                    <listitem>");
-		prDocBook.println("                        <para><emphasis role=\"italic\">Local</emphasis> refers to the context within a single label.</para>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Digital Data Object</emphasis> - A digital object along with its representation metadata.</para>");
 		prDocBook.println("                    </listitem>");
+
 		prDocBook.println("                    <listitem>");
-		prDocBook.println("                        <para><emphasis role=\"italic\">Logical</emphasis> as used in the definition of logical identifier indicates that the identifier logically groups a set of objects. </para>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Gold Source</emphasis> - Used interchangeably with “official” in some cases, a gold source is the authoritative system or repository that contains data or information maintained by an organization responsible for its integrity. The management of gold sources follows the Controlled Content requirements of Document and Data Control (JPL Rules! DocID 57034). For example, Hardware Build Books (HBBs) may contain convenience copies of Inspection Reports (IRs), but the gold source for IRs is the Quality Assurance Reporting System (QARS). While most gold sources are now digitized, it is important to know that some hardcopy gold sources remain (e.g., legacy drawings).</para>");
 		prDocBook.println("                    </listitem>");
+
 		prDocBook.println("                    <listitem>");
-		prDocBook.println("                        <para>A <emphasis role=\"italic\">physical object</emphasis> is an object which is physical or tangible (and, therefore, does not itself fit into a digital archive).  Examples of 'physical objects' include the planet Saturn and the Venus Express magnetometer.  Note that an ASCII file describing Saturn is a digital object, not a physical object (nor a component of a physical object).  </para>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">JPL Data Artifact</emphasis> - A data artifact determined to be of value to JPL to preserve, share, and use both internally and externally to the organization. Formal definition can be found here on JPL Rules!</para>");
 		prDocBook.println("                    </listitem>");
+
 		prDocBook.println("                    <listitem>");
-		prDocBook.println("                        <para>A <emphasis role=\"italic\">resource</emphasis> is the target (referent) of any Uniform Resource Identifier; the thing to which a URI points.</para>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Knowledge</emphasis> - Understanding gained through experience or association. It is often characterized as propositional (know-that), competence (know-how), or acquaintance (know-about) , with relative levels of expertise determined by the depth of understanding of the subject matter, breadth of undertanding of that subject matter in relationship to other and larger domains, and skillfulness in applying it. Knowledge also is often categorized as tacit (hard to express because it is embedded in what we do) and explicit (more readily formalized and codified).</para>");
 		prDocBook.println("                    </listitem>");
+
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Metadata</emphasis> - A digital object (data) that describes a digital data object.</para>");
+		prDocBook.println("                    </listitem>");
+
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Physical Object</emphasis> - Something that physically exists that can be described such as a spacecraft or building</para>");
+		prDocBook.println("                    </listitem>");
+
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Physical Data Object</emphasis> - A digital object that represents a physical Thing.</para>");
+		prDocBook.println("                    </listitem>");
+
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Trusted Data Repository</emphasis> - A data repository that meets the CoreTrustSeal Certification requirements.</para>");
+		prDocBook.println("                    </listitem>");
+
 		prDocBook.println("                </itemizedlist>");
 		prDocBook.println("");
 		prDocBook.println("                <para>");
@@ -1107,8 +1040,6 @@ class WriteDOMDocBooks extends Object {
 	}
 
 	private String getPrompt (String lPrompt) {
-//		return "<emphasis role=\"italic\">" + "<emphasis role=\"bold\">" + lPrompt + "</emphasis>" + "</emphasis>";
-//		return "<emphasis role=\"italic\">" + lPrompt + "</emphasis>";
 		return "<emphasis>" + lPrompt + "</emphasis>";
 	}
 	
@@ -1127,8 +1058,6 @@ class WriteDOMDocBooks extends Object {
 	}
 			
 	private String getValueAnchor(DOMAttr lAttr, String lValue) {
-//		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.parentClassTitle + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.title + "." + lValue;
-//		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.attrParentClass.title + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.title + "." + lValue;
 		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.classNameSpaceIdNC + "." + lAttr.attrParentClass.title + "." + lAttr.nameSpaceIdNC + "." + lAttr.title + "." + lValue;
 		int lAnchorI = lAnchor.hashCode();
 		lAnchor = "N" + Integer.toString(lAnchorI);
@@ -1146,8 +1075,6 @@ class WriteDOMDocBooks extends Object {
 	}
 	
 	private String getAttrAnchor(DOMAttr lAttr) {
-//		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.parentClassTitle + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.title;
-//		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.attrParentClass.title + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.title;
 		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.classNameSpaceIdNC + "." + lAttr.attrParentClass.title + "." + lAttr.nameSpaceIdNC + "." + lAttr.title;
 		int lAnchorI = lAnchor.hashCode();
 		lAnchor = "N" + Integer.toString(lAnchorI);
@@ -1243,11 +1170,6 @@ class WriteDOMDocBooks extends Object {
 	/**
 	* escape certain characters for DocBook
 	*/
-	 String escapeDocBookChar (String aString) {
-		String lString = aString;
-//		lString = replaceString (lString, "\\", "\\\\");
-		return lString;
-	}
 	 
 	 // locally defined classes for classifying classes and attributes
 	 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBooks.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBooks.java
@@ -1,0 +1,1281 @@
+// Copyright 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+// * Neither the name of Caltech nor its operating division, the Jet Propulsion
+// Laboratory, nor the names of its contributors may be used to endorse or
+// promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+package gov.nasa.pds.model.plugin; 
+
+import java.io.*;
+import java.util.*;
+
+// Write the PDS4 Data Dictionary DocBook file. - Modified to write a DocBook file for each namespace id
+
+class WriteDOMDocBooks extends Object {
+	// class structures
+	TreeMap <String, ClassClassificationDefnDOM> classClassificationMap;
+	ArrayList <ClassClassificationDefnDOM> classClassificationArr;	
+	
+	// namespaces to process
+	ArrayList <SchemaFileDefn> lSchemaFileDefnToWriteArr;
+	
+	// attribute structures
+	TreeMap <String, AttrClassificationDefnDOM> attrClassificationMap;
+	ArrayList <AttrClassificationDefnDOM> attrClassificationArr;
+	
+	// Miscellaneous
+	String writtenNamespaceIds = DMDocument.masterPDSSchemaFileDefn.identifier + " v" + DMDocument.masterPDSSchemaFileDefn.versionId ;
+	
+// Insert zero-width space characters (&#x200B;) in text strings; form break points for the lines.
+	
+	public WriteDOMDocBooks () {
+		// class structures
+		classClassificationMap = new TreeMap <String, ClassClassificationDefnDOM> ();
+		attrClassificationMap = new TreeMap <String, AttrClassificationDefnDOM> ();
+		
+		// get the current namespaces and initialize classification maps
+		if (! DMDocument.LDDToolFlag) {
+			// only the common dictionary (pds)
+			lSchemaFileDefnToWriteArr = new ArrayList <SchemaFileDefn> ();
+			lSchemaFileDefnToWriteArr.add(DMDocument.masterPDSSchemaFileDefn);
+		} else {
+			// intialize array to capture namespaces to be written
+			ArrayList <String> lDDNamespaceArr = new ArrayList <String> ();
+			lSchemaFileDefnToWriteArr = new ArrayList <SchemaFileDefn> ();
+			
+			// first get the common dictionary
+			ArrayList <SchemaFileDefn> tempSchemaFileDefnToWriteArr = new ArrayList <SchemaFileDefn> ();
+			tempSchemaFileDefnToWriteArr.add(DMDocument.masterPDSSchemaFileDefn);
+    		lSchemaFileDefnToWriteArr.add(DMDocument.masterPDSSchemaFileDefn);
+    		lDDNamespaceArr.add(DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC);
+            
+			// now add all the LDDs that are stacked for this run
+            tempSchemaFileDefnToWriteArr = new ArrayList <SchemaFileDefn> (DMDocument.LDDSchemaFileSortMap.values());
+			for(SchemaFileDefn lSchemaFileDefn : tempSchemaFileDefnToWriteArr) {
+            	if (! lDDNamespaceArr.contains(lSchemaFileDefn.nameSpaceIdNC)) {
+        			lSchemaFileDefnToWriteArr.add(lSchemaFileDefn);
+        			lDDNamespaceArr.add(lSchemaFileDefn.nameSpaceIdNC);
+            	}
+            }
+		}
+		
+//		System.out.println("");
+		for (Iterator <SchemaFileDefn> i = lSchemaFileDefnToWriteArr.iterator(); i.hasNext();) {
+			SchemaFileDefn lSchemaFileDefn = (SchemaFileDefn) i.next();
+			classClassificationMap.put(lSchemaFileDefn.nameSpaceIdNC, new ClassClassificationDefnDOM (lSchemaFileDefn.nameSpaceIdNC));
+			attrClassificationMap.put(lSchemaFileDefn.nameSpaceIdNC, new AttrClassificationDefnDOM (lSchemaFileDefn.nameSpaceIdNC));
+		}
+		
+		classClassificationMap.put("pds.product", new ClassClassificationDefnDOM ("pds.product"));
+		if (DMDocument.pds4ModelFlag) classClassificationMap.put("pds.ops", new ClassClassificationDefnDOM ("pds.ops"));
+		classClassificationMap.put("pds.support", new ClassClassificationDefnDOM ("pds.support"));
+		classClassificationMap.put("pds.other", new ClassClassificationDefnDOM ("pds.other"));
+
+		classClassificationMap.put("other", new ClassClassificationDefnDOM ("other"));
+		classClassificationArr = new ArrayList <ClassClassificationDefnDOM> (classClassificationMap.values());
+		attrClassificationMap.put("other", new AttrClassificationDefnDOM ("other"));
+		attrClassificationArr = new ArrayList <AttrClassificationDefnDOM> (attrClassificationMap.values());
+		
+		// classify attributes and classes
+		// get the class classification maps
+		for (Iterator <DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
+			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
+			getClassClassification (lClass);
+		}
+		
+		// get the classification arrays
+		for (Iterator <ClassClassificationDefnDOM> i = classClassificationArr.iterator(); i.hasNext();) {
+			ClassClassificationDefnDOM lClassClassificationDefn = (ClassClassificationDefnDOM) i.next();
+			lClassClassificationDefn.classArr = new ArrayList <DOMClass> (lClassClassificationDefn.classMap.values());
+		}
+		
+		// get the attribute classification maps
+		for (Iterator <DOMAttr> i = DOMInfoModel.masterDOMAttrArr.iterator(); i.hasNext();) {
+			DOMAttr lAttr = (DOMAttr) i.next();
+			if (lAttr.isInactive) continue;
+			getAttrClassification (lAttr);
+		}
+		
+		// get the classification arrays
+		for (Iterator <AttrClassificationDefnDOM> i = attrClassificationArr.iterator(); i.hasNext();) {
+			AttrClassificationDefnDOM lAttrClassificationDefn = (AttrClassificationDefnDOM) i.next();
+			lAttrClassificationDefn.attrArr = new ArrayList <DOMAttr> (lAttrClassificationDefn.attrMap.values());
+		}
+		
+		// print out the class and attribute counts
+		DMDocument.registerMessage ("0>info " + "DD DocBook Class Counts");
+		Set <String> set9 = classClassificationMap.keySet();
+		Iterator <String> iter9 = set9.iterator();
+		while(iter9.hasNext()) {
+			String lId = (String) iter9.next();
+			ClassClassificationDefnDOM lClassClassificationDefnDOM = classClassificationMap.get(lId);
+			if (lClassClassificationDefnDOM != null ) {
+				DMDocument.registerMessage ("0>info " + " - namespace: " + lId + "   size: " + lClassClassificationDefnDOM.classArr.size());
+				if (lClassClassificationDefnDOM.classArr.size() > 0) {
+					if (! (lId.compareTo(DMDocument.masterNameSpaceIdNCLC) == 0
+							|| lId.compareTo("pds.product") == 0 
+							|| lId.compareTo("pds.ops") == 0 
+							|| lId.compareTo("pds.support") == 0 
+							|| lId.compareTo("pds.other") == 0 
+							|| lId.compareTo("other") == 0 )) {
+						writtenNamespaceIds += ", " + lId;
+						SchemaFileDefn lSchemaFileDefn = DMDocument.LDDSchemaFileSortMap.get(lId);
+						if (lSchemaFileDefn != null)
+							writtenNamespaceIds += " v" + lSchemaFileDefn.versionId;
+					}
+				}
+			}
+		} 
+		
+		DMDocument.registerMessage ("0>info " + "DD DocBook Attribute Counts");
+		Set <String> set92 = classClassificationMap.keySet();
+		Iterator <String> iter92 = set92.iterator();
+		while(iter92.hasNext()) {
+			String lId = (String) iter92.next();
+			AttrClassificationDefnDOM lAttrClassificationDefnDOM = attrClassificationMap.get(lId);
+			if (lAttrClassificationDefnDOM != null )
+				DMDocument.registerMessage ("0>info " + " - namespace: " + lId + "   size: " + lAttrClassificationDefnDOM.attrArr.size());
+		}
+		return;
+	}
+	
+	public void getClassClassification (DOMClass lClass) {
+		if (lClass.isDataType) return;
+		if (lClass.isUnitOfMeasure) return;
+		
+		// classify the class by namespace and other criteria
+		ClassClassificationDefnDOM lClassClassificationDefn = classClassificationMap.get(lClass.nameSpaceIdNC);
+		if (lClassClassificationDefn != null) {			
+			if (lClass.nameSpaceIdNC.compareTo(DMDocument.masterNameSpaceIdNCLC) == 0) {
+				// i.e., the Common directory, pds
+				if (lClass.steward.compareTo("ops") == 0) {
+					lClassClassificationDefn = classClassificationMap.get("pds.ops");
+					lClassClassificationDefn.classMap.put(lClass.identifier, lClass);
+				} else if (lClass.isRegistryClass) {
+					lClassClassificationDefn = classClassificationMap.get("pds.product");
+					lClassClassificationDefn.classMap.put(lClass.identifier, lClass);	
+				} else {
+					lClassClassificationDefn = classClassificationMap.get("pds.support");
+					lClassClassificationDefn.classMap.put(lClass.identifier, lClass);	
+				}
+			} else {
+				// all LDD namespaces
+				lClassClassificationDefn.classMap.put(lClass.identifier, lClass);
+			}
+		} else {
+			lClassClassificationDefn = classClassificationMap.get("other");
+			lClassClassificationDefn.classMap.put(lClass.identifier, lClass);
+		}
+		return;
+	}
+	
+	public void getAttrClassification (DOMAttr lAttr) {
+		if (! (lAttr.isUsedInClass && lAttr.isAttribute)) return;
+
+		// classify the class by namespace and other criteria
+		String lAttrId = lAttr.title + "." + lAttr.nameSpaceIdNC + "." + lAttr.attrParentClass.title + "." + lAttr.classNameSpaceIdNC + "." +  DMDocument.registrationAuthorityIdentifierValue;
+		AttrClassificationDefnDOM lAttrClassificationDefn = attrClassificationMap.get(lAttr.nameSpaceIdNC);
+		if (lAttrClassificationDefn != null) {	
+			lAttrClassificationDefn.attrMap.put(lAttrId, lAttr);	
+		} else {
+			lAttrClassificationDefn = attrClassificationMap.get("other");
+			lAttrClassificationDefn.attrMap.put(lAttrId, lAttr);
+		}
+		return;
+	}
+	
+//	print the DocBook Files
+	public void writeDocBooks (SchemaFileDefn lSchemaFileDefn) throws java.io.IOException {
+		String lFileName = lSchemaFileDefn.relativeFileSpecDDDocXML;
+		String lLabelVersionId = "_" + DMDocument.masterPDSSchemaFileDefn.lab_version_id;
+		String lDOMLabelVersionId = lLabelVersionId;
+		lFileName = DMDocument.replaceString (lFileName, lLabelVersionId, lDOMLabelVersionId);
+        
+        // iterate over the namespace ids
+		for (SchemaFileDefn lSchemaFileDefnToWrite : lSchemaFileDefnToWriteArr) {
+			ClassClassificationDefnDOM lClassClassificationDefn = classClassificationMap.get(lSchemaFileDefnToWrite.nameSpaceIdNCLC);
+			AttrClassificationDefnDOM lAttrClassificationDefn = attrClassificationMap.get(lSchemaFileDefnToWrite.nameSpaceIdNCLC);
+			writeDocBook (lSchemaFileDefnToWrite, lClassClassificationDefn, lAttrClassificationDefn);
+		}
+		return;
+	}	
+	
+//	write a DocBook File
+	public void writeDocBook (SchemaFileDefn lSchemaFileDefn, ClassClassificationDefnDOM lClassClassificationDefn, AttrClassificationDefnDOM lAttrClassificationDefn) throws java.io.IOException {
+		String lFileName = lSchemaFileDefn.relativeFileSpecDDDocXML;
+		String lLabelVersionId = "_" + DMDocument.masterPDSSchemaFileDefn.lab_version_id;
+		String lDOMLabelVersionId = lLabelVersionId;
+		lFileName = DMDocument.replaceString (lFileName, lLabelVersionId, lDOMLabelVersionId);
+		PrintWriter prDocBook = new PrintWriter(new OutputStreamWriter (new FileOutputStream(new File(lFileName)), "UTF-8"));
+		writeHeader (lSchemaFileDefn, prDocBook);
+        
+        // write the sections
+			if (lClassClassificationDefn != null) {
+				if (lClassClassificationDefn.classArr.size() > 0)
+					writeClassSection (lClassClassificationDefn, prDocBook);
+			}
+			if (lAttrClassificationDefn != null) {
+				if (lAttrClassificationDefn.attrArr.size() > 0)
+					writeAttrSection (lAttrClassificationDefn, prDocBook);
+			}
+        
+        // write the Data Types and Units
+		writeDataTypeSection (DMDocument.masterNameSpaceIdNCLC, prDocBook);
+		writeUnitsSection (DMDocument.masterNameSpaceIdNCLC, prDocBook);
+		writeFooter (prDocBook);
+		prDocBook.close();
+		return;
+	}
+	
+	
+//	print DocBook File
+/*	public void writeDocBook (SchemaFileDefn lSchemaFileDefn) throws java.io.IOException {
+		String lFileName = lSchemaFileDefn.relativeFileSpecDDDocXML;
+		String lLabelVersionId = "_" + DMDocument.masterPDSSchemaFileDefn.lab_version_id;
+		String lDOMLabelVersionId = lLabelVersionId;
+		lFileName = DMDocument.replaceString (lFileName, lLabelVersionId, lDOMLabelVersionId);
+		PrintWriter prDocBook = new PrintWriter(new OutputStreamWriter (new FileOutputStream(new File(lFileName)), "UTF-8"));
+		writeHeader (prDocBook);
+		
+		// write the Common dictionary
+		writeClassSection (DMDocument.masterNameSpaceIdNCLC,prDocBook);
+        writeAttrSection (DMDocument.masterNameSpaceIdNCLC, prDocBook);
+        
+        // write the LDDs
+		for (Iterator <SchemaFileDefn> i = lSchemaFileDefnToWriteArr.iterator(); i.hasNext();) {
+			SchemaFileDefn lSchemaFileDefnToWrite = (SchemaFileDefn) i.next();
+			if (lSchemaFileDefnToWrite.nameSpaceIdNCLC.compareTo(DMDocument.masterNameSpaceIdNCLC) == 0) continue; // skip master namespace
+			ClassClassificationDefnDOM lClassClassificationDefn = classClassificationMap.get(lSchemaFileDefnToWrite.nameSpaceIdNCLC);
+			if (lClassClassificationDefn != null) {
+				if (lClassClassificationDefn.classArr.size() > 0)
+					writeClassSection (lClassClassificationDefn, prDocBook);
+			}
+			AttrClassificationDefnDOM lAttrClassificationDefn = attrClassificationMap.get(lSchemaFileDefnToWrite.nameSpaceIdNCLC);
+			if (lAttrClassificationDefn != null) {
+				if (lAttrClassificationDefn.attrArr.size() > 0)
+					writeAttrSection (lAttrClassificationDefn, prDocBook);
+			}
+		}
+        
+        // write the Data Types and Units
+     	writeDataTypeSection (DMDocument.masterNameSpaceIdNCLC, prDocBook);
+    	writeUnitsSection (DMDocument.masterNameSpaceIdNCLC, prDocBook);
+		writeFooter (prDocBook);
+		prDocBook.close();
+		return;
+	}	*/
+	
+	private void writeClassSection (String lNameSpaceId, PrintWriter prDocBook) {
+        prDocBook.println("");	
+        prDocBook.println("      <!-- =====================Part2 Begin=========================== -->");
+        prDocBook.println("");
+		
+		ClassClassificationDefnDOM lClassClassificationDefn = classClassificationMap.get("pds.product");
+		if (lClassClassificationDefn != null) {
+			prDocBook.println("        <chapter>");
+			prDocBook.println("           <title>Product Classes in the common namespace.</title>");
+			prDocBook.println("           <para>These classes define the products.</para>");
+			for (Iterator <DOMClass> j = lClassClassificationDefn.classArr.iterator(); j.hasNext();) {
+				DOMClass lClass = (DOMClass) j.next();
+				writeClass (lClass, prDocBook);						
+			}
+			prDocBook.println("        </chapter>");
+	        prDocBook.println("");
+		}
+
+		lClassClassificationDefn = classClassificationMap.get("pds.support");
+		if (lClassClassificationDefn != null) {
+			prDocBook.println("        <chapter>");
+			prDocBook.println("           <title>Support classes in the common namespace.</title>");
+			prDocBook.println("           <para>The classes in this section are used by the product classes.</para>");
+			for (Iterator <DOMClass> j = lClassClassificationDefn.classArr.iterator(); j.hasNext();) {
+				DOMClass lClass = (DOMClass) j.next();
+				writeClass (lClass, prDocBook);						
+			}
+			prDocBook.println("        </chapter>");
+	        prDocBook.println("");
+
+		}
+		
+		if (! DMDocument.importJSONAttrFlag) {  // if a JSON run, dont write the following
+			lClassClassificationDefn = classClassificationMap.get("pds.ops");
+			if (lClassClassificationDefn != null) {
+				prDocBook.println("        <chapter>");
+				prDocBook.println("           <title>OPS catalog classes in the common namespace.</title>");
+				prDocBook.println("           <para>These classes support operations. </para>");
+				for (Iterator <DOMClass> j = lClassClassificationDefn.classArr.iterator(); j.hasNext();) {
+					DOMClass lClass = (DOMClass) j.next();
+					writeClass (lClass, prDocBook);						
+				}
+				prDocBook.println("        </chapter>");
+				prDocBook.println("");
+			}
+		}
+		
+        prDocBook.println("      <!-- =====================Part2 End=========================== -->");
+        prDocBook.println("");
+	}
+	
+	private void writeClassSection (ClassClassificationDefnDOM lClassClassificationDefn, PrintWriter prDocBook) {
+        prDocBook.println("");	
+        prDocBook.println("      <!-- ===================== LDD Class Begin =========================== -->");
+        prDocBook.println("");
+		
+		prDocBook.println("        <chapter>");
+		prDocBook.println("           <title>Classes in the " + lClassClassificationDefn.namespaceId + " namespace.</title>");
+		prDocBook.println("           <para>These classes comprise the namespace.</para>");
+		for (Iterator <DOMClass> j = lClassClassificationDefn.classArr.iterator(); j.hasNext();) {
+			DOMClass lClass = (DOMClass) j.next();
+			writeClass (lClass, prDocBook);						
+		}
+		prDocBook.println("        </chapter>");
+        prDocBook.println("");
+		
+        prDocBook.println("      <!-- ===================== LDD Class End =========================== -->");
+        prDocBook.println("");
+	}	
+		
+	private void writeAttrSection (AttrClassificationDefnDOM lAttrClassificationDefn, PrintWriter prDocBook) {
+		prDocBook.println("");	
+		prDocBook.println("      <!-- ===================== LDD Attribute Begin =========================== -->");
+		prDocBook.println("");
+
+		prDocBook.println("        <chapter>");
+		prDocBook.println("           <title>Attributes in the " + lAttrClassificationDefn.namespaceId + " namespace.</title>");
+		prDocBook.println("           <para>These attributes are used by the classes in the " + lAttrClassificationDefn.namespaceId + " namespace. </para>");
+		for (Iterator <DOMAttr> j = lAttrClassificationDefn.attrArr.iterator(); j.hasNext();) {
+			DOMAttr lAttr = (DOMAttr) j.next();
+			writeAttr (lAttr, prDocBook);						
+		}
+		prDocBook.println("        </chapter>");
+		prDocBook.println("");
+		
+		prDocBook.println("      <!-- ===================== LDD Attribute Begin =========================== -->");
+		prDocBook.println("");
+	}
+	
+	private void writeClass (DOMClass lClass, PrintWriter prDocBook) {
+ 		String lValueString = "";
+ 		String lValueDel = "";
+        String lRegistrationStatus = "Active";
+        String lRegistrationStatusInsert = "";
+        if (lClass.registrationStatus.compareTo("Retired") == 0) {
+        	lRegistrationStatus = "Deprecated";
+        	lRegistrationStatusInsert = " " + DMDocument.Literal_DEPRECATED;;
+        }
+ 		prDocBook.println("<sect1>");
+    	prDocBook.println("    <title>" + getClassAnchor(lClass) + getValue(lClass.title) + lRegistrationStatusInsert + "</title>");
+        prDocBook.println("");
+        prDocBook.println("<para>");
+        prDocBook.println("    <informaltable frame=\"all\" colsep=\"1\">");
+        prDocBook.println("        <tgroup cols=\"4\" align=\"left\" colsep=\"1\" rowsep=\"1\">");
+        prDocBook.println("            <colspec colnum=\"1\" colname=\"c1\" colwidth=\"1.0*\"/>");
+        prDocBook.println("            <colspec colnum=\"2\" colname=\"c2\" colwidth=\"1.0*\"/>");
+        prDocBook.println("            <colspec colnum=\"3\" colname=\"c3\" colwidth=\"1.0*\"/>");
+        prDocBook.println("            <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
+        prDocBook.println("            <thead>");
+        prDocBook.println("                <row>");
+        prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">" + getPrompt("Name: ") + getValue(lClass.title) + lRegistrationStatusInsert + "</entry>");
+//        prDocBook.println("                    <entry>" + getPrompt("Version Id: ") + getValue("1.0.0.0") + "</entry>");        
+        prDocBook.println("                    <entry>" + getPrompt("Version Id: ") + getValue(lClass.versionId) + "</entry>");
+        prDocBook.println("                </row>");
+        prDocBook.println("            </thead>");
+        prDocBook.println("            <tbody>");
+        prDocBook.println("                <row>");
+        prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">" + getPrompt("Description:") + getValue(lClass.definition) + "</entry>");
+        prDocBook.println("                </row>");
+        prDocBook.println("                <row>");
+        prDocBook.println("                    <entry>" + getPrompt("Namespace Id: ") + getValue(lClass.nameSpaceIdNC) + "</entry>");
+        prDocBook.println("                    <entry>" + getPrompt("Steward: ") + getValue(lClass.steward) + "</entry>");
+        prDocBook.println("                    <entry>" + getPrompt("Role: ") + getValue(lClass.role) + "</entry>");
+        prDocBook.println("                    <entry>" + getPrompt("Status: ") + lRegistrationStatus + "</entry>");
+        prDocBook.println("                </row>");
+        prDocBook.println("");
+        
+        // write hierarchy
+ 		ArrayList <DOMClass> lClassArr = new ArrayList <DOMClass> (lClass.superClassHierArr);
+ 		lClassArr.add(lClass);
+ 		lValueString = "";
+ 		lValueDel = "";
+		for (Iterator <DOMClass> i = lClassArr.iterator(); i.hasNext();) {
+			DOMClass lHierClass = (DOMClass) i.next();
+			lValueString += lValueDel + getClassLink(lHierClass);
+			lValueDel = " :: "; 
+		}
+        prDocBook.println("                <row>");
+        prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">" + getPrompt("Class Hierarchy: ") + lValueString + "</entry>");
+        prDocBook.println("                </row>");
+
+        // determine the type and number of class members (attributes and classes)
+		int attrCount = 0, assocCount= 0;
+        if (lClass.allAttrAssocArr != null) {
+			for (Iterator <DOMProp> i = lClass.allAttrAssocArr.iterator(); i.hasNext();) {
+				DOMProp lProp = (DOMProp) i.next();
+				if (lProp.isAttribute) {
+					attrCount ++;
+				} else {
+					assocCount ++;
+				}
+			}
+        }
+        
+		// write the attributes
+		if (attrCount == 0) {
+		       prDocBook.println("                <row>");
+	           prDocBook.println("                    <entry>" + getPrompt("No Attributes") + "</entry>");
+	           prDocBook.println("                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\"></entry>");
+	           prDocBook.println("                </row>");
+		} else {
+            prDocBook.println("                <row>");
+            prDocBook.println("                    <entry>" + getPrompt("Attribute(s)") + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("Name") + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("Cardinality") + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("Value") + "</entry>");
+            prDocBook.println("                </row>");
+            
+			for (Iterator <DOMProp> j = lClass.allAttrAssocArr.iterator(); j.hasNext();) {
+				DOMProp lProp = (DOMProp) j.next();
+				if (! lProp.isAttribute) continue;
+				DOMAttr lAttr = (DOMAttr)lProp.hasDOMObject;
+	            lValueString = "None";
+	            lValueDel = "";
+	    		if ( ! (lAttr.domPermValueArr == null || lAttr.domPermValueArr.size() == 0)) {
+		            lValueString = "";
+	    			for (Iterator <DOMProp> k = lAttr.domPermValueArr.iterator(); k.hasNext();) {
+	    				DOMProp lDOMProp = (DOMProp) k.next();
+	    				if (! (lDOMProp.hasDOMObject instanceof DOMPermValDefn))  continue;	    				
+	    			    DOMPermValDefn lPermValueDefn = (DOMPermValDefn) lDOMProp.hasDOMObject;
+	    			    lValueString += lValueDel + getValueLink(lAttr, getValue(lPermValueDefn.value));
+	    				lValueDel = ", ";
+	    			}
+	    		}
+	            prDocBook.println("                <row>");
+	            prDocBook.println("                    <entry></entry>");
+	            prDocBook.println("                    <entry>" + getAttrLink(lAttr) + "</entry>");
+	            prDocBook.println("                    <entry>" + getValue(getCardinality(lAttr.cardMinI, lAttr.cardMaxI)) + "</entry>");
+	            prDocBook.println("                    <entry>" + lValueString + "</entry>");
+	            prDocBook.println("                </row>");	
+			}
+		}
+		
+		// write the associations
+		if (assocCount == 0) {
+		       prDocBook.println("                <row>");
+	           prDocBook.println("                    <entry>" + getPrompt("No Associations") + "</entry>");
+	           prDocBook.println("                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\"></entry>");
+	           prDocBook.println("                </row>");
+		} else {
+
+			// write the associations
+            prDocBook.println("                <row>");
+            prDocBook.println("                    <entry>" + getPrompt("Association(s)") + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("Name") + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("Cardinality") + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("Class") + "</entry>");
+            prDocBook.println("                </row>");
+            
+            // first get array of member classes for this association
+            TreeMap <String, String> lPropOrderMap = new TreeMap <String, String> ();
+            TreeMap <String, String> lPropCardMap = new TreeMap <String, String> ();
+            TreeMap <String, TreeMap <String, DOMClass>> lPropMemberClassMap = new TreeMap <String, TreeMap <String, DOMClass>> ();
+
+            Integer lSeqNumI = 1000;
+            for (Iterator <DOMProp> j = lClass.allAttrAssocArr.iterator(); j.hasNext();) {       	
+				DOMProp lDOMProp = (DOMProp) j.next();
+				if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMClass) {
+					DOMClass lMemberDOMClass = (DOMClass) lDOMProp.hasDOMObject;
+					TreeMap <String, DOMClass> lMemberClassMap = lPropMemberClassMap.get(lDOMProp.title);
+					if (lMemberClassMap != null) {
+						lMemberClassMap.put(lMemberDOMClass.title, lMemberDOMClass);
+					} else {
+						lSeqNumI++;
+						String lSeqNum = lSeqNumI.toString();
+						lPropOrderMap.put(lSeqNum, lDOMProp.title);
+						lMemberClassMap = new TreeMap <String, DOMClass> ();
+						lMemberClassMap.put(lMemberDOMClass.title, lMemberDOMClass);
+						lPropMemberClassMap.put(lDOMProp.title, lMemberClassMap);
+						lPropCardMap.put(lDOMProp.title, getValue(getCardinality(lDOMProp.cardMinI, lDOMProp.cardMaxI)));
+					}
+	    		}
+			}
+            
+            // write the member classes
+			ArrayList <String> lPropOrderArr = new ArrayList <String> (lPropOrderMap.values());
+			for (Iterator <String> j = lPropOrderArr.iterator(); j.hasNext();) {
+				String lDOMPropTitle = (String) j.next();
+				TreeMap <String, DOMClass> lMemberClassMap = lPropMemberClassMap.get(lDOMPropTitle);
+				String lCardString = lPropCardMap.get(lDOMPropTitle);
+				if (lCardString != null && lMemberClassMap != null) {
+					ArrayList <DOMClass> lMemberClassArr = new ArrayList <DOMClass> (lMemberClassMap.values());
+		            lValueString = "";
+		            lValueDel = "";
+		            for (Iterator <DOMClass> k = lMemberClassArr.iterator(); k.hasNext();) {
+						DOMClass lMemberClass = (DOMClass) k.next();
+		    		    lValueString += lValueDel + getClassLink(lMemberClass);
+			    		lValueDel = ", ";
+					}
+	                prDocBook.println("                <row>");
+	                prDocBook.println("                    <entry></entry>");
+	                prDocBook.println("                    <entry>" + getValueBreak(lDOMPropTitle) + "</entry>");
+	                prDocBook.println("                    <entry>" + lCardString + "</entry>");
+	                prDocBook.println("                    <entry>" + lValueString + "</entry>");
+	                prDocBook.println("                </row>");
+	    		}
+			}
+		}
+		
+        // write the references
+ 		ArrayList <DOMClass> lRefClassArr = getClassReferences (lClass);
+ 		lValueString = "";
+ 		lValueDel = "";
+ 		if (! (lRefClassArr == null || lRefClassArr.isEmpty())) {
+ 			for (Iterator <DOMClass> i = lRefClassArr.iterator(); i.hasNext();) {
+ 				DOMClass lRefClass = (DOMClass) i.next();
+ 				lValueString += lValueDel + getClassLink(lRefClass);
+ 				lValueDel = ", ";
+ 			}
+ 		} else {
+ 	 		lValueString = "None";
+ 		}
+        prDocBook.println("                <row>");
+//        prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">" + getPrompt("Referenced from: ") + getValue(lValueString) + "</entry>");
+        prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">" + getPrompt("Referenced from: ") + lValueString + "</entry>");
+        prDocBook.println("                </row>");
+        prDocBook.println("            </tbody>");
+        prDocBook.println("        </tgroup>");
+        prDocBook.println("        </informaltable>");
+        prDocBook.println("</para>");
+    	prDocBook.println("</sect1> ");
+        return;
+	}	
+				
+	private void writeAttrSection (String lNameSpaceId, PrintWriter prDocBook) {
+        prDocBook.println("");	
+        prDocBook.println("      <!-- =====================Part3 Begin=========================== -->");
+        prDocBook.println("");
+		
+		AttrClassificationDefnDOM lAttrClassificationDefn = attrClassificationMap.get(DMDocument.masterNameSpaceIdNCLC);
+		if (lAttrClassificationDefn != null) {
+			prDocBook.println("        <chapter>");
+			prDocBook.println("           <title>Attributes in the common namespace.</title>");
+			prDocBook.println("           <para>These attributes are used by the classes in the common namespace. </para>");
+			for (Iterator <DOMAttr> j = lAttrClassificationDefn.attrArr.iterator(); j.hasNext();) {
+				DOMAttr lAttr = (DOMAttr) j.next();
+				writeAttr (lAttr, prDocBook);						
+			}
+			prDocBook.println("        </chapter>");
+	        prDocBook.println("");
+		}
+		
+        prDocBook.println("      <!-- =====================Part3 End=========================== -->");
+        prDocBook.println("");
+	}
+	
+	private void writeAttr (DOMAttr lAttr, PrintWriter prDocBook) {
+        String lRegistrationStatus = "Active";
+        String lRegistrationStatusInsert = "";
+        if (lAttr.registrationStatus.compareTo("Retired") == 0) {
+        	lRegistrationStatus = "Deprecated";
+        	lRegistrationStatusInsert = " " + DMDocument.Literal_DEPRECATED;;
+        }
+	    prDocBook.println("<sect1>");
+
+	    prDocBook.println("    <title>" + getValue(lAttr.title) + "  in  " + getClassLink(lAttr.attrParentClass) + lRegistrationStatusInsert + "</title>");
+	    prDocBook.println("");
+	    prDocBook.println("<para>");
+	    prDocBook.println("    <informaltable frame=\"all\" colsep=\"1\">");
+	    prDocBook.println("        <tgroup cols=\"4\" align=\"left\" colsep=\"1\" rowsep=\"1\">");
+	    prDocBook.println("            <colspec colnum=\"1\" colname=\"c1\" colwidth=\"1.0*\"/>");
+	    prDocBook.println("            <colspec colnum=\"2\" colname=\"c2\" colwidth=\"1.0*\"/>");
+	    prDocBook.println("            <colspec colnum=\"3\" colname=\"c3\" colwidth=\"1.0*\"/>");
+	    prDocBook.println("            <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
+	    prDocBook.println("            <thead>");
+	    prDocBook.println("                <row>");
+	    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">" + getPrompt("Name: ") + getAttrAnchor(lAttr) + getValue(lAttr.title) + lRegistrationStatusInsert + "</entry>");
+	    prDocBook.println("                    <entry>" + getPrompt("Version Id: ") + getValue("1.0.0.0") + "</entry>");
+//	    prDocBook.println("                    <entry>" + getPrompt("Version Id: ") + getValue(lAttr.versionId) + "</entry>");
+	    prDocBook.println("                </row>");
+	    prDocBook.println("            </thead>");
+	    prDocBook.println("            <tbody>");
+	    prDocBook.println("                <row>");
+	    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">" + getPrompt("Description: ") + getValue(lAttr.definition) + "</entry>");
+	    prDocBook.println("                </row>");
+	    prDocBook.println("                <row>");
+//	    prDocBook.println("                    <entry>" + getPrompt("Namespace Id: ") + getValue(lAttr.attrNameSpaceIdNC) + "</entry>");
+	    prDocBook.println("                    <entry>" + getPrompt("Namespace Id: ") + getValue(lAttr.getNameSpaceIdNC ()) + "</entry>");
+//	    prDocBook.println("                    <entry>" + getPrompt("Steward: ") + getValue(lAttr.steward) + "</entry>");
+	    prDocBook.println("                    <entry>" + getPrompt("Steward: ") + getValue(lAttr.getSteward ()) + "</entry>");
+//	    prDocBook.println("                    <entry>" + getPrompt("Class Name: ") + getValueBreak(lAttr.className) + "</entry>");
+//	    prDocBook.println("                    <entry>" + getPrompt("Class Name: ") + getClassLink(lParentClass) + "</entry>");
+	    prDocBook.println("                    <entry>" + getPrompt("Class Name: ") + getClassLink(lAttr.attrParentClass) + "</entry>");
+	    prDocBook.println("                    <entry>" + getPrompt("Type: ") + getDataTypeLink(lAttr.valueType) + "</entry>");
+	    prDocBook.println("                </row>");
+	    prDocBook.println("                <row>");
+//	    prDocBook.println("                    <entry>" + getPrompt("Minimum Value: ") + getValueReplaceTBDWithNone(lAttr.minimum_value) + "</entry>");
+//	    prDocBook.println("                    <entry>" + getPrompt("Maximum Value: ") + getValueReplaceTBDWithNone(lAttr.maximum_value) + "</entry>");
+//	    prDocBook.println("                    <entry>" + getPrompt("Minimum Characters: ") + getValueReplaceTBDWithNone(lAttr.minimum_characters) + "</entry>");
+//	    prDocBook.println("                    <entry>" + getPrompt("Maximum Characters: ") + getValueReplaceTBDWithNone(lAttr.maximum_characters) + "</entry>");
+
+	    prDocBook.println("                    <entry>" + getPrompt("Minimum Value: ") + getValueReplaceTBDWithNone(lAttr.getMinimumValue (true, false)) + "</entry>");
+	    prDocBook.println("                    <entry>" + getPrompt("Maximum Value: ") + getValueReplaceTBDWithNone(lAttr.getMaximumValue (true, false)) + "</entry>");
+	    prDocBook.println("                    <entry>" + getPrompt("Minimum Characters: ") + getValueReplaceTBDWithNone(lAttr.getMinimumCharacters (true, false)) + "</entry>");
+	    prDocBook.println("                    <entry>" + getPrompt("Maximum Characters: ") + getValueReplaceTBDWithNone(lAttr.getMaximumCharacters (true, false)) + "</entry>");
+	    prDocBook.println("                </row>");
+	    
+	    
+	    prDocBook.println("                <row>");
+	    prDocBook.println("                    <entry>" + getPrompt("Unit of Measure Type: ") + getUnitIdLink(lAttr.unit_of_measure_type) + "</entry>");
+	    prDocBook.println("                    <entry>" + getPrompt("Default Unit Id: ") + getValueReplaceTBDWithNone(lAttr.default_unit_id) + "</entry>");
+	    prDocBook.println("                    <entry>" + getPrompt("Attribute Concept: ") + getValueReplaceTBDWithNone(lAttr.classConcept) + "</entry>");
+	    prDocBook.println("                    <entry>" + getPrompt("Conceptual Domain: ") + getValueReplaceTBDWithNone(lAttr.dataConcept) + "</entry>");
+	    prDocBook.println("                </row>");
+	    
+	    prDocBook.println("                <row>");
+	    prDocBook.println("                    <entry>" + getPrompt("Status: ") + lRegistrationStatus + "</entry>");
+	    prDocBook.println("                    <entry>" + getPrompt("Nillable: ") + lAttr.isNilable + "</entry>");            
+//	    prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" >" + getPrompt("Pattern: ") + getValueReplaceTBDWithNone(lAttr.pattern) + "</entry>");
+	    prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" >" + getPrompt("Pattern: ") + getValueReplaceTBDWithNone(lAttr.getPattern(true)) + "</entry>");
+	    prDocBook.println("                </row>");
+	    prDocBook.println("");
+	    
+		if (lAttr.domPermValueArr == null || lAttr.domPermValueArr.size() == 0) {
+	       prDocBook.println("                <row>");
+	       prDocBook.println("                    <entry>" + getPrompt("Permissible Value(s)") + "</entry>");
+	       prDocBook.println("                    <entry>" + getPrompt("No Values") + "</entry>");
+	       prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\"></entry>");
+	       prDocBook.println("                </row>");	
+		} else {
+	       prDocBook.println("                <row>");
+	       prDocBook.println("                    <entry>" + getPrompt("Permissible Value(s)") + "</entry>");
+	       prDocBook.println("                    <entry>" + getPrompt("Value") + "</entry>");
+	       prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">" + getPrompt("Value Meaning") + "</entry>");
+	       prDocBook.println("                </row>");	
+
+			for (Iterator <DOMProp> j = lAttr.domPermValueArr.iterator(); j.hasNext();) {
+				DOMProp lProp = (DOMProp) j.next();
+				if (! (lProp.hasDOMObject instanceof DOMPermValDefn))  continue;
+				DOMPermValDefn lPermValueDefn = (DOMPermValDefn) lProp.hasDOMObject;
+				if (lPermValueDefn.value.compareTo("...") == 0) continue;
+				lRegistrationStatusInsert = "";
+				if (lPermValueDefn.registrationStatus.compareTo("Retired") == 0) lRegistrationStatusInsert = " - " + DMDocument.Literal_DEPRECATED;
+
+				String lDependValue = lAttr.valueDependencyMap.get(lPermValueDefn.value);
+				String lDependClause = "";
+				if (lDependValue != null) lDependClause = " (" + lDependValue + ")";								
+				
+				String lValueMeaning = lPermValueDefn.value_meaning;
+				if (lValueMeaning == null) lValueMeaning = "TBD_value_meaning";
+			    
+				if (lAttr.title.compareTo("pattern") == 0) {
+					if ((lValueMeaning == null) || (lValueMeaning.indexOf("TBD") == 0))
+                        lValueMeaning = "";
+				}
+	 	        prDocBook.println("                <row>");
+		        prDocBook.println("                    <entry></entry>"); 
+		        prDocBook.println("                    <entry>" + getValueAnchor(lAttr, getValue(lPermValueDefn.value)) + getValueBreak (getValue(lPermValueDefn.value)) + getValue(lDependClause) + lRegistrationStatusInsert + "</entry>");
+		        prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">" + getValue(lValueMeaning) + "</entry>");
+		        prDocBook.println("                </row>");
+			}
+		}
+		if (! (lAttr.permValueExtArr == null || lAttr.permValueExtArr.isEmpty())) {
+		
+			for (Iterator <PermValueExtDefn> i = lAttr.permValueExtArr.iterator(); i.hasNext();) {
+				PermValueExtDefn lPermValueExt = (PermValueExtDefn) i.next();	
+				if (lPermValueExt.permValueExtArr == null || lPermValueExt.permValueExtArr.isEmpty()) continue;
+			       prDocBook.println("                <row>");
+			       prDocBook.println("                    <entry>" + getPrompt("Extended Value(s) for: " + getValueBreak (lPermValueExt.xpath)) + "</entry>");
+			       prDocBook.println("                    <entry>" + getPrompt("Value") + "</entry>");
+			       prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">" + getPrompt("Value Meaning") + "</entry>");
+			       prDocBook.println("                </row>");	
+			
+				for (Iterator <PermValueDefn> j = lPermValueExt.permValueExtArr.iterator(); j.hasNext();) {
+					PermValueDefn lPermValueDefn = (PermValueDefn) j.next();
+		 	        prDocBook.println("                <row>");
+			        prDocBook.println("                    <entry></entry>"); 
+			        prDocBook.println("                    <entry>" + getValueBreak (lPermValueDefn.value) + "</entry>");
+//			        prDocBook.println("                    <entry>" + getValueAnchor(lAttr, lPermValueDefn.value) + getValueBreak (lPermValueDefn.value) + "</entry>");
+			        prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">" + getValue(lPermValueDefn.value_meaning) + "</entry>");
+			        prDocBook.println("                </row>");
+				}
+			}
+		}
+	               
+	    prDocBook.println("            </tbody>");
+	    prDocBook.println("        </tgroup>");
+	    prDocBook.println("        </informaltable>");
+	    prDocBook.println("</para>");
+	  	prDocBook.println("</sect1> ");
+	  	prDocBook.println("");
+	}
+	
+	private void writeDataTypeSection (String lNameSpaceIdNC, PrintWriter prDocBook) {
+		ArrayList <String> lPatternArr = new ArrayList<String> ();
+        prDocBook.println("");
+        prDocBook.println("      <!-- =====================Part4a Begin=========================== -->");
+        prDocBook.println("");
+//		prDocBook.println("    <chapter>");
+//		prDocBook.println("       <title>Data Types in the common namespace.</title>");
+//		prDocBook.println("       <para>These classes define the data types. </para>");
+					
+//		Sort the data types			
+		TreeMap <String, DOMClass> sortDataTypeMap = new TreeMap <String, DOMClass> ();
+		for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
+			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
+			if (lNameSpaceIdNC.compareTo(lClass.nameSpaceIdNC) != 0) continue;
+			if (!lClass.isDataType) continue;
+			sortDataTypeMap.put(lClass.title, lClass);
+		}	
+		ArrayList <DOMClass> sortDataTypeArr = new ArrayList <DOMClass> (sortDataTypeMap.values());	
+		if (sortDataTypeArr.size() <= 0) {
+	        prDocBook.println("");
+	        prDocBook.println("      <!-- ===================== Part4a End=========================== -->");
+			return;
+		}
+		
+		prDocBook.println("    <chapter>");
+		prDocBook.println("       <title>Data Types in the common namespace.</title>");
+		prDocBook.println("       <para>These classes define the data types. </para>");
+	
+//		Write the data types
+		String lSchemaBaseType = "None", lMinChar = "None", lMaxChar = "None", lMinVal = "None", lMaxVal = "None";
+		for (Iterator<DOMClass> i = sortDataTypeArr.iterator(); i.hasNext();) {
+			DOMClass lClass = (DOMClass) i.next();
+			
+			lSchemaBaseType = "None"; lMinChar = "None"; lMaxChar = "None"; lMinVal = "None"; lMaxVal = "None";
+			lPatternArr = new ArrayList<String> ();
+
+			for (Iterator<DOMProp> j = lClass.ownedAttrArr.iterator(); j.hasNext();) {
+				DOMProp lProp = j.next();
+				DOMAttr lAttr = (DOMAttr) lProp.hasDOMObject;
+				if (lAttr.title.compareTo("xml_schema_base_type") == 0) {
+					lSchemaBaseType = DOMInfoModel.getSingletonAttrValue(lAttr.valArr);
+					if (lSchemaBaseType == null) lSchemaBaseType = "None";
+					lSchemaBaseType = DMDocument.replaceString (lSchemaBaseType, "xsd:", "");
+				}
+
+				if (lAttr.title.compareTo("maximum_characters") == 0) {
+					lMaxChar = DOMInfoModel.getSingletonAttrValue(lAttr.valArr);
+					if ((lMaxChar == null || lMaxChar.compareTo("2147483647") == 0)) lMaxChar = "None";
+				}
+				
+				if (lAttr.title.compareTo("minimum_characters") == 0) {
+					lMinChar = DOMInfoModel.getSingletonAttrValue(lAttr.valArr);
+					if ((lMinChar == null || lMinChar.compareTo("-2147483648") == 0)) lMinChar = "None";
+
+				}
+				if (lAttr.title.compareTo("maximum_value") == 0) {
+					lMaxVal = DOMInfoModel.getSingletonAttrValue(lAttr.valArr);
+					if ((lMaxVal == null || lMaxVal.compareTo("2147483647") == 0)) lMaxVal = "None";
+
+				}
+				if (lAttr.title.compareTo("minimum_value") == 0) {
+					lMinVal = DOMInfoModel.getSingletonAttrValue(lAttr.valArr);
+					if ((lMinVal == null || lMinVal.compareTo("-2147483648") == 0)) lMinVal = "None";
+
+				}
+				if (lProp.title.compareTo("pattern") == 0) {
+					String lVal = DOMInfoModel.getSingletonAttrValue(lAttr.valArr);
+					if (lVal != null) {
+						// if not null there there are one or more patterns
+						for (Iterator <String> k = lAttr.valArr.iterator(); k.hasNext();) {
+							String lPattern = (String) k.next();
+							lPatternArr.add(lPattern);
+						}
+					}
+				}
+			}
+					
+            prDocBook.println("<sect1>");
+            prDocBook.println("    <title>" + getClassAnchor(lClass) + getValue(lClass.title) + "</title>");
+            prDocBook.println("");
+            prDocBook.println("<para>");
+            prDocBook.println("    <informaltable frame=\"all\" colsep=\"1\">");
+            prDocBook.println("        <tgroup cols=\"4\" align=\"left\" colsep=\"1\" rowsep=\"1\">");
+            prDocBook.println("            <colspec colnum=\"1\" colname=\"c1\" colwidth=\"1.0*\"/>");
+            prDocBook.println("            <colspec colnum=\"2\" colname=\"c2\" colwidth=\"1.0*\"/>");
+            prDocBook.println("            <colspec colnum=\"3\" colname=\"c3\" colwidth=\"1.0*\"/>");
+            prDocBook.println("            <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
+            prDocBook.println("            <thead>");
+            prDocBook.println("                <row>");
+            prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">" + getPrompt("Name: ") + getValue(lClass.title) + "</entry>");
+//            prDocBook.println("                    <entry>" + getPrompt("Version Id: ") + getValue("1.0.0.0") + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("Version Id: ") + getValue(lClass.versionId) + "</entry>");
+            prDocBook.println("                </row>");
+            prDocBook.println("            </thead>");
+            prDocBook.println("            <tbody>");
+            prDocBook.println("                <row>");
+            prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">" + getPrompt("Description ") + getValue(lClass.definition) + "</entry>");
+            prDocBook.println("                </row>");
+            prDocBook.println("                <row>");
+            prDocBook.println("                    <entry>" + getPrompt("Schema Base Type:  ") + getValueReplaceTBDWithNone(lSchemaBaseType) + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("") + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("") + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("") + "</entry>");
+            prDocBook.println("                </row>");
+            prDocBook.println("                <row>");
+            prDocBook.println("                    <entry>" + getPrompt("Minimum Value: ") + getValueReplaceTBDWithNone(lMinVal) + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("Maximum Value: ") + getValueReplaceTBDWithNone(lMaxVal) + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("Minimum Characters: ") + getValueReplaceTBDWithNone(lMinChar) + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("Maximum Characters: ") + getValueReplaceTBDWithNone(lMaxChar) + "</entry>");
+            prDocBook.println("                </row>");
+
+            if (lPatternArr == null || lPatternArr.isEmpty()) {
+                prDocBook.println("                <row>");
+                prDocBook.println("                    <entry>" + "</entry>");
+                prDocBook.println("                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\">" + getPrompt("No Pattern") + "</entry>");
+	            prDocBook.println("                </row>");
+            } else {
+                prDocBook.println("                <row>");
+                prDocBook.println("                    <entry>" + "</entry>");
+            	prDocBook.println("                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\">" + getPrompt("Pattern") + "</entry>");           	
+	            prDocBook.println("                </row>");
+    			for (Iterator <String> k = lPatternArr.iterator(); k.hasNext();) {
+    				String lPattern = (String) k.next();
+    	            prDocBook.println("                <row>");
+                    prDocBook.println("                    <entry>" + "</entry>");
+    	            prDocBook.println("                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\">" + getValue(lPattern) + "</entry>");
+    	            prDocBook.println("                </row>");
+    			}
+            }
+			
+            prDocBook.println("");
+            prDocBook.println("            </tbody>");
+            prDocBook.println("        </tgroup>");
+            prDocBook.println("        </informaltable>");
+            prDocBook.println("</para>");
+          	prDocBook.println("</sect1> ");
+		}
+		prDocBook.println("    </chapter>");		
+        prDocBook.println("");
+        prDocBook.println("      <!-- ===================== Part4a End=========================== -->");
+        prDocBook.println("");
+	}
+	
+	private void writeUnitsSection (String lNameSpaceIdNC, PrintWriter prDocBook) {
+		ArrayList <String> lPatternArr = new ArrayList<String> ();
+        prDocBook.println("");
+        prDocBook.println("      <!-- =====================Part4b Begin=========================== -->");
+        prDocBook.println("");
+//		prDocBook.println("    <chapter>");
+//		prDocBook.println("       <title>Units of Measure in the common namespace.</title>");
+//		prDocBook.println("       <para>These classes define the units of measure. </para>");
+		
+		// get the units
+		ArrayList <DOMProp> lDOMPermValueArr;
+		TreeMap <String, DOMClass> sortUnitsMap = new TreeMap <String, DOMClass> ();
+		for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
+			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
+			if (lNameSpaceIdNC.compareTo(lClass.nameSpaceIdNC) != 0) continue;
+			if (! lClass.isUnitOfMeasure) continue;
+			sortUnitsMap.put(lClass.title, lClass);
+		}	
+		ArrayList <DOMClass> sortUnitsArr = new ArrayList <DOMClass> (sortUnitsMap.values());	
+		if (sortUnitsArr.size() <= 0) {
+	        prDocBook.println("      <!-- ===================== Part4b End=========================== -->");
+			return;
+		}
+		
+		prDocBook.println("    <chapter>");
+		prDocBook.println("       <title>Units of Measure in the common namespace.</title>");
+		prDocBook.println("       <para>These classes define the units of measure. </para>");
+
+		for (Iterator<DOMClass> i = sortUnitsArr.iterator(); i.hasNext();) {
+			DOMClass lClass = (DOMClass) i.next();
+			lDOMPermValueArr = new ArrayList <DOMProp> ();
+			for (Iterator<DOMProp> j = lClass.allAttrAssocArr.iterator(); j.hasNext();) {
+				DOMProp lProp = j.next();
+				DOMAttr lDOMAttr = (DOMAttr) lProp.hasDOMObject;
+				if (lDOMAttr.title.compareTo("unit_id") == 0) {
+					if (lDOMAttr.domPermValueArr != null) lDOMPermValueArr = lDOMAttr.domPermValueArr;
+				}
+			}
+					
+            prDocBook.println("<sect1>");
+            prDocBook.println("    <title>" + getClassAnchor(lClass) + getValue(lClass.title) + "</title>");
+            prDocBook.println("");
+            prDocBook.println("<para>");
+            prDocBook.println("    <informaltable frame=\"all\" colsep=\"1\">");
+            prDocBook.println("        <tgroup cols=\"4\" align=\"left\" colsep=\"1\" rowsep=\"1\">");
+            prDocBook.println("            <colspec colnum=\"1\" colname=\"c1\" colwidth=\"1.0*\"/>");
+            prDocBook.println("            <colspec colnum=\"2\" colname=\"c2\" colwidth=\"1.0*\"/>");
+            prDocBook.println("            <colspec colnum=\"3\" colname=\"c3\" colwidth=\"1.0*\"/>");
+            prDocBook.println("            <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
+            prDocBook.println("            <thead>");
+            prDocBook.println("                <row>");
+            prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">" + getPrompt("Name:  ") + getValue(lClass.title) + "</entry>");
+//            prDocBook.println("                    <entry>" + getPrompt("Version Id:  ") + getValue("1.0.0.0") + "</entry>");
+            prDocBook.println("                    <entry>" + getPrompt("Version Id:  ") + getValue(lClass.versionId) + "</entry>");
+            prDocBook.println("                </row>");
+            prDocBook.println("            </thead>");
+            prDocBook.println("            <tbody>");
+            prDocBook.println("                <row>");
+            prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">" + getPrompt("Description: ") + getValue(lClass.definition) + "</entry>");
+            prDocBook.println("                </row>");
+            prDocBook.println("                <row>");
+            prDocBook.println("                    <entry>" + "</entry>");
+            prDocBook.println("                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\">" + getPrompt("Unit Id") + "</entry>");
+            prDocBook.println("                </row>");
+            
+            if (! lDOMPermValueArr.isEmpty()) {
+    			for (Iterator <DOMProp> k = lDOMPermValueArr.iterator(); k.hasNext();) {
+    				DOMProp lDOMProp = (DOMProp) k.next();
+    				if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMPermValDefn) {
+    					DOMPermValDefn lDOMPermValDefn = (DOMPermValDefn) lDOMProp.hasDOMObject;
+    		            prDocBook.println("                <row>");
+    		            prDocBook.println("                    <entry>" + "</entry>");
+    		            prDocBook.println("                    <entry>" + getValue(lDOMPermValDefn.value) + "</entry>");
+    		            String lValueMeaning = lDOMPermValDefn.value_meaning;
+    		            if (lValueMeaning == null) lValueMeaning = "TBD_value_meaning";
+    		            prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">" + getValue(lValueMeaning) + "</entry>");
+    		            prDocBook.println("                </row>");
+    				}
+    			}
+            } else {
+	            prDocBook.println("                <row>");
+	            prDocBook.println("                    <entry>" + "</entry>");
+	            prDocBook.println("                    <entry>" + "None" + "</entry>");
+	            prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">" + getValue("") + "</entry>");
+	            prDocBook.println("                </row>");
+            }
+			
+            prDocBook.println("");
+            prDocBook.println("            </tbody>");
+            prDocBook.println("        </tgroup>");
+            prDocBook.println("        </informaltable>");
+            prDocBook.println("</para>");
+          	prDocBook.println("</sect1> ");
+		}
+		
+		// finalize Part 4
+		prDocBook.println("         </chapter>");
+        prDocBook.println("");
+        prDocBook.println("      <!-- ===================== Part4b End=========================== -->");
+        prDocBook.println("");
+	}
+	
+	private void writeHeader (SchemaFileDefn lSchemaFileDefn, PrintWriter prDocBook) {
+		prDocBook.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+		prDocBook.println("<?xml-model href=\"http://www.oasis-open.org/docbook/xml/5.0/rng/docbook.rng\" schematypens=\"http://relaxng.org/ns/structure/1.0\"?>");
+		prDocBook.println("<book xmlns=\"http://docbook.org/ns/docbook\"");
+		prDocBook.println("    xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"5.0\">");
+		prDocBook.println("    <info>");
+		prDocBook.println("        <title>" + DMDocument.ddDocTitle + "</title>");
+		prDocBook.println("        <subtitle>Abridged - Versionxxx " + DMDocument.masterPDSSchemaFileDefn.ont_version_id + "</subtitle>");
+		prDocBook.println("        <author>");
+		prDocBook.println("            <orgname>" + DMDocument.ddDocTeam + "</orgname>");
+		prDocBook.println("        </author>");
+		prDocBook.println("        <releaseinfo>Information Model Version " + DMDocument.masterPDSSchemaFileDefn.ont_version_id + " on " + DMDocument.sTodaysDate + "</releaseinfo>");
+		prDocBook.println("        <releaseinfo>Data Dictionary: " + lSchemaFileDefn.lddName + "</releaseinfo>");
+		prDocBook.println("        <date>" + DMDocument.sTodaysDate + "</date>");
+		prDocBook.println("    </info>");
+		prDocBook.println("        ");
+		prDocBook.println("        <chapter>");
+		prDocBook.println("            <title>Introduction</title>");
+		prDocBook.println("            <para>The Data Dictionary defines the organization and components of product labels. Components of a product label include classes and their attributes.</para>");
+		prDocBook.println("            <para>");
+		prDocBook.println("            </para>");
+		prDocBook.println("            <sect1>");
+		prDocBook.println("                <title>Audience</title>");
+		prDocBook.println("                <para>The Data Dictionary - Abridged - has been abstracted from the unabridged version with the needs of data providers and data end users in mind. It contains full definitions but not all the fine detail or repetition necessary to support the underlying Information Model.</para>");
+		prDocBook.println("                <para>");
+		prDocBook.println("                </para>");
+		prDocBook.println("            </sect1>");
+		prDocBook.println("            <sect1>");
+		prDocBook.println("                <title>Acknowledgements</title>");
+		prDocBook.println("                <para>The Data Dictionary and the Information Model is a joint effort involving discipline experts functioning as a data design working group.</para>");
+		prDocBook.println("                <para>");
+		prDocBook.println("                </para>");
+		prDocBook.println("            </sect1>");
+		prDocBook.println("            <sect1>");
+		prDocBook.println("                <title>Scope</title>");
+		prDocBook.println("                <para>The Data Dictionary defines the common and discipline level classes and attributes used to create product labels. It also defines the meta-attributes (i.e. attributes about attributes) used to define attributes. This abridged version includes only one entry for each attribute where the unabridge version includes an entry for each use of an attribute in a class.</para>");
+		prDocBook.println("                <para>");
+		prDocBook.println("                </para>");
+		prDocBook.println("            </sect1>");
+		prDocBook.println("            <sect1>");
+		prDocBook.println("                <title>Applicable Documents</title>");
+		prDocBook.println("                <para>");
+		prDocBook.println("                    <emphasis role=\"bold\">Controlling Documents</emphasis>");
+		prDocBook.println("");
+		prDocBook.println("                    <itemizedlist>");
+		prDocBook.println("                        <listitem>");
+		prDocBook.println("                            <para>");
+		prDocBook.println("                                Information Model Specification - The Information Model is used as the source for class, attribute, and data type definitions. The model is presented in document format as the Information Model Specification.");
+		prDocBook.println("                            </para>");
+		prDocBook.println("                        </listitem>");
+		prDocBook.println("                        <listitem>");
+		prDocBook.println("                            <para>");
+		prDocBook.println("                                ISO/IEC 11179:3 Registry Metamodel and Basic Attributes Specification, 2003. - The ISO/IEC 11179 specification provides the schema for the data dictionary.");
+		prDocBook.println("                            </para>");
+		prDocBook.println("                        </listitem>");
+		prDocBook.println("                    </itemizedlist>");
+		if (! DMDocument.importJSONAttrFlag) {
+			prDocBook.println("                    <emphasis role=\"bold\">Reference Documents</emphasis>");
+			prDocBook.println("                    <itemizedlist>");
+			prDocBook.println("                        <listitem>");
+			prDocBook.println("                            <para>");
+			prDocBook.println("                                Planetary Science Data Dictionary - The online version of the PDS3 data dictionary was used as the source for a few data elements being carried over from the PDS3 data standards.");
+			prDocBook.println("                            </para>");
+			prDocBook.println("                        </listitem>");
+			prDocBook.println("                        ");
+			prDocBook.println("                    </itemizedlist>");
+		}
+		prDocBook.println("                </para>");
+		prDocBook.println("            </sect1>");
+		prDocBook.println("            <sect1>");
+		prDocBook.println("                <title>Terminology</title>");
+		prDocBook.println("                <para>This document uses very specific engineering terminology to describe the various structures involved.  It is particularly important that readers who have absorbed the Standards Reference bear in mind that terms which are familiar in that context can have very different meanings in the present document. </para>");
+		prDocBook.println("                <para>Following are some definitions of essential terms used throughout this document.</para>");
+		prDocBook.println("                <itemizedlist>");
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para>An <emphasis role=\"italic\">attribute</emphasis> is a property or characteristic that provides a unit of information. For example, 'color' and 'length' are possible attributes. </para>");
+		prDocBook.println("                    </listitem>");
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para>A <emphasis role=\"italic\">class</emphasis> is a set of attributes (including a name) which defines a family.  A class is generic - a template from which individual members of the family may be constructed.");
+		prDocBook.println("                        </para>");
+		prDocBook.println("                    </listitem>");
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para>A <emphasis role=\"italic\">conceptual object</emphasis> is an object which is intangible (and, because it is intangible, does not fit into a digital archive).  Examples of 'conceptual objects' include the Cassini mission and NASA's strategic plan for solar system exploration.  Note that a PDF describing the Cassini mission is a digital object, not a conceptual object (nor a component of a conceptual object). </para>");
+		prDocBook.println("                    </listitem>");
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para>A <emphasis role=\"italic\">data element</emphasis> is a unit of data for which the definition, identification, representation and <emphasis role=\"italic\">permissible values</emphasis> are specified by means of a set of attributes. For example, the concept of a <emphasis role=\"italic\">calibration_lamp_state_flag</emphasis> is used to indicate whether the lamp used for onboard camera calibration was turned on or off during the capture of an image. The <emphasis role=\"italic\"> data element</emphasis> aspect of this concept is the named attribute (or data element)  <emphasis role=\"italic\">calibration_lamp_state_flag</emphasis>.</para>");
+		prDocBook.println("                    </listitem>");
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para>A <emphasis role=\"italic\">data object</emphasis> is a physical, conceptual, or digital object.</para>");
+		prDocBook.println("                    </listitem>");
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para>A <emphasis role=\"italic\">digital object</emphasis> is an object which is real data - for example, a binary image of a redwood tree or an ASCII table of atmospheric composition versus altitude.</para>");
+		prDocBook.println("                    </listitem>");
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Formal</emphasis> as used in the definition of attributes that are names indicates that an established procedure was involved in creating the name.</para>");
+		prDocBook.println("                    </listitem>");
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para>A <emphasis role=\"italic\">unique identifier</emphasis> is a special type of identifier used to provide a reference number which is unique in a context.</para>");
+		prDocBook.println("                    </listitem>");
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Local</emphasis> refers to the context within a single label.</para>");
+		prDocBook.println("                    </listitem>");
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para><emphasis role=\"italic\">Logical</emphasis> as used in the definition of logical identifier indicates that the identifier logically groups a set of objects. </para>");
+		prDocBook.println("                    </listitem>");
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para>A <emphasis role=\"italic\">physical object</emphasis> is an object which is physical or tangible (and, therefore, does not itself fit into a digital archive).  Examples of 'physical objects' include the planet Saturn and the Venus Express magnetometer.  Note that an ASCII file describing Saturn is a digital object, not a physical object (nor a component of a physical object).  </para>");
+		prDocBook.println("                    </listitem>");
+		prDocBook.println("                    <listitem>");
+		prDocBook.println("                        <para>A <emphasis role=\"italic\">resource</emphasis> is the target (referent) of any Uniform Resource Identifier; the thing to which a URI points.</para>");
+		prDocBook.println("                    </listitem>");
+		prDocBook.println("                </itemizedlist>");
+		prDocBook.println("");
+		prDocBook.println("                <para>");
+		prDocBook.println("                </para>");
+		prDocBook.println("            </sect1>");
+		prDocBook.println("        </chapter>");
+//		prDocBook.println("    </part>");
+		prDocBook.println("");
+		return;
+	}
+	
+	private void writeFooter (PrintWriter prDocBook) {
+		prDocBook.println("");
+		prDocBook.println("	</book>");
+	}
+
+	private String getPrompt (String lPrompt) {
+//		return "<emphasis role=\"italic\">" + "<emphasis role=\"bold\">" + lPrompt + "</emphasis>" + "</emphasis>";
+//		return "<emphasis role=\"italic\">" + lPrompt + "</emphasis>";
+		return "<emphasis>" + lPrompt + "</emphasis>";
+	}
+	
+	private String getValue (String lValue) {
+		return DOMInfoModel.escapeXMLChar(lValue);
+	}
+	
+	private String getValueBreak (String lValue) {
+		String lValueBreak = DMDocument.replaceString(lValue, "_", "_&#x200B;");
+		return lValueBreak;
+	}
+	
+	private String getValueReplaceTBDWithNone(String lValue) {
+		if (lValue.indexOf("TBD") == 0) return "None";
+		return DOMInfoModel.escapeXMLChar(lValue);
+	}
+			
+	private String getValueAnchor(DOMAttr lAttr, String lValue) {
+//		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.parentClassTitle + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.title + "." + lValue;
+//		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.attrParentClass.title + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.title + "." + lValue;
+		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.classNameSpaceIdNC + "." + lAttr.attrParentClass.title + "." + lAttr.nameSpaceIdNC + "." + lAttr.title + "." + lValue;
+		int lAnchorI = lAnchor.hashCode();
+		lAnchor = "N" + Integer.toString(lAnchorI);
+		return "<anchor xml:id=\"" + lAnchor + "\"/>";
+	}
+	
+	private String getValueLink(DOMAttr lAttr, String lValue) {
+		String lAttrParentClassTitle = "TBD_lAttrParentClassTitle";
+		if (lAttr.attrParentClass != null) 
+			lAttrParentClassTitle = lAttr.attrParentClass.title;
+		String lLink = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.classNameSpaceIdNC + "." + lAttrParentClassTitle + "." + lAttr.nameSpaceIdNC + "." + lAttr.title + "." + lValue;
+		int lLinkI = lLink.hashCode();
+		lLink = "N" + Integer.toString(lLinkI);
+		return "<link linkend=\"" + lLink + "\">" + getValueBreak(lValue) + "</link>";
+	}
+	
+	private String getAttrAnchor(DOMAttr lAttr) {
+//		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.parentClassTitle + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.title;
+//		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.attrParentClass.title + "." + lAttr.attrNameSpaceIdNC + "." + lAttr.title;
+		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.classNameSpaceIdNC + "." + lAttr.attrParentClass.title + "." + lAttr.nameSpaceIdNC + "." + lAttr.title;
+		int lAnchorI = lAnchor.hashCode();
+		lAnchor = "N" + Integer.toString(lAnchorI);
+		return "<anchor xml:id=\"" + lAnchor + "\"/>";
+	}
+
+	private String getAttrLink(DOMAttr lAttr) {
+		String lAttrParentClassTitle = "TBD_lAttrParentClassTitle";
+		if (lAttr.attrParentClass != null) {
+			lAttrParentClassTitle = lAttr.attrParentClass.title;
+		}
+		String lLink = DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.classNameSpaceIdNC + "." + lAttrParentClassTitle + "." + lAttr.nameSpaceIdNC + "." + lAttr.title;
+		int lLinkI = lLink.hashCode();
+		lLink = "N" + Integer.toString(lLinkI);
+		String lRegistrationStatusInsert = "";
+		if (lAttr.registrationStatus.compareTo("Retired") == 0) lRegistrationStatusInsert = " " + DMDocument.Literal_DEPRECATED;
+		return "<link linkend=\"" + lLink + "\">" + getValueBreak(lAttr.title) + lRegistrationStatusInsert + "</link>";
+	}
+	
+	private String getClassAnchor(DOMClass lClass) {
+		String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." + lClass.nameSpaceIdNC + "." + lClass.title;
+		int lAnchorI = lAnchor.hashCode();
+		lAnchor = "N" + Integer.toString(lAnchorI);
+		return "<anchor xml:id=\"" + lAnchor + "\"/>";
+	}
+	
+	private String getClassLink(DOMClass lClass) {
+		String lLink = DMDocument.registrationAuthorityIdentifierValue + "." + lClass.nameSpaceIdNC + "." + lClass.title;
+		int lLinkI = lLink.hashCode();
+		lLink = "N" + Integer.toString(lLinkI);
+		String lRegistrationStatusInsert = "";
+		if (lClass.registrationStatus.compareTo("Retired") == 0) lRegistrationStatusInsert = " " +  DMDocument.Literal_DEPRECATED;
+		return "<link linkend=\"" + lLink + "\">" + getValueBreak(lClass.title) + lRegistrationStatusInsert + "</link>";
+	}
+	
+	private String getDataTypeLink(String lDataType) {
+		String lLink = DMDocument.registrationAuthorityIdentifierValue + "." + DMDocument.masterNameSpaceIdNCLC + "." + lDataType;
+		int lLinkI = lLink.hashCode();
+		lLink = "N" + Integer.toString(lLinkI);
+//		String lDataTypeWrap = DMDocument.replaceString(lDataType, "_", "_&#x200B;");
+		return "<link linkend=\"" + lLink + "\">" + getValueBreak(lDataType) + "</link>";
+	}
+	
+	private String getUnitIdLink(String lUnitId) {
+		if (lUnitId.indexOf("TBD") == 0) return "None";
+		String lLink = DMDocument.registrationAuthorityIdentifierValue + "." + DMDocument.masterNameSpaceIdNCLC + "." + lUnitId;
+		int lLinkI = lLink.hashCode();
+		lLink = "N" + Integer.toString(lLinkI);
+		return "<link linkend=\"" + lLink + "\">" + lUnitId + "</link>";
+	}
+	
+	private String getCardinality(int lCardMin, int lCardMax) {
+		String pCardMax = "Unbounded";
+		if (lCardMax != 9999999) pCardMax = (new Integer(lCardMax)).toString();
+		String pCardMin = (new Integer(lCardMin)).toString();
+		return pCardMin + ".." + pCardMax;
+	}
+
+//	return all classes that reference this class 
+	private ArrayList <DOMClass> getClassReferences (DOMClass lTargetClass) {
+		ArrayList <DOMClass> refClassArr = new ArrayList <DOMClass> ();
+		for (Iterator <DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
+			DOMClass lClass = (DOMClass) i.next();
+			if (lClass.isInactive) continue;
+			if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) != 0) {
+				for (Iterator <DOMProp> j = lClass.ownedAssocArr.iterator(); j.hasNext();) {
+					DOMProp lProp = j.next();
+					DOMClass lCompClass = (DOMClass) lProp.hasDOMObject;
+				    
+					if (lTargetClass == lCompClass) {
+					   if (! refClassArr.contains(lClass)) {
+						  refClassArr.add(lClass);
+					   }
+					}
+				}					
+		        for (Iterator <DOMProp> j = lClass.inheritedAssocArr.iterator(); j.hasNext();) {
+		        	DOMProp lProp = j.next();
+					DOMClass lCompClass = (DOMClass) lProp.hasDOMObject;
+				  
+					if (lTargetClass == lCompClass) {
+						if (! refClassArr.contains(lClass)) {
+									refClassArr.add(lClass);
+						}
+					}
+				}
+			}
+		}
+			
+		
+		return refClassArr;
+	}	
+	
+	/**
+	* escape certain characters for DocBook
+	*/
+	 String escapeDocBookChar (String aString) {
+		String lString = aString;
+//		lString = replaceString (lString, "\\", "\\\\");
+		return lString;
+	}
+	 
+	 // locally defined classes for classifying classes and attributes
+	 
+	public class ClassClassificationDefnDOM {
+		String identifier;
+		String namespaceId;
+		ArrayList <DOMClass> classArr;
+		TreeMap <String, DOMClass> classMap;
+		
+		public ClassClassificationDefnDOM (String id) {
+			identifier = id; 
+			namespaceId = id;
+			classArr = new ArrayList <DOMClass> ();
+			classMap = new TreeMap <String, DOMClass> ();
+		} 
+	}
+	 
+	public class AttrClassificationDefnDOM {
+		String identifier;
+		String namespaceId;
+		ArrayList <DOMAttr> attrArr;
+		TreeMap <String, DOMAttr> attrMap;
+		
+		public AttrClassificationDefnDOM (String id) {
+			identifier = id; 
+			namespaceId = id;
+			attrArr = new ArrayList <DOMAttr> ();
+	        attrMap = new TreeMap <String, DOMAttr> ();
+		} 
+	}
+}

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMRDFTTLFile.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMRDFTTLFile.java
@@ -1,0 +1,358 @@
+// Copyright 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+// * Neither the name of Caltech nor its operating division, the Jet Propulsion
+// Laboratory, nor the names of its contributors may be used to endorse or
+// promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package gov.nasa.pds.model.plugin; 
+
+import java.io.FileOutputStream;
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.OutputStreamWriter;
+import java.util.*;
+
+/**
+ * Writes the PDS4 DD content to a TTL (RDF) file 
+ * 
+ * *** Currently Used ***
+ * IMTool - PDS4.All.Products.Class.Prop
+ * LDDTool - PDS4.LDD.All * 
+ */
+
+class WriteDOMRDFTTLFile extends Object{
+
+	String masterNameSpaceIdNC = "TBD_masterNameSpaceIdNC";
+	PrintWriter prRDFFile;
+	
+	// allow each class to be defined only once
+	ArrayList <String> writtenClassIdArr = new ArrayList <String> ();
+
+	// ensure each class is written once
+	TreeMap <String, ClassPropertiesOWL> referencedClassIdMap = new TreeMap <String, ClassPropertiesOWL> ();
+	
+	// flag for oaisif (fuseki) vs pds4 (graphdb)
+	// slashes should be OK, just use <>
+	boolean isPDS = true;
+
+	public WriteDOMRDFTTLFile () {
+		return;
+	}
+
+	// write the TTL file
+	public void writeDOMRDFTTLFile (String lClassificationType, ClassAttrPropClassification lClassAttrPropClassification) throws java.io.IOException {
+		String lFileName = DMDocument.masterPDSSchemaFileDefn.relativeFileSpecOWLRDF_DOM;
+		lFileName = DOMInfoModel.replaceString (lFileName, ".rdf", "_IKG.ttl");
+		
+		
+		prRDFFile = new PrintWriter(new OutputStreamWriter (new FileOutputStream(new File(lFileName)), "UTF-8"));
+		
+		// set the namespaceid to be used as the RDF prefix
+		masterNameSpaceIdNC = ClassAttrPropClassification.getMasterNameSpaceIdNC();
+		
+		// write the Header
+		writeRDFHdr(lClassAttrPropClassification);
+		
+		// write the Body
+		writeRDFBody (lClassAttrPropClassification);
+		
+		// write the Footer and close
+		writeRDFFtr();
+		prRDFFile.close();
+		
+	}	
+	// Print the JSON Header
+	public void writeRDFHdr (ClassAttrPropClassification lClassAttrPropClassification) {
+		
+		prRDFFile.println("@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .");
+		prRDFFile.println("@prefix owl: <http://www.w3.org/2002/07/owl#> .");
+		prRDFFile.println("@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .");
+		prRDFFile.println("@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .");
+		prRDFFile.println("@prefix dc: <http://purl.org/dc/elements/1.1/> .");
+		for (String lPre : lClassAttrPropClassification.nameSpaceIdNCArr) {
+			prRDFFile.println("@prefix " + lPre + ": <http://ontology.pds.nasa.gov/" + lPre + "/> .");
+		}
+		prRDFFile.println("###########################################");
+		prRDFFile.println("########## Class definitions");
+		prRDFFile.println("########## DateTime:" + DMDocument.masterTodaysDateTimeUTCwT);
+		prRDFFile.println("###########################################");
+	}
+
+	// Print the JSON Footer
+	public  void writeRDFFtr () {
+		prRDFFile.println("  ");
+	}
+	
+//	print the body
+	public  void writeRDFBody (ClassAttrPropClassification lClassAttrPropClassification) {
+
+   		// write the simple base properties, e.g., ISA, attributeOf, componentOf
+//   		writeSubClassRedefined (lClassAttrPropClassification); // PDS definition for ISA -> subClassOf
+   		writeDatatypePropertyAttributeOf (lClassAttrPropClassification);  // definition for attributeOf
+   		writeDatatypePropertyComponentOf (lClassAttrPropClassification); // definition for componentOf
+
+		// scan through the ClassPropertiesOWL and write the classes
+		ArrayList <ClassPropertiesOWL> lClassPropertiesOWLArr = lClassAttrPropClassification.getClassPropertiesOWL ();
+
+		// debug
+/*		ArrayList <String> allClassIdArr = new ArrayList <String> ();
+		for(ClassPropertiesOWL lClassPropertiesOWL : lClassPropertiesOWLArr) {
+			allClassIdArr.add(lClassPropertiesOWL.theClass.identifier);
+		}
+   		System.out.println("\ndebug ******* writeRDFBody allClassIdArr:" + allClassIdArr); */
+		
+		for(ClassPropertiesOWL lClassPropertiesOWL : lClassPropertiesOWLArr) {	
+           	// write the RDF for the class and its properties, including its superclass
+//    		writeClassDefn (lClassPropertiesOWL, lClassAttrPropClassification, true);
+    		writeClassDefn (lClassPropertiesOWL, lClassAttrPropClassification);
+		}
+        
+        // write a class definition for each class referenced but not defined
+        ArrayList <String> referencedClassIdArr = new ArrayList <String> (referencedClassIdMap.keySet());
+		for (String lClassId : referencedClassIdArr) {
+        	if (! writtenClassIdArr.contains(lClassId)) {
+        		ClassPropertiesOWL lClassPropertiesOWL = referencedClassIdMap.get(lClassId);
+        		String preISA = "rdfs";
+        		if (true) preISA = masterNameSpaceIdNC;
+        		prRDFFile.println(" ");	
+        		prRDFFile.println("### Referenced Undefined:" + lClassPropertiesOWL.theClass.identifier + " ###");	
+        		prRDFFile.println(lClassPropertiesOWL.iri + " " + "rdf:type" + " " + "rdfs:Class" + ";");	
+        		prRDFFile.println("  " + "rdfs:label \"" + lClassPropertiesOWL.title + "\";");	
+        		prRDFFile.println("  " + "rdfs:comment \"" + escapeXMLChar(lClassPropertiesOWL.definition) + "\".");
+        	}
+        }
+		
+		// write the relationships
+//		ArrayList <RelationshipProperties> lRelationshipPropertiesArr = lClassAttrPropClassification.getRelationshipProperties ();
+//		writeRelationships (lRelationshipPropertiesArr);
+	}
+	
+	// write a class
+//	public  void writeClassDefn (ClassPropertiesOWL lClassPropertiesOWL, ClassAttrPropClassification lClassAttrPropClassification, boolean useISA) {	
+	public  void writeClassDefn (ClassPropertiesOWL lClassPropertiesOWL, ClassAttrPropClassification lClassAttrPropClassification) {	
+//		System.out.println("debug writeClassDefn -PARENT- lClassPropertiesOWL.identifier:" + lClassPropertiesOWL.identifier + "  --  lClassPropertiesOWL.theClass.identifier:" + lClassPropertiesOWL.theClass.identifier);
+
+		// write each class only once; two or more instances can occur as children
+		if (writtenClassIdArr.contains(lClassPropertiesOWL.theClass.identifier)) return;
+		writtenClassIdArr.add(lClassPropertiesOWL.theClass.identifier);
+		
+		String preISA = "rdfs";
+//		if (useISA) preISA = masterNameSpaceIdNC;
+		prRDFFile.println(" ");	
+		
+		prRDFFile.println("### Class (Selected):" + lClassPropertiesOWL.theClass.identifier + " ###");	
+		prRDFFile.println(lClassPropertiesOWL.iri + " " + "rdf:type" + " " + "rdfs:Class" + ";");	
+		prRDFFile.println("  " + "rdfs:label \"" + lClassPropertiesOWL.title + "\";");	
+		prRDFFile.println("  " + "owl:versionInfo \"" + lClassPropertiesOWL.versionId + "\";");	
+		prRDFFile.println("  " + preISA + ":subClassOf " + lClassPropertiesOWL.subClassOfIRI + ";");							
+		prRDFFile.println("  " + "rdfs:comment \"" + escapeXMLChar(lClassPropertiesOWL.definition) + "\".");
+		
+		// ensure the subclass of this class is ultimately defined
+		ClassPropertiesOWL lClassPropertiesOWLSubclass  = new ClassPropertiesOWL (lClassPropertiesOWL.subClassOf);
+		referencedClassIdMap.put(lClassPropertiesOWLSubclass.theClass.identifier, lClassPropertiesOWLSubclass);
+
+   		// write the RDF for classes associated with the class.
+ 		writeAssociatedClasses (lClassPropertiesOWL);
+  		
+		// write the RDF for each subclass of this class and its properties (e.g., Instrument.type = Accelerometer)
+//		writeTypesAsSubClasses (lClassPropertiesOWL, lClassAttrPropClassification, 1);
+		return;
+	}
+	
+	// write the RDF for classes associated with the class.
+	public  void writeAssociatedClasses (ClassPropertiesOWL lClassPropertiesOWL) {
+		
+		// return if the Component OF Class Array is null
+		if (lClassPropertiesOWL.theComponentOfClassArr == null) return;
+
+		int numComp = lClassPropertiesOWL.theComponentOfClassArr.size();
+		
+		// return if the Component OF Class Array is empty
+		if (numComp == 0) return;
+		
+		// if the Component OF Class Array has one entry ...
+		if (numComp == 1) {
+			writeAssociatedClassSingle (lClassPropertiesOWL);
+		} else { // if the Component OF Class Array has more than one entry ...
+			writeAssociatedClassMulti (lClassPropertiesOWL);
+		}
+		return;
+	}
+	
+	// write the RDF for classes associated with the class.
+	public  void writeAssociatedClassSingle (ClassPropertiesOWL lClassPropertiesOWL) {
+		
+		// write an association for the single component class
+		for (ClassPropertiesOWL lClassPropertiesOWLComp : lClassPropertiesOWL.theComponentOfClassArr) {
+
+			// write the definition of the ObjectProperty that relates the single component class to the selected class			
+			prRDFFile.println(" ");	
+			prRDFFile.println("### ObjectProperty (One):" + lClassPropertiesOWL.theClass.identifier + " ###");	
+//			prRDFFile.println(" ");	
+			String lIRI = ClassPropertiesBase.formValueIRI(ClassPropertiesBase.objectPropertyComponentOfP1 + "-" + lClassPropertiesOWL.title);
+			prRDFFile.println(lIRI + " " + "rdf:type" + " " + "owl:ObjectProperty" + ";");	
+			prRDFFile.println("  " + "rdfs:label \"" + "component of " + lClassPropertiesOWL.title + "\";");	
+			prRDFFile.println("  " + "rdfs:domain " + lClassPropertiesOWLComp.iri + ";");	
+			prRDFFile.println("  " + "rdfs:range " + lClassPropertiesOWL.iri + ";");	
+			prRDFFile.println("  " + "rdfs:subPropertyOf " + ClassPropertiesBase.objectPropertyComponentOf + ";");	
+			prRDFFile.println("  " + "rdfs:comment \"" + "These are the component(s) of " + lClassPropertiesOWL.title + "\".");
+
+			// ensure the component is ultimately defined
+			referencedClassIdMap.put(lClassPropertiesOWLComp.theClass.identifier, lClassPropertiesOWLComp);				
+		}
+	}
+	
+	// write the RDF for classes associated with the class.
+	public  void writeAssociatedClassMulti (ClassPropertiesOWL lClassPropertiesOWL) {
+		
+		// write the definition of the ObjectProperty that relates the parent components class to the selected class
+		// the component classes are subclasses of the parent "components" class
+		String lIRICompSuperClass = ClassPropertiesBase.formValueIRI(ClassPropertiesBase.objectPropertySubclassPrefix + "-" + lClassPropertiesOWL.title + "-components");
+		String lIRI = ClassPropertiesBase.formValueIRI(ClassPropertiesBase.objectPropertyComponentOfP1 + "-" + lClassPropertiesOWL.title);
+		prRDFFile.println(" ");	
+		prRDFFile.println("### ObjectProperty (Multi):" + lClassPropertiesOWL.theClass.identifier + " ###");	
+//		prRDFFile.println(" ");	
+		prRDFFile.println(lIRI + " " + "rdf:type" + " " + "owl:ObjectProperty" + ";");	
+		prRDFFile.println("  " + "rdfs:label \"" + "components of " + lClassPropertiesOWL.title + "\";");
+		prRDFFile.println("  " + "rdfs:domain " + lIRICompSuperClass + ";");	
+		prRDFFile.println("  " + "rdfs:range " + lClassPropertiesOWL.iri + ";");	
+		prRDFFile.println("  " + "rdfs:subPropertyOf " + ClassPropertiesBase.objectPropertyComponentOf + ";");	
+		prRDFFile.println("  " + "rdfs:comment \"" + "These are the component(s) of " + lClassPropertiesOWL.title + "\".");
+		
+		
+		// write the definition of the single "Components" class
+		prRDFFile.println(" ");	
+		prRDFFile.println("### Proxy Component Class (Multi):" + lClassPropertiesOWL.theClass.identifier + " ###");	
+		prRDFFile.println(lIRICompSuperClass + " " + "a" + " " + "owl:Class" + ";");	
+		prRDFFile.println("  " + "rdfs:label \"" + lClassPropertiesOWL.title + " Components" + "\";");	
+		prRDFFile.println("  " + "rdfs:comment \"" + "This is the " + lClassPropertiesOWL.title + " components superclass." + "\".");
+		
+		// write the definition of each individual component class, as a subclass of the single "Components" class.
+		for (ClassPropertiesOWL lClassPropertiesOWLComp : lClassPropertiesOWL.theComponentOfClassArr) {
+			prRDFFile.println(" ");	
+			prRDFFile.println("### Proxy Component Subclass (Multi):" + lClassPropertiesOWLComp.theClass.identifier + " ###");	
+			prRDFFile.println(lClassPropertiesOWLComp.iri + " " + "a" + " " + "owl:Class" + ";");	
+			prRDFFile.println("  " + "rdfs:label \"" + lClassPropertiesOWLComp.title + "\";");	
+			prRDFFile.println("  " + "rdfs:subClassOf " + lIRICompSuperClass + ".");	
+
+			// ensure the component is ultimately defined
+			referencedClassIdMap.put(lClassPropertiesOWLComp.theClass.identifier, lClassPropertiesOWLComp);		
+		}
+	}
+			
+	// write the values of *_type as subclasses (e.g., Instrument.type = Accelerometer)
+	public  void writeTypesAsSubClasses (ClassPropertiesOWL lClassPropertiesOWL, ClassAttrPropClassification lClassAttrPropClassification, int sign) {
+		// check for ClassPropertiesOWL with a null DOMClass; such as created from permissible values - see note below					
+		if (lClassPropertiesOWL.theClass == null) {
+			return;
+		}
+		for (Iterator <DOMProp> j = lClassPropertiesOWL.theClass.ownedAttrArr.iterator(); j.hasNext();) {
+			DOMProp lDOMProp = (DOMProp) j.next();
+			if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMAttr) {					
+				DOMAttr lDOMAttr = (DOMAttr) lDOMProp.hasDOMObject;
+				if (lDOMAttr.title.compareTo("type") == 0) {
+					for (Iterator <DOMProp> k = lDOMAttr.domPermValueArr.iterator(); k.hasNext();) {
+						DOMProp lDOMPropPermValue = (DOMProp) k.next();
+						if (lDOMPropPermValue.hasDOMObject != null && lDOMPropPermValue.hasDOMObject instanceof DOMPermValDefn) {
+							DOMPermValDefn lDOMPermVal = (DOMPermValDefn) lDOMPropPermValue.hasDOMObject;
+
+							// note that this creates a ClassPropertiesOWL with a null DOMClass					
+							ClassPropertiesOWL lClassPropertiesPermVal = new ClassPropertiesOWL (lDOMPermVal, lClassPropertiesOWL);
+//							writeClassDefn (lClassPropertiesPermVal, lClassAttrPropClassification, false);
+							writeClassDefn (lClassPropertiesPermVal, lClassAttrPropClassification);
+						}
+					}
+				}
+			}
+		}
+	}	
+	
+	public  void writeRelationships (ArrayList <RelationshipProperties> lRelationshipPropertiesArr) {
+		for(RelationshipProperties lRelationshipProperties : lRelationshipPropertiesArr) {
+			writeRelationshipProperties (lRelationshipProperties);
+		}	
+	}
+	
+	public  void writeRelationshipProperties (RelationshipProperties lRelationshipProperties) {
+		prRDFFile.println(" ");	
+		String lLIDVID = ClassPropertiesBase.formValueLID(lRelationshipProperties.fromClassProperties.nameSpaceIdNC + ":" + lRelationshipProperties.lidvid); 
+		prRDFFile.println(masterNameSpaceIdNC + ":" + lLIDVID + " " + "rdf:type" + " " + "rdf:Property" + ";");	
+		prRDFFile.println("  " + "rdfs:label \"" + lRelationshipProperties.title + "\";");	
+		prRDFFile.println("  " + "rdfs:domain " + lRelationshipProperties.fromClassProperties.nameSpaceIdNC + ":" + lRelationshipProperties.fromClassProperties.lidvid + ";");				
+		prRDFFile.println("  " + "rdfs:range " + lRelationshipProperties.toClassProperties.nameSpaceIdNC + ":" + lRelationshipProperties.toClassProperties.lidvid + ".");	
+	}	
+
+	// write the RDF for attributes associated with the class.
+	public  void writeAssociatedAttributes (ClassPropertiesOWL lClassPropertiesOWL) {
+		ArrayList <ClassPropAttr> theClassPropAttrArr = lClassPropertiesOWL.getTheClassPropAttrArr () ;
+		for (ClassPropAttr lClassPropAttr : theClassPropAttrArr) {
+			DOMAttr lDOMAttr = lClassPropAttr.toAttr;
+			prRDFFile.println(" ");	
+			String lIRI = ClassPropertiesBase.formValueIRI(lClassPropertiesOWL.lid + lDOMAttr.title + "::" + lClassPropertiesOWL.vid);
+			prRDFFile.println(lIRI  + " " + "rdf:type" + " " + "owl:DatatypeProperty" + ";");	
+			prRDFFile.println("  " + "rdfs:label \"" + lDOMAttr.parentClassTitle + " " + lDOMAttr.title + "\";");	
+			prRDFFile.println("  " + "rdfs:domain " + lClassPropertiesOWL.iri + ";");	
+			prRDFFile.println("  " + "rdfs:range " + lDOMAttr.xmlBaseDataType + ";");	
+			prRDFFile.println("  " + "rdfs:subPropertyOf " + ClassPropertiesBase.datatypePropertyAttributeOf + ";");	
+			prRDFFile.println("  " + "rdfs:comment \"" + escapeXMLChar(lDOMAttr.definition) + "\".");	
+		}
+	}
+	
+	// special definitions
+	
+	// write RDF for the rdfs:subClassOf property; label as ISA
+	public  void writeSubClassRedefined (ClassAttrPropClassification lClassAttrPropClassification) {
+		prRDFFile.println(" ");	
+		prRDFFile.println(masterNameSpaceIdNC + ":" + "subClassOf" + " " + "rdfs:subPropertyOf" + " " + "rdfs:subClassOf" + ";");	
+		prRDFFile.println("  " + "rdfs:label \"" + "is_a" + "\".");	
+
+		// Pds4:subClassOf a rdfs:subClassOf ;
+		//   Pds4:label: “ISA”
+	}
+	
+	// write the one definition for attributeOf
+	public  void writeDatatypePropertyAttributeOf (ClassAttrPropClassification lClassAttrPropClassification) {
+		prRDFFile.println(" ");	
+		prRDFFile.println(ClassPropertiesBase.datatypePropertyAttributeOf + " " + "rdf:type" + " " + "owl:DatatypeProperty" + ";");	
+		prRDFFile.println("  " + "rdfs:label \"" + "attributeOf" + "\".");	
+	}	
+	
+	// write the one definition for componentOf
+	public  void writeDatatypePropertyComponentOf (ClassAttrPropClassification lClassAttrPropClassification) {
+		prRDFFile.println(" ");	
+		prRDFFile.println(ClassPropertiesBase.objectPropertyComponentOf + " " + "rdf:type" + " " + "owl:ObjectProperty" + ";");	
+		prRDFFile.println("  " + "rdfs:label \"" + "componentOf" + "\".");	
+	}	
+
+	static String escapeXMLChar (String aString) {
+		String lString = aString;
+		lString = DOMInfoModel.replaceString (lString, "\\", "\\\\");  // escape of backslash must be first
+		lString = DOMInfoModel.replaceString (lString, "\"", "&quot;");
+		lString = DOMInfoModel.replaceString (lString, "'", "&apos;");
+		return lString;
+	}
+}	

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMStandardIdExtract.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMStandardIdExtract.java
@@ -59,7 +59,7 @@ class WriteDOMStandardIdExtract extends Object {
 
   public void writeExtractFileBegin() throws java.io.IOException {
     // Write the files consisting of individual classes
-    String lFileName = DMDocument.outputDirPath + "Extract/" + "StandardId" + "_"
+    String lFileName = DMDocument.outputDirPath + "export/" + "StandardId" + "_"
         + DOMInfoModel.lab_version_id + ".txt";
     prPVL =
         new PrintWriter(new OutputStreamWriter(new FileOutputStream(new File(lFileName)), "UTF-8"));

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMTermEntryJSON.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMTermEntryJSON.java
@@ -1,0 +1,201 @@
+// Copyright 2019, California Institute of Technology ("Caltech").
+// U.S. Government sponsorship acknowledged.
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// * Redistributions must reproduce the above copyright notice, this list of
+// conditions and the following disclaimer in the documentation and/or other
+// materials provided with the distribution.
+// * Neither the name of Caltech nor its operating division, the Jet Propulsion
+// Laboratory, nor the names of its contributors may be used to endorse or
+// promote products derived from this software without specific prior written
+// permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package gov.nasa.pds.model.plugin; 
+
+import java.io.*;
+import java.util.*;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+
+// Write the Terminological Entries to a file
+
+class WriteDOMTermEntryJSON extends Object {
+	
+	// LDD name
+	String lddName;
+	String lddVersion;
+	    
+	public WriteDOMTermEntryJSON () {
+		lddName = "TBD_lddName";
+		lddVersion = "TBD_lddVersion";
+		return;
+	}
+	
+//	write terminological entries
+	public void WriteDOMTermEntries (SchemaFileDefn lSchemaFileDefn) throws java.io.IOException {
+		String lFileName = lSchemaFileDefn.relativeFileSpecCCSDSCSV;			
+		lFileName += "_termmap.txt";
+//		PrintWriter prDocBook = new PrintWriter(new OutputStreamWriter (new FileOutputStream(new File(lFileName)), "UTF-8"));
+
+		// get the term mappings
+		TreeMap <String, TermEntryDefnGroup> TermEntryDefnGroupMap = getTermMappings ();
+		
+		// get the JSON object
+		JSONObject jsonObjectRoot = getJSONObject (TermEntryDefnGroupMap);
+
+		// write the JSON object
+		writeJson(jsonObjectRoot, "C:\\AA7Ontologies\\A01PDS4\\Document\\LDDTool\\export\\csv\\PDS4_PDS_CCSDS_1I00_termmap.JSON");
+		return;
+	}
+	
+	// get the term mappings
+	private TreeMap <String, TermEntryDefnGroup> getTermMappings () {
+		// map of Term Entry Definitions index by class and attribute identifier
+		TreeMap <String, TermEntryDefnGroup> termEntryDefnGroupMap = new TreeMap <String, TermEntryDefnGroup> ();
+
+        // scan all the classes for terminological entries at the attribute level
+		for (DOMClass lDOMClass : DOMInfoModel.masterDOMClassArr) {
+			
+			// skip inactive
+			if (lDOMClass.isInactive) continue;
+			
+			// scan through all owned attributes of the class
+			for (DOMProp lDOMProp : lDOMClass.ownedAttrArr) {
+				if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMAttr) {
+					DOMAttr lDOMAttr = (DOMAttr) lDOMProp.hasDOMObject;
+					
+					// skip attribute with no terminological entry map
+					if (lDOMAttr.termEntryMap == null || lDOMAttr.termEntryMap.isEmpty() ) continue;
+					
+//					System.out.println("\ndebug getTermMappings lDOMClass.identifier:" + lDOMClass.identifier);
+//					System.out.println("debug getTermMappings lDOMAttr.identifier:" + lDOMAttr.identifier);
+//					System.out.println("debug getTermMappings -- FOUND -- lDOMAttr.identifier:" + lDOMAttr.identifier);
+					
+					// found a terminological entry map; get the TermEntryDefns of the map as an array
+					for (TermEntryDefn lTermEntryDefn : lDOMAttr.termEntryMap.values()) {
+						lddName = lTermEntryDefn.lddName;
+						lddVersion = lTermEntryDefn.lddVersion;
+						String lKey = lDOMAttr.identifier + "_" + lTermEntryDefn.name + "_" + DOMInfoModel.getNextUId();
+						
+						TermEntryDefnGroup termEntryDefnGroup = new TermEntryDefnGroup ();
+						termEntryDefnGroup.identifier = lKey;
+						termEntryDefnGroup.attrId = lDOMAttr.nameSpaceId + lDOMAttr.title;
+						termEntryDefnGroup.termEntryDefn = lTermEntryDefn;
+						
+/*						System.out.println("\ndebug getTermMappings termEntryDefnGroup.identifier:" + termEntryDefnGroup.identifier);
+						System.out.println("debug getTermMappings termEntryDefnGroup.attrId:" + termEntryDefnGroup.attrId);
+						System.out.println("debug getTermMappings termEntryDefnGroup.termEntryDefn.fromInstanceId:" + termEntryDefnGroup.termEntryDefn.fromInstanceId);
+						System.out.println("debug getTermMappings termEntryDefnGroup.termEntryDefn.toInstanceId:" + termEntryDefnGroup.termEntryDefn.toInstanceId);
+						System.out.println("debug getTermMappings termEntryDefnGroup.termEntryDefn.name:" + termEntryDefnGroup.termEntryDefn.name);
+						System.out.println("debug getTermMappings termEntryDefnGroup.termEntryDefn.semanticRelation:" + termEntryDefnGroup.termEntryDefn.semanticRelation);
+						System.out.println("debug getTermMappings termEntryDefnGroup.termEntryDefn.lddName:" + termEntryDefnGroup.termEntryDefn.lddName);
+						System.out.println("debug getTermMappings termEntryDefnGroup.termEntryDefn.lddVersion:" + termEntryDefnGroup.termEntryDefn.lddVersion);
+*/
+						termEntryDefnGroupMap.put(lKey, termEntryDefnGroup);
+					}
+				}
+			}
+		}
+//       return termEntryDefnMap;
+       return termEntryDefnGroupMap;
+	}
+	
+	// get the term mappings as a JSON object
+	private JSONObject getJSONObject (TreeMap <String, TermEntryDefnGroup> termEntryDefnGroupMap) {
+		// create the JSON object
+		JSONObject jsonObjectRoot = new JSONObject ();
+		jsonObjectRoot.put("datetime", DMDocument.masterTodaysDateTimeUTCwT);
+		jsonObjectRoot.put("infoModelVersionId", DMDocument.infoModelVersionId);
+		jsonObjectRoot.put("title", "PDS4 Term Mappings");
+		jsonObjectRoot.put("lddName", lddName);
+		jsonObjectRoot.put("lddVersion", lddVersion);
+
+		// create array of one element {from, to} arrays
+		JSONArray jsonTermMapElementArrArr = new JSONArray();
+		
+		// scan over the term entry definitions
+		for (TermEntryDefnGroup termEntryDefnGroup : termEntryDefnGroupMap.values()) {
+			
+			// get the term map elements
+					
+			// create a one {from, to} array
+			JSONArray jsonFromToArr = new JSONArray();
+
+			// get the From (new) term
+			JSONObject jsonFromObject = new JSONObject ();
+			String fromInstanceId = getEscapedValue(termEntryDefnGroup.termEntryDefn.fromInstanceId);
+			jsonFromObject.put("from", fromInstanceId);
+			jsonFromToArr.add(jsonFromObject);
+			
+			// get the To (PDS4) term
+			JSONObject jsonToObject = new JSONObject ();
+			String toInstanceId = getEscapedValue(termEntryDefnGroup.termEntryDefn.toInstanceId);
+			jsonToObject.put("to", toInstanceId);
+			jsonFromToArr.add(jsonToObject);
+			
+			// get the SKOS semanticRelation
+			JSONObject jsonSKOSObject = new JSONObject ();
+			String semanticRelation = getEscapedValue(termEntryDefnGroup.termEntryDefn.semanticRelation);
+			jsonSKOSObject.put("skos", semanticRelation);
+			jsonFromToArr.add(jsonSKOSObject);
+			
+			// get the description of the mapping
+			JSONObject jsonDefinitionObject = new JSONObject ();
+			String definition = getEscapedValue(termEntryDefnGroup.termEntryDefn.definition);
+			jsonDefinitionObject.put("defn", definition);
+			jsonFromToArr.add(jsonDefinitionObject);
+			
+			// create one {from, to} enclosing object
+			JSONObject jsonFromToObj = new JSONObject ();
+			jsonFromToObj.put("termmap", jsonFromToArr);
+			
+			// add one {from, to} enclosing object 
+			jsonTermMapElementArrArr.add(jsonFromToObj);
+		}
+		jsonObjectRoot.put("termmaps", jsonTermMapElementArrArr);
+        return jsonObjectRoot;
+	}
+
+	
+    public static void writeJson(JSONObject jsonObject, String file) {
+    	// write the JSON Object
+        try {
+//            System.out.println(jsonObject);
+            FileWriter jsonFileWriter = new FileWriter(file);
+            jsonFileWriter.write(jsonObject.toJSONString());
+            jsonFileWriter.flush();
+            jsonFileWriter.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+	
+	private String getEscapedValue (String lValue) {
+		return DOMInfoModel.escapeXMLChar(lValue);
+	}
+	
+	class TermEntryDefnGroup {
+		String identifier;
+		String attrId;
+		TermEntryDefn termEntryDefn;
+	}
+}


### PR DESCRIPTION
Issue #467 : Add flags to support generation of TTL/OWL files 
Issue #458 : As a developer I want to have the PDS4 Information Model expressed in the RDF/OWL/TTL format. 

Added "-O" option to export TTL/OWL files from the PDS4 IM. 
The TTL/OWL export conforms to the requirements provided by the JPL Institutional Knowledge Graph (IKG) task.
This RDF file is written using OWL semantics and is in the TTL (turtle) syntax.
				
This update also includes code clean-up for exporting the terminological mapping file and customized one-off files. The terminological mapping issues remain open.

Test: Use the -O option to generate the OWL/TTL export. Note that the -l option (el for LDDTool) is omitted, i.e., the DMDocument app runs as IMTool not LDDTool and uses only the Common dictionary.

.\bin\DMDOC.bat -pO ==> java" -jar ".\lib\DMDocument.jar" -pO 

Output: See attached file: \export\owl\PDS4_PDS_OWL_1J00_IKG.ttl

Resolves #467 #458 


[PDS4_PDS_OWL_1J00_IKG.zip](https://github.com/NASA-PDS/pds4-information-model/files/10760756/PDS4_PDS_OWL_1J00_IKG.zip)
