### PR TITLE
Issue #670 Adds to default output JSON TermMap 

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -179,7 +179,7 @@ public class DMDocument extends Object {
 
   // import export file flags
   static boolean exportJSONFileFlag = false; // LDDTool, set by -J option
-  static boolean exportJSONFileAllFlag = false; // LDDTool, set by -6 option
+  static boolean exportJSONFileAllFlag = false; // LDDTool, set by -6 option *** Not Currently Used - Deprecate? ***
   static boolean exportSpecFileFlag = false;
   static boolean exportDDFileFlag = false;
   static boolean exportTermMapFileFlag = false;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMProcessState.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMProcessState.java
@@ -250,13 +250,14 @@ public class DMProcessState {
     }
     return false;
   }
-  public Boolean getexportJSONFileAllFlag() {
-    Integer lProcessOrder = processFlagMap.get("Export JSON File All Flag");
-    if (lProcessOrder != null) {
-      return true;
-    }
-    return false;
-  }
+  
+//  public Boolean getexportJSONFileAllFlag() {
+//    Integer lProcessOrder = processFlagMap.get("Export JSON File All Flag");
+//    if (lProcessOrder != null) {
+//      return true;
+//    }
+//    return false;
+//  }
 
   public Boolean getcheckFileNameFlag() {
     Integer lProcessOrder = processFlagMap.get("Check File Name Flag");
@@ -378,10 +379,10 @@ public class DMProcessState {
 	return;
   }
 
-  public void setexportJSONFileAllFlag() {
-    processFlagMap.put("Export JSON File All Flag", 1200);
-    return;
-  }
+//  public void setexportJSONFileAllFlag() {
+//    processFlagMap.put("Export JSON File All Flag", 1200);
+//    return;
+//  }
 
   public void setcheckFileNameFlag() {
     processFlagMap.put("Check File Name Flag", 1210);

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModels.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModels.java
@@ -128,17 +128,16 @@ public class ExportModels extends Object {
         .registerMessage("0>info " + "writeAllArtifacts - DD Pins *** plus class *** File Done");
 
     // write the 11179 DOM JSON file - requires DOMInfoModel to be executed
-    DMDocument.dmProcessState.setRelativeFileSpecDOMModelJSON(DMDocument.masterPDSSchemaFileDefn);
-    WriteDOMDDJSONFile writeDOMDDJSONFile = new WriteDOMDDJSONFile();
-    writeDOMDDJSONFile.writeJSONFile();
-    DMDocument.registerMessage("0>info " + "writeAllArtifacts - JSON Done");
+//    DMDocument.dmProcessState.setRelativeFileSpecDOMModelJSON(DMDocument.masterPDSSchemaFileDefn);
+//    WriteDOMDDJSONFile writeDOMDDJSONFile = new WriteDOMDDJSONFile();
+//    writeDOMDDJSONFile.writeJSONFile();
+//    DMDocument.registerMessage("0>info " + "writeAllArtifacts - JSON Done");
     
     // write the 11179 DOM JSON file - requires DOMInfoModel to be executed
-    // *** NEW VERSION ***
-//    DMDocument.dmProcessState.setRelativeFileSpecDOMModelJSON(DMDocument.masterPDSSchemaFileDefn);
-    WriteDOMDDJSONFileLib writeDOMDDJSONFileNew = new WriteDOMDDJSONFileLib();
-    writeDOMDDJSONFileNew.writeJSONFile(false, DMDocument.masterPDSSchemaFileDefn); // false -> not LDDToolFlag
-    DMDocument.registerMessage("0>info " + "writeAllArtifacts - JSON *** NEW *** Done");
+    DMDocument.dmProcessState.setRelativeFileSpecDOMModelJSON(DMDocument.masterPDSSchemaFileDefn);
+    WriteDOMDDJSONFileLib writeDOMDDJSONFileLib = new WriteDOMDDJSONFileLib();
+    writeDOMDDJSONFileLib.writeJSONFile(DMDocument.masterPDSSchemaFileDefn);
+    DMDocument.registerMessage("0>info " + "writeAllArtifacts - JSON Done");
     
 
     // write the 11179 DD Data Element Definition XML Files
@@ -246,12 +245,20 @@ public class ExportModels extends Object {
             + DMDocument.masterLDDSchemaFileDefn.identifier + " - Done");
 
     // write the 11179 JSON file
-    if (DMDocument.exportJSONFileFlag || DMDocument.exportJSONFileAllFlag) {
-      DMDocument.dmProcessState.setRelativeFileSpecDOMModelJSON(DMDocument.masterLDDSchemaFileDefn);
-      WriteDOMDDJSONFile writeDOMDDJSONFile = new WriteDOMDDJSONFile();
-      writeDOMDDJSONFile.writeJSONFile();
-      DMDocument.registerMessage("0>info " + "writeAllArtifacts - JSON Done");
-    }
+//    if (DMDocument.exportJSONFileFlag || DMDocument.exportJSONFileAllFlag) {
+//      DMDocument.dmProcessState.setRelativeFileSpecDOMModelJSON(DMDocument.masterLDDSchemaFileDefn);
+//      WriteDOMDDJSONFile writeDOMDDJSONFile = new WriteDOMDDJSONFile();
+//      writeDOMDDJSONFile.writeJSONFile();
+//      DMDocument.registerMessage("0>info " + "writeAllArtifacts - JSON Done");
+//    }
+    
+    // write the 11179 DOM JSON file
+      if (DMDocument.exportJSONFileFlag) {
+    	  DMDocument.dmProcessState.setRelativeFileSpecDOMModelJSON(DMDocument.masterPDSSchemaFileDefn);
+    	  WriteDOMDDJSONFileLib writeDOMDDJSONFileLib = new WriteDOMDDJSONFileLib();
+    	  writeDOMDDJSONFileLib.writeJSONFile(DMDocument.masterPDSSchemaFileDefn);
+    	  DMDocument.registerMessage("0>info " + "writeAllArtifacts - JSON Done");
+      }
 
     // write the Info Spec file
     if (DMDocument.exportSpecFileFlag) {
@@ -283,6 +290,7 @@ public class ExportModels extends Object {
 		DMDocument.registerMessage ("0>info " + "ExportModels - OWL/RDF output in RDF format (IM Export) - Done");
 	}
 	
+	// *** To be deprecated ***
 	// write the Terminological Mapping defined in the TermMap LDD to JSON
 	if (DMDocument.exportTermMapFileFlag) {
 		// write the terminological entry files

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModelsCustom.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ExportModelsCustom.java
@@ -156,12 +156,6 @@ public class ExportModelsCustom extends Object {
 		WriteLucidFiles.WriteLucidFile();
 		*/
 		
-		// write the terminological entry files
-/*		WriteDOMTermEntryJSON writeDOMTermEntryJSON = new WriteDOMTermEntryJSON ();
-		writeDOMTermEntryJSON.WriteDOMTermEntries (DMDocument.masterPDSSchemaFileDefn);
-		DMDocument.registerMessage ("0>info " + "WriteDOMTermEntryJSON -  Done"); */
-
-		
 		// write the PDS4 CCSDS CSV file 
 		/*
 		WriteDocCSV writeDocCSV = new WriteDocCSV ();


### PR DESCRIPTION
The JSON Termmap writer has been added to WriteDOMDDJSONFileLib. The original WriteDOMDDJSONFile will be deprecated after successful testing during I&T. WriteDOMDDJSONFileLib is a refactor of WriteDOMDDJSONFile to use the org.json.simple JSON library.

The output from the refactored WriteDOMDDJSONFileLib seems to produce, in general, the same output as the original WriteDOMDDJSONFile. Cosmetic differences are that the JSON output file needs to be “pretty printed” and the “order” of the "names" was not maintained.  

There were a few cases found where a "name" did not exist for a "value". In such cases a "blank node name" was created. The format of the blank node name is "bn#" where # is a sequence number.

Resolves #670
Refs CCB-351