### PR TITLE
Issue #596 - Stage the PDS4 Information Model Version 1.20.0.0 (1.K.0.0)

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -136,8 +136,8 @@ public class DMDocument extends Object {
 
   static String LDDToolVersionId = "0.0.0";
   static String buildDate = "";
-  static String buildIMVersionId = "1.19.0.0";
-  static String buildIMVersionFolderId = "1J00";
+  static String buildIMVersionId = "1.20.0.0";
+  static String buildIMVersionFolderId = "1.K.0.0";
   static String classVersionIdDefault = "1.0.0.0";
   static boolean PDS4MergeFlag = false; // create protege output; not currently used
   // static boolean LDDClassElementFlag = false; // if true, write XML elements for classes
@@ -339,7 +339,8 @@ public class DMDocument extends Object {
 
     // The current version is included to allow for -V currentIMVersion
     alternateIMVersionArr = new ArrayList<>();
-    alternateIMVersionArr.add("1J00"); // current
+    alternateIMVersionArr.add("1K00"); // current
+    alternateIMVersionArr.add("1J00");
     alternateIMVersionArr.add("1I00");
     alternateIMVersionArr.add("1H00");
     alternateIMVersionArr.add("1G00");


### PR DESCRIPTION
Stage the IMTool system for V1.20.0.0 to allow the implementation of approved SCRs and bug fixes.
				
Resolves #596

Testing: See attached file.

The IM Specification document and all other generated documents should have the IM Version Id: 1.20.0.0   (1.K.0.0)



[index_1K00.zip](https://github.com/NASA-PDS/pds4-information-model/files/10817283/index_1K00.zip)
