### PR TITLE
Issue #661 LDDTool fails for dependent LDDs since v14.2.0

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -1825,6 +1825,15 @@ public class LDDDOMParser extends Object {
     if (lComponentDOMClass != null) {
       return lComponentDOMClass;
     }
+    
+    // try with dot converted to colon
+	String newLocalIdentifier = DOMInfoModel.replaceString(lLocalIdentifier, ".", ":");
+
+    // Is the class local
+    lComponentDOMClass = classMapLocal.get(newLocalIdentifier);
+    if (lComponentDOMClass != null) {
+      return lComponentDOMClass;
+    }
 
     // Assume class is external
     String lClassIdentifier =


### PR DESCRIPTION
Issue #661 LDDTool fails for dependent LDDs since v14.2.0

Added code to check local_identifier with colon in addition to dot as namespace delimiter

Resolves #661