### PR TITLE
Issue #658 : LDDTool does not support IM version 1K00 

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -141,7 +141,7 @@ public class DMDocument extends Object {
   static String LDDToolVersionId = "0.0.0";
   static String buildDate = "";
   static String buildIMVersionId = "1.20.0.0";
-  static String buildIMVersionFolderId = "1.K.0.0";
+  static String buildIMVersionFolderId = "1K00";
   static String classVersionIdDefault = "1.0.0.0";
   static boolean PDS4MergeFlag = false; // create protege output; not currently used
   // static boolean LDDClassElementFlag = false; // if true, write XML elements for classes


### PR DESCRIPTION
Issue #658 : LDDTool does not support IM version 1K00 

Typo - change buildIMVersionFolderId from "1.K.0.0"  to "1K00"

Resolves #658