### PR TITLE
Add an optional License_Information class to the Identification_Area

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -565,6 +565,10 @@ public class DMDocument extends Object {
     XMLDocParserDomMDPTNConfig lMDPTNConfig = new XMLDocParserDomMDPTNConfig();
     masterClassDispoMap2 = lMDPTNConfig.getXMLTable2(dataDirPath + "MDPTNConfigClassDisp.xml");
 
+//    // 222 test
+//    DMCheckDispositions dmCheckDispositions = new DMCheckDispositions ();
+//    dmCheckDispositions.printDispositions("", masterClassDispoMap2);
+    
     // set up the System Build version
     XMLSchemaLabelBuildNum = pds4BuildId;
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetValueMeanings.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetValueMeanings.java
@@ -168,6 +168,11 @@ class GetValueMeanings extends Object {
     // masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
     lPVD = new PermValueDefn(
+        "pds:Product_Observational/pds:Identification_Area/pds:License_Information/pds:Internal_Reference.reference_type.product_to_license",
+        "product_to_license", "A reference to a document or context product containing the full text of the license, terms, or public domain classification");
+        masterValueMeaningMap.put(lPVD.identifier, lPVD);
+    
+    lPVD = new PermValueDefn(
         "pds:Product_Observational/pds:Observation_Area/pds:Investigation_Area/pds:Internal_Reference.reference_type.data_to_investigation",
         "data_to_investigation", "The data product is associated to an investigation");
     masterValueMeaningMap.put(lPVD.identifier, lPVD);

--- a/model-ontology/src/ontology/Data/MDPTNConfigClassDisp.xml
+++ b/model-ontology/src/ontology/Data/MDPTNConfigClassDisp.xml
@@ -95,6 +95,7 @@
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Discipline_Area</Field> <Field>1MC</Field> <Field>#10</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Object_Statistics</Field> <Field>1MTC</Field> <Field>#10</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Time_Coordinates</Field> <Field>1MC</Field> <Field>#10</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
+  <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.License_Information</Field> <Field>1MC</Field> <Field>#10</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Composite_Structure</Field> <Field>1MC</Field> <Field>#10</Field> <Field>pds</Field> <Field>pds</Field> </Record> 
   <Record> <Field>Disposition</Field> <Field>Y</Field> <Field>UpperModel.0001_NASA_PDS_1.Local_ID_Reference</Field> <Field>1MC</Field> <Field>#10</Field> <Field>pds</Field> <Field>pds</Field> </Record> 

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Fri Aug 04 18:30:06 EDT 2023
+; Wed Aug 30 12:54:04 EDT 2023
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -2267,6 +2267,31 @@
 	(attrTitle "reference_type")
 	(identifier "reference_type")
 	(specMesg "In Product_Native, every instance of 'pds:Internal_Reference/pds:reference_type' must be set to one of the following values: 'described_by_document', 'native_to_archival'."))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Observational%2Fpds%3AIdentification_Area%2Fpds%3ALicense_Information%2Fpds%3AInternal_Reference.100002548] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "pds")
+	(attrTitle "reference_type")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Observational%2Fpds%3AIdentification_Area%2Fpds%3ALicense_Information%2Fpds%3AInternal_Reference.100002548.101])
+	(identifier "pds:Product_Observational/pds:Identification_Area/pds:License_Information/pds:Internal_Reference")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "pds:Product_Observational/pds:Identification_Area/pds:License_Information/pds:Internal_Reference"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Observational%2Fpds%3AIdentification_Area%2Fpds%3ALicense_Information%2Fpds%3AInternal_Reference.100002548.101] of  Schematron_Assert
+
+	(assertMsg " must be set to one of the following values ")
+	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('product_to_license')")
+	(assertType "EVERY")
+	(attrTitle "reference_type")
+	(identifier "reference_type")
+	(specMesg "TBD")
+	(testValArr "product_to_license"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Observational%2Fpds%3AObservation_Area%2Fpds%3AInvestigation_Area.100002547] of  Schematron_Rule
 

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Fri Aug 04 18:30:05 EDT 2023
+; Wed Aug 30 12:54:04 EDT 2023
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -7,1379 +7,63 @@
 (defclass %3ACLIPS_TOP_LEVEL_SLOT_CLASS "Fake class to save top-level slot information"
 	(is-a USER)
 	(role abstract)
-	(single-slot axes
-;+		(comment "The axes attribute provides a count of the axes.")
-		(type INTEGER)
+	(multislot rule_value
+;+		(comment "The rule_value attribute provides values to be used to complete certain schematon statements.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot mission_objectives_summary
+;+		(comment "The mission_objectives_summary attribute describes the major scientific objectives of a planetary mission or project.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot scale_factor_at_projection_origin
-;+		(comment " The scale_factor_at_projection_origin attribute provides a multiplier for reducing a distance obtained from a map by computation or scaling to the actual distance at the projection origin. ")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot data_object_type
-;+		(comment "The data_object_type attribute identifies the data object type of a given set of data. Example values Within the PDS according to the standards outlined in the PDS Standards Reference. Note: within AMMOS and only for the Magellan catalog attribute is used as an alias for data_set_id. The use of data_object_type as such provides backward compatibility with earlier AMMOS conventions. The use of this attribute as an alias for data_set_id is not recommended for any new tables. See data_set_id.")
-		(type SYMBOL)
-		(allowed-values ARRAY CONTAINER CUBE FILE IMAGE INDEX_TABLE N%2FA SPECTRAL_QUBE SPICE_KERNEL TEXT TIME_SERIES)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_type_list_area
-;+		(comment "The has_type_list_area association is a relationship to Type_List_Area.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot cross_reference_area
-;+		(comment "The cross_reference_area association is a relationship to Cross_Reference_Area a set of identifiers that reference other products.")
+	(single-slot archive_bundle
+;+		(comment "The archive bundle association is a relationship to the archive bundle class.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot dd_class_reference
-;+		(comment "The dd_class_reference association is a relationship to DD_Class_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Class_Reference)
-		(create-accessor read-write))
-	(multislot lowest_detectable_opacity
-;+		(comment "lowest_detectable_opacity indicates the sensitivity of a ring occultation data set to nearly opaque rings. It specifies the rough value for the smallest normal ring opacity that can be detected in the data at the resolution provided, incorporating both statistical effects and calibration uncertainties. Strongly recommended in labels of ring occultation observations. Not intended as a value for a table field.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot max_bytes
-;+		(comment "The maximum number of bytes allowed on a physical volume.")
-		(type STRING)
-;+		(value "2TB")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot type_list_identifer
-;+		(comment "The type_list_identifier attribute identifies the list from which the values in the type_list were selected.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot field_length
-;+		(comment "The field_length attribute provides the number of bytes in the field.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(single-slot median
-;+		(comment "The median attribute provides the number separating the higher half of the values from the lower half; empty and Special_Constants values are excluded.")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_Geo_Transformation
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot created_by
-;+		(comment "The created_by slot provides the names of the people who create the data set.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(cardinality 1 10)
-		(create-accessor read-write))
-	(single-slot east_bounding_coordinate
-;+		(comment "The east_bounding_coordinate attribute provides the eastern-most coordinate of the limit of coverage expressed in longitude.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot lidvid_reference_from
-;+		(comment "The lid_reference_from provides the identifier of the starting object in a one  directional relationship.")
-		(type INSTANCE)
-;+		(allowed-classes LIDVID_ID_Reference_From)
-		(create-accessor read-write))
-	(single-slot instrument_host_desc
-;+		(comment "The instrument_host_desc provides a description of an instrument host")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot mission_start_date
-;+		(comment "The mission_start_date attribute provides the date of the beginning of a mission in UTC system format.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot earth_received_start_time_utc
-;+		(comment "earth_received_start_time_utc gives the UTC time corresponding to the earliest time for the data product at which telemetry or other photons were received on Earth. Optional for occultation data.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot attrNameSpaceNC
-;+		(comment "The attrNameSpaceNC attribute provides the attribute name space Id without a colon.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Table_Field_Old
-;+		(comment "The has_Table_Field association is a relationship to field.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot earth_received_start_time
-;+		(comment "The earth_received_start_time attribute gives the beginning time at which a signal (such a telemetry) was received on Earth.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot occultation_type
-;+		(comment "occultation_type distinguishes between three types of occultation experiments: Stellar, Solar, or Radio. Stellar occultations involve observing a star as a targeted ring or body passes in front, as seen from either a spacecraft or Earth-based observatory. Solar occultations are similar to stellar occultations except that the Sun is used in place of a star. Radio occultations typically involve observing the continuous-wave radio transmissions from a spacecraft as it passes behind the target as seen from a radio telescope on Earth or another spacecraft. Required in labels of occultation observations. Normally not intended as a value for a table field.")
-		(type STRING)
-;+		(value "Radio" "Solar" "Stellar")
-		(create-accessor read-write))
-	(multislot keyword
-;+		(comment "The keyword attribute provides one or more words to be used for  keyword search.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot horizontal_display_direction
-;+		(comment "The horizontal_display_direction attribute specifies the direction across the screen of a display device that data along the horizontal axis of an Array is supposed to be displayed.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot upperleft_corner_x
-;+		(comment "The upperleft_corner_x and upperleft_corner_y attributes provide the projection x and y values, in meters, relative to the map projection origin, at sample 0.5 and line 0.5 (upper left corner of pixel 1,1 within image array).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot group_location
-;+		(comment "The group_location attribute provides the starting position for a Group_Field within the containing Record or Group_Field class, in bytes. Location '1' indicates the first byte of the containing class.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot upperleft_corner_y
-;+		(comment "The upperleft_corner_x and upperleft_corner_y attributes provide the projection x and y values, in meters, relative to the map projection origin, at sample 0.5 and line 0.5 (upper left corner of pixel 1,1 within image array).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot file_name_token
-;+		(comment "The file name token is a substring that names a directory. The maximum size of a file name is thirty characters.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot data_type_concept
-;+		(comment "Associated data type concept.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot minimum_scaled_value
-;+		(comment "The minimum_scaled_value attribute provides the minimum value after application of scaling_factor and value_offset (see their definitions; minimum_scaled_value is the minimum of Ov).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot contains_primary_member
-;+		(comment "The contains_primary_member attribute indicates whether a collection contains products that are primary members of the collection.")
-		(type SYMBOL)
-		(allowed-values FALSE TRUE)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot calibration_collection_reference
-;+		(comment "The calibration collection reference attribute provides the logical_identifier for a calibrartion collection.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot citation_text
-;+		(comment "The citation_text attribute provides a character string containing a literature or other citation in sufficient detail that the material  could be located in PDS or elsewhere.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot volume_format
-;+		(comment "The volume_format attribute identifies the logical format used in writing a data volume.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot volume_size
-;+		(comment "The volume size attribute provide the number of bytes in the volume.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot permissible_value
-;+		(comment "The permissible_value association is a relationship to Permissible_Value.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot discipline_name_2
-;+		(comment "The discipline_name attribute identifies the major academic or scientific domain or specialty of interest to an individual or to a PDS Node.")
-		(type STRING)
-;+		(value "Engineering" "Geosciences" "Imaging" "Navigation_Ancillary_Information_Facility" "Planetary_Atmospheres" "Planetary_Plasma_Interactions" "Planetary_Rings" "Radio_Science" "Small_Bodies")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot spice_reference
-;+		(comment "The spice reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier::version_id")
-		(create-accessor read-write))
-	(multislot schematronAssign
-;+		(comment "The schematronAssign attribute provides values for schemtron rule assignments at the rule level.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot collection_id
-;+		(comment "The collection id attribute provides a unique identifier for a collection.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot classNameSpaceNC
-;+		(comment "The classNameSpaceNC attribute provides the class name space Id without a colon.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot electronic_mail_address
-;+		(comment "The electronic mail address attribute provides a multi-part email address: the first part (the user name), which identifies a unique user, is separated by an \"at sign\"  from the host name, which uniquely identifies the mail server.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot volume_set_id
-;+		(comment "The volume_set_id attribute identifies a data volume or a set of volumes. Volume sets are normally considered as a single orderable entity. Examples: USA_NASA_PDS_MG_1001, USA_NASA_PDS_GR_0001_TO_GR_0009")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot local_planar_description
-;+		(comment "The local_planar_description attribute provides a description of the local planar system.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot property_map_type
-;+		(comment "The property_map_type attribute indicates the category of the property map.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot axis_index_order
-;+		(comment "The axis_index_order attribute provides the axis index that varies fastest with respect to storage order.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot associated_Camera_Model
-;+		(comment "The associated_Camera_Model association is a relationship to Camera Model.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot horizontal_framelet_offset
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot data_object
-;+		(comment "The data_object association is a relationship to Data Object.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot upper_110709_Class2
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot color_display_axis
-;+		(comment "The color_display_axis attribute identifies, by name, the axis of an Array %28or Array subclass%29 that is intended to be displayed in the color dimension of a display device. I.e., bands from this dimension will be loaded into the red, green, and blue bands of the display device. The value of this attribute must match the value of one, and only one, axis_name attribute in an Axis_Array class of the associated Array.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot upper_110709_Class0
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot sampling_parameter_name
-;+		(comment "The sampling_parameter_name element provides the name of the parameter which determines the sampling interval of a particular instrument or dataset parameter. For example, magnetic field intensity is sampled in time increments, and a spectrum is sampled in wavelength or frequency.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot upper_110709_Class1
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot da_contact_puid
-;+		(comment "The da_contact indicates the node person responsible for data administration.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Record
-;+		(comment "The has_Record association is a relationship to record.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot alternate_telephone_number
-;+		(comment "The alternate_telephone_number attribute provides a telephone number (in addition to telephone_number) in international notation which complies with the ITU-T E.164 format recommendation.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot mission_stop_date
-;+		(comment "The mission_stop_date attribute provides the date of the end of a mission in UTC system format.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot azimuthal_angle
-;+		(comment "The azimuthal_angle attribute provides the angle measured clockwise from north, and expressed in degrees.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot processing_level_id_old
-;+		(comment "The processing_level_id attribute provides the state to which data have been processed.")
-		(type STRING)
-;+		(value "RAW" "RDC" "CLB" "DRV")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot bit_fields
-;+		(comment "The bit_fields attribute provides the number of defined bit fields (Field_Bit definitions) within the Packed_Data_Field.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot data_type_unit_of_measure_name
-;+		(comment "The data type unit of measurement name attribute provides the unit of measure used with a value.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot type_description
-;+		(comment "The type_description attribute provides a description of the object's type.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot semi_major_radius
-;+		(comment "The semi_major_axis attribute provides the radius of the equatorial axis of the ellipsoid.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot maximum_record_bytes
-;+		(comment "The maximum_record_bytes atrtribute provides the maximum number of bytes that may be contained in a record.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot property_name
-;+		(comment "The property name attribute provides a word or a combination of words by which a property is known.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot home
-;+		(comment "The home attribute indicates where  an object resides. It provides sufficient information to be able to access the object.")
-		(type STRING)
 		(create-accessor read-write))
 	(multislot superclass_name
 		(type STRING)
 		(create-accessor read-write))
-	(multislot vector_component
-;+		(comment "The vector_component association is a relationship to the vector_component.")
-		(type INSTANCE)
-;+		(allowed-classes Vector_Component)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot document_format
-;+		(comment "The document_format attribute associates a Document_Format with the Document_Format_Set.")
-		(type INSTANCE)
-;+		(allowed-classes Document_Edition)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot local_planar_georeference_information
-;+		(comment "The local_planar_georeference_information attribute provides a description of the information provided to register the local planar system to a planet %28e.g. control points, satellite ephemeral data, inertial navigation data%29.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot volumes
-;+		(comment "An integer value indicating the number of archive volumes in this delivery.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot geometry_collection_reference
-;+		(comment "The geometry collection reference attribute provides the logical_identifier for a geometry collection.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot first_line_sample
-;+		(comment "The first_line_sample attribute provides the sample within a source image line that corresponds to the first line in a sub-image.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot longitude_of_central_meridian
-;+		(comment "The longitude_of_central_meridian attribute defines the line of longitude at the center of a map projection generally used as the basis for constructing the projection.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot loop_flag
-;+		(comment "The loop_flag attribute specifies whether or not a movie object should be played repeatedly without prompting from the user.")
-		(type STRING)
-;+		(value "false" "true")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot local_identifier_reference
-;+		(comment "The local_identifier_reference attribute provides the value of the local_identifier of the entity described by the referencing class. Note that a local_identifier attribute, with the same value as this local_identifier_reference, must be present within the label.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot expected_packets
-;+		(comment "The expected_packets attribute provides the total number of telemetry packets which constitute a complete data product, i.e., a data product without missing data.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot maximum_ring_longitude
-;+		(comment "maximum_ring_longitude specifies one boundary for the ring longitude range in the data; normally the largest value. However, for ranges that cross the prime meridian, the maximum ring longitude will have a value less than the minimum ring longitude. Values range from 0 to 360 in units of degrees. Required in label files for ring occultation data.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot y
-;+		(comment "The y attribute provides the value of the y coordinate in a position vector.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot x
-;+		(comment "The x attribute provides the value of the x coordinate in a position vector.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot z
-;+		(comment "The z attribute provides the value of the z coordinate in a position vector.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot source
-;+		(comment "The bibliographic_reference association is a relationship to bibliographic reference.")
-		(type INSTANCE)
-;+		(allowed-classes External_Reference_Extended)
-		(create-accessor read-write))
-	(multislot supported_operating_system_note
-;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot upper_110421_test_Slot_0
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot software_type
-;+		(comment "The software type attribute identifies the class of which the software is a member.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot external_standard_version_id
-;+		(comment "The external_standard_version_id attribute provides the version of the external standard.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot value_domain
-;+		(comment "Associated value domains.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot da_contact_pds_users_id
-;+		(comment "The da_contact slot indicates the person responsible for data administration.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot spacecraft_clock_start_count
-;+		(comment "The spacecraft_clock_start_count attribute provides the value of the spacecraft clock at the beginning of a time period of interest.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot collection_type
-;+		(comment "The collection_type attribute provides a classification for the collection.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot reference_longitude
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot source_pds3_id
-;+		(comment "source_pds3_id is the PDS3 product identifier for the source product. If the source product has been archived under PDS4, use the Internal_Reference class in the Investigation_Area. source_pds3_id is constructed as PDS3 dataset_id, a colon, then the PDS3 product_id. The acceptable nil_reasons are 'inapplicable' and 'unknown'.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot preference_id
-;+		(comment "The preference id provides a formal name used to refer to the prefered item.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot uniformly_sampled
-;+		(comment "The uniformly_sampled association is a relationship to Uniformly_Sampled.")
-		(type INSTANCE)
-;+		(allowed-classes Uniformly_Sampled)
-		(create-accessor read-write))
-	(multislot local_attribute_id
-;+		(comment "The local_attribute_id provides the identifier of an attribute and indicates membership in a class.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Field_LID
-;+		(comment "The has_Field_LID association is a relationship to an LID.")
+	(multislot other_data_object_set
+;+		(comment "Aggregation association for other data objects.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot sip_manifest_file_specification_name
-;+		(comment "Relative path name of the SIP manifest file in the SIP_Manifest directory. Formation Rule: --volume_id-- + “_SIP_Manifest”.")
+	(multislot axis_storage_order
+;+		(comment "The axis_storage_order attribute associates a name with each of the axis.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot file_specification_name
+;+		(comment "The file_specification_name attribute provides the file_name prepended by the directory_path to the file.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot stop_bit_location
+;+		(comment "The stop_bit_location attribute provides the position of the last bit in a bit field relative to the first bit in the parent packed data field. Bytes are sequential and bits are numbered continuously across byte boundaries within a single bit field. The first bit position in the packed data field is \"1\".")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot minimum_observed_ring_azimuth
-;+		(comment "minimum_observed_ring_azimuth specifes the smallest value for observed_ring_azimuth in the data file. Values range from 0 to 360 in units of degrees. Required in label files for ring occultation data.")
-		(type FLOAT)
+	(multislot record_type
+;+		(comment "The record type attribute classifies a record.")
+		(type STRING)
 		(create-accessor read-write))
-	(single-slot start_bit_location
-;+		(comment "The start_bit_location attribute provides the position of the first bit in a bit field relative to the first bit in the parent packed data field. Bytes are sequential and bits are numbered continuously across byte boundaries within a single bit field. The first bit position in the packed data field is \"1\".")
+	(single-slot annotation
+;+		(comment "The annotation attribute provides an explanatory note added to a text.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot time_series_direction
-;+		(comment "time_series_direction indicates the direction the occultation proceeds through the target within a particular data product. Possible values are 'ingress', 'egress', 'both' or 'multiple'. The value 'Multiple' is only used for some Hubble-based occultations where the occultation track is not monotonic over relatively short time scales. Not intended as a value for a table field.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot subtype
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot data_type
-;+		(comment "The data_type attribute provides the hardware representation used to store a value.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_document_file
-;+		(comment "The has_document_file association is a relationship to a document file.")
-		(type INSTANCE)
-;+		(allowed-classes Document_File)
-		(create-accessor read-write))
-	(single-slot telephone_number
-;+		(comment "The telephone_number attribute provides a telephone number in  international notation which complies with the ITU-T E.164 format recommendation.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot spice_filename
-;+		(comment "spice_filename gives the file name%28s%29 of SPICE files used in the analysis. Only used if the SPICE files cannot be identified using a LID or LIDVID. Otherwise the association is made in the Reference_Class using the Internal_Reference class. Optional in labels for radio occultation. Nillable in which case the nil_reason should be 'inapplicable'.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot group_number
-;+		(comment "The group_number attribute provides the position of a group, within a series of groups, counting from 1.  If two groups within a record are physically separated by one or more fields, they have consecutive group numbers; the intervening fields are numbered separately.  Groups within a parent group, but separated by one or more fields, will also have consecutive group numbers.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(single-slot row_bytes
-;+		(comment "The row bytes attribute provides the count of the bytes in a row.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot external_reference
-;+		(comment "The external_reference association is a relationship to External_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes External_Reference)
-		(create-accessor read-write))
-	(single-slot offset
-;+		(comment "The offset attribute provides the displacement of the object starting position from the beginning of the parent structure (file, record, etc.).  If there is no displacement, offset=0.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_Local_ID_Relation
-;+		(comment "The has_Local_ID_Relation association is a relationship to Local_ID_Relation.")
-		(type INSTANCE)
-;+		(allowed-classes Local_ID_Relation)
-		(create-accessor read-write))
-	(multislot local_mean_solar_time
-;+		(comment "The local_mean_solar_time attribute provides the hour angle of the fictitious mean Sun at a fixed point on a rotating solar system body.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot associated_with
-;+		(comment "The associated_with association is a relationship to contextual information.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot collected_by
-;+		(comment "The collected_by association is a relationship to instrument.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot external_property_map_id
-;+		(comment "The external_property_map_id attribute provides the identifier of a property_map instance external to this context.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot category
-;+		(comment "The category attribute identifies the type of function that the tool or service performs.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot reference_type
-;+		(comment "The reference_type attribute provides the name of the association.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot target_desc
-;+		(comment "The target_desc attribute describes the characteristics of a particular target.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot naif_target_id
-;+		(comment "The naif_target_id element provides the numeric ID used within the SPICE system to identify the target..")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot country
-;+		(comment "The country attribute provides the full  name of a country.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot axis_display
-;+		(comment "The has_Axis_Display association is a relationship to Axis_Display.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot container_type
-;+		(comment "The container type attribute indicates the method used to package the components.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot document_editions
-;+		(comment "The document_editions attribute provides a count of the total number of complete, distinct editions of the document.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot application_process_name
-;+		(comment "The application_process_name attribute provides the name associated with the source or process which created the data.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot refer_data_set_projection
-;+		(comment "Associated Data Set Projection.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot observing_system_component_type
-;+		(comment "The observing_system_component_type attribute provides the function or role of the component in the observing system.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot subscriber
-;+		(comment "The subscriber association is a relationship to a Subscriber_PDS3 class.")
-		(type INSTANCE)
-;+		(allowed-classes Subscriber_PDS3)
-		(create-accessor read-write))
-	(multislot manifest_reference
-;+		(comment "The manifest reference attribute provides a reference to a manifest product.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot volume_version_id
-;+		(comment "The volume_version_id attribute identifies the version of a data volume. All original volumes should use a volume_version_id of 'Version 1'.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot minimum_ring_longitude
-;+		(comment "minimum_ring_longitude specifes one boundary for the ring longitude range in the data; normally the smallest value. However, for ranges that cross the prime meridian, the minimum ring longitude will have a value greater than the maximum ring longitude. Values range from 0 to 360 in units of degrees. Required in label files for ring occultation data.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot stop_date
-;+		(comment "The stop_date attribute provides the date when an activity ended.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot upper_111205b_Class0
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot group_length
-;+		(comment "The group_length attribute provides the total length, in bytes, of a repeating field and/or group structure. It is the number of bytes in the repeating fields/groups plus any embedded unused bytes that are also repeated multiplied by the number of repetitions.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot campaign_objectives_summary
-;+		(comment "The campaign objectives summary attribute provides a comprehensive and brief abstract of a campaigns objectives.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot maximum_wavelength
-;+		(comment "maximum_wavelength is the largest wavelength used in the observation. Optional in labels. Used with minimum_wavelength when the observation is over a wavelength range.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot blue_channel_band
-;+		(comment "The blue_channel_band attribute identifies the number of the band, along the band axis, that should be loaded, by default, into the blue channel of a display device. The first band along the band axis has band number 1.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot investigation_name
-;+		(comment "The investigation_name attribute provides a unique name for an investigation.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot id_reference_type
-;+		(comment "The id_reference_type attribute provides the name of an association between two objects.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot packet_map_mask
-;+		(comment "The packet_map_mask attribute is a binary or hexadecimal number identifying which of a data file's expected packets were actually received.  The digits correspond positionally with the relative packet numbers of the data file.  The bits are to be read left to right; i.e., the first %28left-most%29 digit of the number corresponds to the first packet of the data file.  A bit value of 1 indicates that the packet was received; a value of 0 indicates that it was not received.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_Axis_Array
-;+		(comment "The has_Axis_Array association is a relationship to Axis_Array.")
-		(type INSTANCE)
-;+		(allowed-classes Axis_Array)
-		(create-accessor read-write))
-	(multislot has_Field_File_Specification_Name
-;+		(comment "The has_Field_File_Specification_Name association is a relationship to Field_File_Specification_Name.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot service_type
-;+		(comment "The service type attribute identifies the class of system function provided.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot id_reference_to
-;+		(comment "The id_reference_to provides the identifier of the ending object in a one  directional relationship.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot azimuth_measure_point_longitude
-;+		(comment "The azimuth_measure_point_longitude attribute provides the longitude of the map projection origin.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot observing_system_name
-;+		(comment "The observing_system_name attribute provides a unique name for an observing system.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot internal_reference
-;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Internal_Reference)
-		(create-accessor read-write))
-	(multislot acted_on_behalf_of
-;+		(comment "The acted_on_behalf_of association is a recursive relationship on agent.")
-		(type INSTANCE)
-;+		(allowed-classes Agent)
-		(create-accessor read-write))
-	(single-slot manifest_checksum
-;+		(comment "The manifest checksum provides the checksum for the manifest file.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot earth_received_stop_date_time
-;+		(comment "The earth_received_stop_date_time attribute provides the latest time at which any component telemetry data for a particular product was received.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot planar_coordinate_encoding_method
-;+		(comment "The planar_coordinate_encoding_method attribute indicates the means used to represent horizontal positions.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot discipline_name
-;+		(comment "The discipline_name attribute describes the observing discipline (as opposed to a PDS Discipline Node Name, though the concepts and values are similar). Some of these values are, with respect to the PDS Nodes, inter-disciplinary and should be used when they are applicable in perference to the more restrictive values.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot external_namespace_id
-;+		(comment "The external_namespace_id attribute provides a namespace_id external to this context.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot directory_delimiter
-;+		(comment "The directory delimiter is a character that separates a directory name from another directory name or from a file name.")
-		(type STRING)
-		(default "<slash>")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot default_blue
-;+		(comment "The default_blue attribute provides the number of the plane along the axis that is to be loaded, by default, into the blue plane of a display device.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(single-slot label_revision_note
-;+		(comment "The label revision note attribute provides a history of changes to the label.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot refer_data_supplier
+	(single-slot volume_series_name
 ;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot file_area
+;+		(comment "The file_area association is a relationship to File Area")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot has_manifest
-;+		(comment "The has_manifest association is a relationship to a manifest.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot component
-		(type STRING)
-		(default "IM" "DD")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_tracking_detail
-;+		(comment "The has_tracking_detail association is a relationship to tracking_detail.")
-		(type INSTANCE)
-;+		(allowed-classes Tracking_Detail)
-		(create-accessor read-write))
-	(multislot data_set_name
-;+		(comment "The data_set_name attribute provides the full name given to a data set or a data product. The data_set_name typically identifies the instrument that acquired the data of that instrument Example value data_set_id. Note This attribute is defined in the AMMOS Magellan catalog as an alias for file_name to provide backward compatibility")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot classTitle
-;+		(comment "The classTitle attribute provides the name of the class to be used for display.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot attribute_data_type
-;+		(comment "The attribute_data_type attribute provides the  data type used to represent the value.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot coordinate_system_name
-;+		(comment "This attribute is used in the image map projection. Under review. xxx E. RYE;DS xxx")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot funding_award
-;+		(comment "The funding_award attribute provides a unique alphanumeric identifier of the funding award within the funding_source.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot reference_latitude
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot model_id
-;+		(comment "The model_id attribute helps discriminate instrument hardware. For example \"flight\", \"engineering\", or \"proto\" have been used.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot value_data_type
-;+		(comment "The value_data_type attribute is used in a data dictionary to specify the data type of an attribute's value.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot has_primary_result_description
-;+		(comment "The has_primary_result_description association is a relationship to Primary_Result_Description.")
-		(type INSTANCE)
-;+		(allowed-classes Primary_Result_Summary)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot investigation_reference
-;+		(comment "The investigation reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object..")
-		(type STRING)
-		(default "logical_identifier")
-		(create-accessor read-write))
-	(multislot has_Polar_Stereographic
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot reference_key_id
-;+		(comment "The reference_key_id attribute provides the catalog with an identifier for a reference document.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot associated_optional_description
-;+		(comment "The associated_optional_description association is a relationship to optional descriptions.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot invalid_constant
-;+		(comment "The invalid_constant attribute provides a value that indicates the original value was outside the valid range for the parameter.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_Spatial_Reference_Information
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot volume_id
-;+		(comment "The volume_id attribute provides a unique identifier for a data volume. Example: MG_1001.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot first_sampling_parameter_value
-;+		(comment "The first_sampling_parameter_value element provides the first value in an ascending series and is therefore the minimum value at which a given data item was sampled.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot space
-;+		(comment "space = \" \" (* space *) ; The character space is required to be bound to the “space” member of ISO/IEC 10646, but it only has meaning within character-literals and string-literals.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot system_requirements_note
-;+		(comment "The system requirements note attribute identifies what is necessary to process the software.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot utm_zone_number
-;+		(comment "The utm_zone_number attribute provides the identifier for the UTM zone.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot submitter_name
-;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot ups_zone_identifier
-;+		(comment "The ups_zone_identifier attribute provides an identifier for the UPS zone.")
-		(type STRING)
-;+		(value "A" "B" "Y" "Z")
-		(create-accessor read-write))
-	(multislot rule_statement
-;+		(comment "The rule_statement association is a relationship to DD_Rule_Statement")
-		(type INSTANCE)
-;+		(allowed-classes DD_Rule_Statement)
-		(create-accessor read-write))
-	(single-slot sample_projection_offset
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot electronic_mail_id
-;+		(comment "The eletronic mail id provides a formal name used to refer to an electronic mail address.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot maximum_value_exclusive_flag
-;+		(comment "The maximum_value_exclusive_flag attribute indicates that the  maximum_value is exclusive, when true.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot time_display_axis
-;+		(comment "The time_display_axis attribute identifies, by name, the axis of an Array %28or Array subclass%29, the bands of which are intended to be displayed sequentially in time on a display device. The frame_rate attribute, if present, provides the rate at which these bands are to be displayed.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot data_set_id
-;+		(comment "The data set id provides a formal name used to refer to a data set.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_composite_structure
-;+		(comment "The has_Composite_Structure association is a relationship to Composite_Structure.")
-		(type INSTANCE)
-;+		(allowed-classes Composite_Structure)
-		(create-accessor read-write))
-	(multislot field_number
-;+		(comment "The field_number attribute provides the position of a field, within a series of fields, counting from 1. If two fields within a record are physically separated by one or more groups, they have consecutive field numbers; the fields within the intervening group(s) are numbered separately.  Fields within a group separated by one or more (sub)groups, will also have consecutive field numbers.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(single-slot was_associated_with
-		(type INSTANCE)
-;+		(allowed-classes Agent)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot virtual_relation
-;+		(comment "The virtual_relation association is a relationship to Virtual_Relation.")
-		(type INSTANCE)
-;+		(allowed-classes Virtual_Relation)
-		(create-accessor read-write))
-	(multislot geometry_reference
-;+		(comment "The geometry reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier::version_id")
-		(create-accessor read-write))
-	(single-slot longitude_resolution
-;+		(comment "The longitude_resolution attribute indicates the minimum difference between two adjacent longitude values expressed in angular units of measure.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot postal_address_text
-;+		(comment "The postal address text attribute provides a mailing address.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot identifier_reference
-;+		(comment "The identifier_reference attribute provides the value of an identifier.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot bound_character
-;+		(comment "bound-character = non-quote-character  |  quote ; The bound-characters, and the escape character, are required in any implementation to be associated with particular members of the implementation character set. - A bound-character is required to be associated with the member having the corresponding symbol, if any, in any implementation character-set derived from ISO/IEC 10646.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot compile_note
-;+		(comment "The compile note attribute provides a brief statement giving particulars about the compilation of the software source.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot directory_name_token
-;+		(comment "The directory name token is a substring that names a directory. The maximum size of a directory name is thirty characters.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot local_attribute_extended
-;+		(comment "The local_attribute_extended association is a relationship to Local_Attribute_Extended.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot maximum_ring_radius
-;+		(comment "maximum_ring_radius indicates the largest ring radius value in the data table. Units are km and are always positive. Required in label files for ring occultation data.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot error_constant
-;+		(comment "The error_constant attribute provides a value that indicates the original value was in error.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot encoding_type
-;+		(comment "The encoding_type attribute provides the storage format (binary or character).")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot full_name
-;+		(comment "The full_name attribute provides the complete name for a person and includes titles and suffixes.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot distribution_type
-;+		(comment "This attribute is used in by the data set release class. It is under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot record_delimiter
-;+		(comment "The record_delimiter attribute provides the character or characters used to indicate the end of a record.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot grating_position
-;+		(comment "The grating_position attribute of a spectral qube describes the grating position which corresponds to the band. Grating positions are usually assigned consecutively from 0, and increasing position causes increasing wavelength for each detector.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot assertType
-		(type STRING)
-		(create-accessor read-write))
-	(multislot earth_received_stop_time_utc
-;+		(comment "earth_received_stop_time_utc gives the UTC time corresponding to the latest time for the data product at which telemetry or other photons were received on Earth. Optional for occultation data.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot orbit_direction
-;+		(comment "The orbit_direction element provides the direction of movement along the orbit about the primary as seen from the north pole of the 'invariable plane of the solar system', which is the plane passing through the center of mass of the solar system and perpendicular to the angular momentum vector of the solar system orbit motion. PROGRADE for positive rotation according to the right-hand rule, RETROGRADE for negative rotation.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot isMissionOnly
-;+		(comment "The isMissionOnly attribute indicates whether a rule is for mission level dictionaries only.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot data_set_terse_desc
-;+		(comment "A one line description of the data set")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot last_sampling_parameter_value
-;+		(comment "The last_sampling_parameter_value element provides the last value in an ascending series and is therefore the maximum value at which a given data item was sampled.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot edition_name
-;+		(comment "The edition name attribute provides a name by which the edition is known.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot sipid
-;+		(comment "SIP Identifier - Producer Archive Project ID (PAPID) in conjunction with a unique integer. PAPID is assigned by the NSSDC.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot received_packets
-;+		(comment "The received_packets attribute provides the total number of telemetry packets which constitute a reconstructed data product, cf. expected_packets.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot center_longitude
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot earth_received_start_date_time
-;+		(comment "The earth_received_start_date_time attribute provides the earliest time at which any component telemetry data for a particular product was received.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot publication_reference
-;+		(comment "The publication reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier")
-		(create-accessor read-write))
-	(multislot document_reference
-;+		(comment "The document reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot maximum_record_length
-;+		(comment "The maximum_record_length attribute provides the upper, inclusive bound on the length of a record, including any record delimiter.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot bit_mask
-;+		(comment "The bit mask attribute is a series of ASCII binary digits identifying the active bits in a value; it has exactly the same number of bits as the array element to which it is applied. The bit mask must be specified from most significant to least significant bit (left to right).")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot property_value
-;+		(comment "The property value attribute provides the value assigned to a property.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot upper_120106b_Class1
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot attrTitle
-;+		(comment "The attrTitle attribute provides the name of the attribute to be used for display.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot alias
-;+		(comment "The alias association is a relationship to Alias, an alternate name and identification.")
-		(type INSTANCE)
-;+		(allowed-classes Alias)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(multislot author_list
-;+		(comment "The author_list attribute contains a semi-colon-separated list of names of people to be cited as authors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final author. All authors should be listed explicitly - do not elide the list using \"et al.\".")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot ring_event_stop_time_utc
-;+		(comment "ring_event_stop_time_utc gives the UTC time corresponding to the latest time given by ring_event_time or ring_event_tdb in the data table. ring_event_stop_time_utc is required for all ring occultation data. ring_event_stop_time_utc is required label attribute for all ring occultation data.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot byte_order
-;+		(comment "The byte order attribute indicates whether the most siginificant or the least significant byte is placed first in the sequence of bytes that comprise an element.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot type
-;+		(comment "The type attribute provides a classification for the resource.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot creation_date_time
-;+		(comment "The creation_date_time attribute provides a date and time when the object was created.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot radial_resolution
-;+		(comment "radial_resolution indicates the nominal radial distance over which changes in ring properties can be detected within a data product. Note: this value may be larger than the radial_sampling_interval value, because a data product can be over-sampled. Required in labels if the value is fixed, as it is for stellar occultations. If the value varies, the corresponding minimum and maximum attributes must be used instead. Not intended to be used as a table field.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot local_true_solar_time
-;+		(comment "The local_true_solar_time (LTST) attribute provides the local time on a rotating solar system body where LTST is 12 h at the sub-solar point (SSP) and increases 1 h for each 15 degree increase in east longitude away from the SSP for prograde rotation.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot observing_system_component
-;+		(comment "The observing_system_component association is a relationship to Observing_System_Component.")
-		(type INSTANCE)
-;+		(allowed-classes Observing_System_Component)
-		(create-accessor read-write))
-	(multislot instrument_host_reference
-;+		(comment "The instrument host  reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier")
-		(create-accessor read-write))
-	(multislot has_Table_Character_Grouped
-;+		(comment "The has_Table_Character_Grouped association is a relationship to grouped sequence of fields.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot bits
-;+		(comment "The bits attribute provides the number of bits in the object.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot external_property_maps_id
-;+		(comment "The external_property_maps_id attribute provides the identifier of a property_maps instance external to this context.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot alias_list
-;+		(comment "The alias_list association is a relationship to Alias_List, a list of alternate names and identifications.")
-		(type INSTANCE)
-;+		(allowed-classes Alias_List)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot release_id
-;+		(comment "This attribute is used in by the data set release class. It is under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot valid_minimum
-;+		(comment "The valid_minimum attribute specifies the minimum valid value in the field or digital object with which the Special_Constants class is associated. Values below the valid_minimum have a special meaning. Values of this attribute should be represented in the same data_type as the elements in the object or field described.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Local_ID_Reference
-;+		(comment "The has_Local_ID_Reference association is a relationship to has_Local_ID_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Local_ID_Reference)
-		(create-accessor read-write))
-	(multislot funding_acknowledgement_text
-;+		(comment "The funding_acknowledgement_text attribute provides a text description of the relationship between the funding source and the archival data.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot document_collection_reference
-;+		(comment "The document collection reference attribute provides the logical_identifier for a document collection.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot external_source_product_identifier
-;+		(comment "The external_source_product_identifier provides unique identifiers for one or more source products that are not in the PDS4 Registry. For guidelines on the construction of this identifier, refer to section E.2.6.1.2 of the Data Provider's Handbook.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot node_puid
-;+		(comment "The node_puid attribute provides a globally unique identifer for a node.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot browse_collection_reference
-;+		(comment "The browse collection reference attribute provides the logical_identifier for a browse collection.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot rule_test
-;+		(comment "The rule_test attribute provides the body of the statement to be executed by the schematron processor.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_one_choice
-;+		(comment "The has_one_choice association is a relationship to a class contains a list of attributes from which a choice of one is made.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot lid_reference_from
-;+		(comment "The lid_reference_from provides the identifier of the starting object in a one  directional relationship.")
-		(type INSTANCE)
-;+		(allowed-classes LID_ID_Reference_From)
-		(create-accessor read-write))
-	(multislot revision_id
-;+		(comment "The revision_id attribute provides the revision level of a document, which may be set outside PDS and may be different from its version_id.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Table_Field
-;+		(comment "The has_Table_Field association is a relationship to the field types.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot field_location
-;+		(comment "The field_location attribute provides the starting byte for a field within a record or group, counting from '1'.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_Display_2d_Image
-;+		(comment "The has_Display_2d_Image association is a relationship to Display_2d_Image.")
-		(type INSTANCE)
-;+		(allowed-classes Display_2D_Image)
-		(create-accessor read-write))
-	(multislot processing_level_id
-;+		(comment "The processing_level_id attribute provides a broad indication of data processing level.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot sample_bit_mask
-;+		(comment "The sample_bit_mask attribute identifies the active bits in a sample. Note:  In the PDS, the domain of sample_bit_mask is dependent upon the currently-described value in the sample_bits attribute and only applies to integer values. For an 8-bit sample where all bits are active the sample_bit_mask would be 2#11111111#.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot north_bounding_coordinate
-;+		(comment "The north_bounding_coordinate attribute provides the northern-most coordinate of the limit of coverage expressed in latitude.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot dictionary_type
-;+		(comment "The dictionary_type attribute provides the name of a dictionary category.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Character_Field_Grouped
-;+		(comment "The has_Table_Field_Grouped association is a relationship to the field types for a group.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot aperture
-;+		(comment "The aperture attribute provides a measure of the effective collecting area of the telescope -- its diameter (if single and circular) or its equivalent diameter (if non-circular and/or an array).  For purposes of this definition, aperture efficiency is assumed to be 100 percent.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot property_map_id
-;+		(comment "The identifier attribute provides the formal name used to refer to a property map.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot local_static_permissible_value
-		(type INSTANCE)
-;+		(allowed-classes DD_Static_Permissible_Value)
-		(create-accessor read-write))
-	(multislot xpath
-		(type STRING)
-		(create-accessor read-write))
-	(multislot mission_phase_name
-;+		(comment "The mission_phase_name attribute provides the commonly recognized name for a mission phase.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot unit_id
-;+		(comment "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot member_entry
-;+		(comment "The member_entry association is a relationship to Member_Entry.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot has_rings_supplement
-;+		(comment "The has_rings_supplement association is a relationship to rings_supplement")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot has_tagged_data_object
-;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot choice_flag
-;+		(comment "The choice flag attribute indicates that the class is being used to group either classes or attributes to allow a choice. Choice flag is only included if the value 'true' is desired.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot reference_frame_id
-;+		(comment "The reference frame id attribute identifies a reference frame, an origin and set of axes, the physical realization of a reference system, i.e., the reference frame orientation and axes are established by the reported coordinates of datum points in the reference system.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot data_reference
-;+		(comment "The data reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier::version_id")
-		(create-accessor read-write))
-	(single-slot skos_relation_name
-;+		(comment "The attribute skos_relation_name provides a meaning of the relationship between two associated terms.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot pixel_resolution_y
-;+		(comment " The pixel_resolution_x and pixel_resolution_y attributes indicate the image array pixel resolution %28distance%2Fpixel or degree%2Fpixel%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y resolution values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where resolution may differ for each axis %28%47rectangular%47 pixels%29. NOTE: Definition of this PDS4 attribute differs from how %47resolution%47 was defined within PDS3. ")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot ring_event_stop_tdb
-;+		(comment "ring_event_stop_tdb indicates the value for latest time in the described data, and is given in ring_event_tdb format. Optional in labels; not intended for use as a table field.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot reference_entry
-;+		(comment "The reference_entry association is a relationship to Reference_Entry.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot pixel_resolution_x
-;+		(comment " The pixel_resolution_x and pixel_resolution_y attributes indicate the image array pixel resolution %28distance%2Fpixel or degree%2Fpixel%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y resolution values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where resolution may differ for each axis %28%47rectangular%47 pixels%29. NOTE: Definition of this PDS4 attribute differs from how %47resolution%47 was defined within PDS3. ")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot field_format
-;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot interface_type
-;+		(comment "The interface type attribute identifies the class of interconnection provided.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot volume_de_fullname
-;+		(comment "The volume_de_fullname attribute provide the full name of the data engineer.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot local_association_class
-;+		(comment "The local_association_class association provides a relationship to a class.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Association)
-		(create-accessor read-write))
-	(single-slot product_creation_time
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot latitude_resolution
-;+		(comment "The latitude_resolution attribute indicates the minimum difference between two adjacent latitude values expressed in angular units of measure.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot repetitions
-;+		(comment "The repetitions attribute provides the number of occurrences.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot instrument_host_version_id
-;+		(comment "The instrument_host_version_id attribute provides the version of the instrument host.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot operations_contact_puid
-;+		(comment "The operations_contact indicates the node person responsible for node operations.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Geodetic_Model
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot cs_local_identifier_reference
-;+		(comment "The cs_local_identifier_reference attribute is used to reference one component of a composite structure.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot high_representation_saturation
-;+		(comment "The high_representative_saturation attribute specifies a special value whose presence indicates the true value cannot be represented in the chosen data type and length -- in this case being above the allowable range -- which may happen during conversion from another data type. The value must be less than the value of the valid_minimum attribute or more than the value of the valid_maximum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot encoding_standard_id
-;+		(comment "The encoding_standard_id attribute provides the formal name of a standard used for the structure of an Encoded Byte Stream digital object.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot url
-;+		(comment "The url attribute provides a Uniform Resource Identifier (URI) that specifies where a resource is available and the mechanism for retrieving it.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot phone_book_flag
-;+		(comment "The phone_book_flag attribute indicates whether or not this person should be included in the phone book.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot member_in_group
-;+		(comment "Associated Personnel")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot ring_event_start_tdb
-;+		(comment "ring_event_start_tdb indicates the value for earliest time in the described data, and is given in ring_event_tdb format. Optional in labels; not intended for use as a table field.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot data_format
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot medium_type
-;+		(comment "The medium_type attribute identifies the physical storage medium for a data volume. Examples: CD-ROM, CARTRIDGE TAPE.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot data_set_release_date
-;+		(comment "The data_set_release_date attribute provides the date when a data set is released by the data producer for archive or publication. In many systems this represents the end of a proprietary or validation period. Formation rule In AMMOS identify the date at which a product may be released to the general public from proprietary access. AMMOS-related systems should apply this attribute only to proprietary data.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot associated_Electronic_Mail
-;+		(comment "The associated_Electronic_Mail association is a relationship to Electronic Mail.")
+	(multislot has_Band_Bin_Set
+;+		(comment "The has_Band_Bin_Set association is a relationship to Band_Bin_Set.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
@@ -1388,65 +72,606 @@
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Deleted_Grouped_Sequence
-;+		(comment "The has_Deleted_Grouped_Sequence association is a relationship to field sequence.")
+	(multislot schematronAssignPattern
+;+		(comment "The schematronAssignPattern attribute provides values for schemtron rule assignments at the pattern level.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot value_domain_entry
+;+		(comment "The value_domain_entry association is a relationship to Value_Domain.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot virtual_reference_type
-;+		(comment "The virtual_reference_type attribute provides the name of an association between two objects.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot entity_type
-;+		(comment "The entity_type attribute provides a classification for the entity.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot minimum
-;+		(comment "The minimum attribute provides the largest stored value which actually appears; empty and Special_Constant values are excluded.")
-		(type FLOAT)
+	(single-slot axis_index
+;+		(comment "The axis index attribute provides the index of the axis in an ordered set. The index of the first axis has a value of 1.")
+		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot bundle_type
-;+		(comment "The bundle_type attribute provides a classification for the bundle.")
+	(single-slot data_format
 		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot saturated_constant
-;+		(comment "The saturated_constant attribute provides a value that indicates the original value was invalid because of sensor saturation.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot instrument_id
-;+		(comment "The instrument id provides a formal name used to refer to an instrument.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot program_notes_id
-;+		(comment "The program notes id attribute provides an identifier to a brief statement giving particulars about a software program.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot associated_object_local_id
-;+		(comment "The associated_object_local_id associates another object using its local identifier.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot upper_120227b_Class2
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot checksum_manifest_checksum
-;+		(comment "The checksum manifest checksum provides the checksum for the checksum manifest file.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot loop_delay
-;+		(comment "The loop_delay attribute specifies the amount of time to pause between 'loops' or repeated playbacks of a movie.")
-		(type FLOAT)
-;+		(cardinality 0 1)
+	(single-slot has_File
+;+		(comment "The has_File association is a relationship to File.")
+		(type INSTANCE)
+;+		(allowed-classes File)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot modification_detail
 ;+		(comment "The modification_detail association is a relationship to Modification_Detail, the details of one round of modification for the product.")
 		(type INSTANCE)
 ;+		(allowed-classes Modification_Detail)
 		(create-accessor read-write))
-	(single-slot attribute_concept
-;+		(comment "The attribute_concept attribute provides the type of information (classification) conveyed by the attribute -- e.g., stop_date_time has  attribute_concept = date_time.")
+	(multislot id_reference
+;+		(comment "The id_reference provides the identifier of an object in a one  directional relationship.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot white_space
+;+		(comment "A sequence of one or more space characters, horizontal tabs, end of line characters, or newline characters except within a character-literal or string-literal (see 7.3), shall be considered whitespace. Any use of this International Standard may define any other characters or sequences of characters not in the above character set to be whitespace as well, such as vertical tabulators, end of page indicators, etc.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot uniformly_sampled
+;+		(comment "The uniformly_sampled association is a relationship to Uniformly_Sampled.")
+		(type INSTANCE)
+;+		(allowed-classes Uniformly_Sampled)
+		(create-accessor read-write))
+	(single-slot sample_projection_offset
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot document_puid
+;+		(comment "The document_puid attribute provides a globally unique identifer for a document.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot note
+;+		(comment "The note attribute provides an explanatory or critical comment.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot local_planar_description
+;+		(comment "The local_planar_description attribute provides a description of the local planar system.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot refer_file
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot local_class
+;+		(comment "The local_class association is a relationship to Local_Class.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot has_occultation_time_series
+;+		(comment "The has_occultation_time_series association is a relationship to occultation_time_series")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot value_begin_date
+;+		(comment "The value_begin_date attribute provides the first date on which the permissible value is in effect.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot creation_date_time
+;+		(comment "The creation_date_time attribute provides a date and time when the object was created.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot band_number
+;+		(comment "The band_number attribute provides a number corresponding to the band in the spectral qube. The band number is equivalent to the instrument band number.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Table_Character_Grouped
+;+		(comment "The has_Table_Character_Grouped association is a relationship to grouped sequence of fields.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot instrument_host_logical_identifier
+;+		(comment "The instrument host logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot default_red
+;+		(comment "The default_red attribute provides the number of the plane along the axis that is to be loaded, by default, into the red plane of a display device.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot has_one_choice
+;+		(comment "The has_one_choice association is a relationship to a class contains a list of attributes from which a choice of one is made.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot has_Geodetic_Model
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot has_property_map_external
+;+		(comment "The has_property_map_external association is a relationship to Property_Map_External")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot observed_event_stop_tdb
+;+		(comment "observed_event_stop_tdb indicates the value for latest time in the described data, and is given in elapsed seconds since the J2000 epoch. Optional in labels; not intended for use as a table field.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot ring_profile_direction
+;+		(comment "ring_profile_direction indicates the radial direction of a ring occultation within a particular data product. Possible values are 'Ingress', 'Egress', or 'Multiple'. The value 'Multiple' is only used for some Hubble-based occultations where the occultation track is not monotonic over relatively short time scales. Required in labels of ring occultation observations. Not intended as a value for a table field.")
+		(type STRING)
+;+		(value "Egress" "Ingress" "Multiple")
+		(create-accessor read-write))
+	(multislot collected_from
+;+		(comment "The collected_from association is a relationship to target.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot encoding_type
+;+		(comment "The encoding_type attribute provides the storage format (binary or character).")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot aperture
+;+		(comment "The aperture attribute provides a measure of the effective collecting area of the telescope -- its diameter (if single and circular) or its equivalent diameter (if non-circular and/or an array).  For purposes of this definition, aperture efficiency is assumed to be 100 percent.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot has_State_Plane_Coordinate_System
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot instrument_name
+;+		(comment "The instrument_name attribute provides a unique name for an instrument.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot maximum_record_length
+;+		(comment "The maximum_record_length attribute provides the upper, inclusive bound on the length of a record, including any record delimiter.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot type_list
+;+		(comment "The type_list attribute classifies the instrument according to its function. The values in this list are comma separated.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot processing_level
+;+		(comment "The processing_level attribute provides a broad classification of data processing level.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot telemetry_provider_id
+;+		(comment "The telemetry_provider_id attribute identifies the provider and or version of the telemetry data used in the generation of this data.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot naif_host_id
+;+		(comment "The naif_host_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot telephone_number
+;+		(comment "The telephone_number attribute provides a telephone number in  international notation which complies with the ITU-T E.164 format recommendation.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot sample_last_pixel
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot attribute_relative_xpath
+;+		(comment "The attribute_relative_xpath attribute provides a location path for an attribute within a tree representation of an XML document. The location path includes the attribute name.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot low_representation_saturation
+;+		(comment "The low_representative_saturation attribute specifies a special value whose presence indicates the true value cannot be represented in the chosen data type and length -- in this case being below the allowable range -- which may happen during conversion from another data type. The value must be less than the value of the valid_minimum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot DD_Rule_Let
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot bundle_type
+;+		(comment "The bundle_type attribute provides a classification for the bundle.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot upper_101016_Slot_0
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot reference_longitude
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot dd_attribute_reference
+;+		(comment "The dd_attribute_reference association is a relationship to DD_Attribute_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes DD_Attribute_Reference)
+		(create-accessor read-write))
+	(multislot telescope_latitude
+;+		(comment "The telescope_latitude attribute provides the angular distance of the telescope north (positive) from the equator, measured on the meridian of the telescope.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot parsing_standard_id
+;+		(comment "The parsing_standard_id attribute provides the formal name of a standard used for the structure of a Parsable Byte Stream digital object.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot upper_120214_Class0
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot targetclass_name
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot preference_id
+;+		(comment "The preference id provides a formal name used to refer to the prefered item.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_rings_supplement
+;+		(comment "The has_rings_supplement association is a relationship to rings_supplement")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot character_constraint
+;+		(comment "The character_constraint attribute limits the characters allowed.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot value_domain
+;+		(comment "Associated value domains.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot kernel_type
+;+		(comment "The kernel_type attribute identifies the type of SPICE kernel.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot type_list_identifer
+;+		(comment "The type_list_identifier attribute identifies the list from which the values in the type_list were selected.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot starting_point_identifier
+;+		(comment "The starting_point attribute provides the local_identifier of the object to be accessed first.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot sub_stellar_clock_angle
+;+		(comment "sub_stellar_clock_angle is an angle measured at a point in the ring plane, from the direction toward a star to the local radial direction. This angle is projected into the ring plane and measured in the clockwise %28retrograde%29 direction. Equivalently, this is the prograde angle from the local radial direction to the direction toward the star. For stellar occultation data, this angle is equal to %28180 - OBSERVED_RING_AZIMUTH%29 mod 360. It is available only for backward compatibility with previously published Cassini VIMS occultation data analysis; observed_ring_azimuth is the preferred quantity for archiving. sub_stellar_clock_angle is an optional data table field for Cassini VIMS occultation data; not recommended for other occultation data. In a label, the min and max variation attributes are optional for Cassini VIMS occultation data; not recommended for other occultation data. ")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot has_Field_Checksum
+;+		(comment "The has_Field_Checksum association is a relationship to Table_Field_Checksum.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot file_size
+;+		(comment "The file_size attribute provides the size of the file.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot observed_event_stop_time_utc
+;+		(comment "observed_event_stop_time_utc indicates the UTC value for latest time in the described data. It is part of a start/stop pair. If one of observed_event_start_time_utc and observed_event_stop_time_utc is used, both must be used.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot minimum_latitude
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot investigation_reference
+;+		(comment "The investigation reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object..")
+		(type STRING)
+		(default "logical_identifier")
+		(create-accessor read-write))
+	(multislot refer_data_supplier
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot data_type
+;+		(comment "The data_type attribute provides the hardware representation used to store a value.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot is_enumerated_flag
+;+		(comment "The is_enumerated_flag attribute indicates whether an attribute has an enumerated set of permissible values.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot editor_list
+;+		(comment "The editor_list attribute contains a semi-colon-separated list of names of people to be cited as editors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final editor. All editors should be listed explicitly - do not elide the list using \"et al.\".")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot field_description
+;+		(comment "The field description attribute provides a statement, picture in words, or account that describes a field.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot has_data_folder
+;+		(comment "The has_data_folder association is a relationship to data folder.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_delimited_record
+;+		(comment "The has_delimited_record association is a relationship to record.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot map_projection_name
+;+		(comment "The map_projection_name attribute provides the name of the map projection.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot created_by
+;+		(comment "The created_by slot provides the names of the people who create the data set.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(cardinality 1 10)
+		(create-accessor read-write))
+	(multislot has_Table_Character_Field_Sequence
+;+		(comment "The has_Table_Character_Field_Sequence association is a relationship to field sequence.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot has_Spatial_Domain
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot application_process_name
+;+		(comment "The application_process_name attribute provides the name associated with the source or process which created the data.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot sampling_parameter_unit
+;+		(comment "The sampling_parameter_unit element specifies the unit of measure of associated data sampling parameters.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot data_collection_reference
+;+		(comment "The data collection reference attribute provides the logical_identifier for a data collection.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot preferred_flag
+;+		(comment "The preferred_flag indicates whether this entry is  preferred over all other entries.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot instrument_logical_identifier
+;+		(comment "The instrument logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot refer_directory
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot x
+;+		(comment "The x attribute provides the value of the x coordinate in a position vector.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot mission_puid
+;+		(comment "The mission_puid attribute provides a globally unique identifer for a mission.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot y
+;+		(comment "The y attribute provides the value of the y coordinate in a position vector.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot z
+;+		(comment "The z attribute provides the value of the z coordinate in a position vector.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot external_property_maps_id
+;+		(comment "The external_property_maps_id attribute provides the identifier of a property_maps instance external to this context.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot special
+;+		(comment "special = \"(\" | (* left parenthesis *) \")\" | (* right parenthesis *) \".\" | (* full stop *) \",\" | (* comma *) \":\" | (* colon *) \";\" | (* semicolon *) \"=\" | (* equals sign *) \"/\" | (* solidus *) \"*\" | (* asterisk *) \"-\" | (* hyphen-minus *) \"{\" | (* left curly bracket *) \"}\" | (* right curly bracket *) \"[\" | (* left square bracket *) \"]\" ; (* right square bracket *)")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot spice_file_name
+;+		(comment "The spice_file_name attribute provides the names of the SPICE files used in processing the data.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_Field_Bit
+;+		(comment "The has_Field_Bit association is a relationship to Field_Bits.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot has_Member
+;+		(comment "The has_Member association is a relationship to members of a collection.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot latitude_type
+;+		(comment " The latitude_type attribute defines the type of latitude %28planetographic, planetocentric%29 used within a cartographic product and as reflected in attribute values within associated PDS labels. The IAU definition for direction of positive longitude should be adopted: http:%2F%2Fastrogeology.usgs.gov%2Fgroups%2FIAU-WGCCRE. ")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot primary_collection_reference
+;+		(comment "The primary collection reference provides a logical_identifier for  the primary collection this product is a member of.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot campaign_start_date
+;+		(comment "The campaign start date attribute provides the date when a campaign began.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot map_projection_rotation
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot file_local_identifier
+;+		(comment "The file local identifier attribute provides a formal name used to refer to a file description within the label. A file local identifier is unique within a label.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot attrTitle
+;+		(comment "The attrTitle attribute provides the name of the attribute to be used for display.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot unit_of_measure_type
+;+		(comment "The unit_of_measure_type attribute identifies the class from which the attribute being defined in this data dictionary draws its possible expressions for units.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot funding_award
+;+		(comment "The funding_award attribute provides a unique alphanumeric identifier of the funding award within the funding_source.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot copied_to
+;+		(comment "Associated physical volumes.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot upper_120227b_Class2
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot maximum_occurrences
+;+		(comment "The maximum occurrences attribute indicates the number of times something may occur. It is also called the maximum cardinality. The asterisk character is used as a value to indicate that no upper bound exists.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot earth_received_start_time
+;+		(comment "The earth_received_start_time attribute gives the beginning time at which a signal (such a telemetry) was received on Earth.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot quote
+;+		(comment "quote = '\"' ; (* quotation mark *)")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot has_Data_Object
+;+		(comment "The has_Data_Object association is a relationship to Data Object.")
+		(type INSTANCE)
+;+		(allowed-classes Data_Object)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot local_attribute_extended
+;+		(comment "The local_attribute_extended association is a relationship to Local_Attribute_Extended.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot has_document_edition
+;+		(comment "The has document edition association is a relationship to Document Edition.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot assertMsg
+		(type STRING)
+		(create-accessor read-write))
+	(multislot system_requirements_note
+;+		(comment "The system requirements note attribute identifies what is necessary to process the software.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot stop_date
+;+		(comment "The stop_date attribute provides the date when an activity ended.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot document_id
+;+		(comment "The docuemnt id provides a formal name used to refer to a document.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot file_name_delimiter
+;+		(comment "The file name delimiter separates the file name from the file extension.")
+		(type STRING)
+		(default "<period>")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot key_electronic_mail_address
+;+		(comment "The key electronic mail address attribute provides a unique identifier for each individual who is allowed access to the PDS.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot repetitions
+;+		(comment "The repetitions attribute provides the number of occurrences.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot software_format_type
+;+		(comment "The software format type attribute classifies the format of the software.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Record
+;+		(comment "The has_Record association is a relationship to record.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot affiliation_type
+;+		(comment "The affiliation type attribute describes the type of relationship an individual has with the PDS.  Individuals with PDS affiliations are generally listed in the PDS Phone Book.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot acted_on_behalf_of
+;+		(comment "The acted_on_behalf_of association is a recursive relationship on agent.")
+		(type INSTANCE)
+;+		(allowed-classes Agent)
+		(create-accessor read-write))
+	(multislot observing_system_name
+;+		(comment "The observing_system_name attribute provides a unique name for an observing system.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot medium_type
+;+		(comment "The medium_type attribute identifies the physical storage medium for a data volume. Examples: CD-ROM, CARTRIDGE TAPE.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot manifest_product_reference
+;+		(comment "The manifest product reference attribute provides the logical_identifier and version id of a manifest product.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot upper_110709_Class0
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot assertStmt
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot filter_number
+;+		(comment "The filter_number attribute of a spectral qube describes the physical location of a band %28identified by the band_number%29 in a detector array. Filter 1 is on the leading edge of the array.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot upper_110709_Class1
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot semi_minor_radius
+;+		(comment "The semi_minor_radius attribute provides the value of the intermediate axis of the ellipsoid that defines the approximate shape of a target body. The semi-minor axis is usually in the equatorial plane.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot upper_110709_Class2
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot model_id
+;+		(comment "The model_id attribute helps discriminate instrument hardware. For example \"flight\", \"engineering\", or \"proto\" have been used.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot positive_longitude_direction
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot associated_optional_folder
+;+		(comment "The associated_optional_folder association is a relationship to optional folders.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot wavelength_range
+;+		(comment "The wavelength range attribute specifies the wavelength range over which the data were collected or which otherwise characterizes the observation(s). Boundaries are vague, and there is overlap.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot coordinate_system_type
+;+		(comment "This attribute is used in the image map projection. Under review. xxx E. RYE;DS xxx")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot bit_mask
+;+		(comment "The bit mask attribute is a series of ASCII binary digits identifying the active bits in a value; it has exactly the same number of bits as the array element to which it is applied. The bit mask must be specified from most significant to least significant bit (left to right).")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -1455,236 +680,106 @@
 		(type INSTANCE)
 ;+		(allowed-classes Local_Internal_Reference)
 		(create-accessor read-write))
-	(multislot associated_data_object
-;+		(comment "The associated_data_object association is a relationship to data object.")
+	(single-slot non_quote_character
+;+		(comment "non-quote-character = letter | digit | special | underscore | apostrophe | space ;")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot funding_acknowledgement_text
+;+		(comment "The funding_acknowledgement_text attribute provides a text description of the relationship between the funding source and the archival data.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot dd_Context_Value_List
+;+		(comment "The dd_Context_Value_List association is a relationship to dd_Context_Value_List.")
 		(type INSTANCE)
-;+		(allowed-classes Tagged_Digital_Object Tagged_NonDigital_Object)
-		(create-accessor read-write))
-	(single-slot confidence_level_note
-;+		(comment "The confidence_level_note attribute is a text field which characterizes the reliability of data within a data set or the reliability of a particular programming algorithm or software component. Essentially, this note discusses the level of confidence in the accuracy of the data or in the ability of the software to produce accurate results.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot model_object_id
-;+		(comment "The model_object_id attribute provides the unique identifier of a class, attribute, or value that is defined in the information model.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot DD_Rule_Let
-		(type STRING)
+;+		(allowed-classes DD_Context_Value_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot rotation_direction
-;+		(comment "The rotation_direction element provides the direction of rotation as viewed from the north pole of the 'invariable plane of the solar system', which is the plane passing through the center of mass of the solar system and perpendicular to the angular momentum vector of the solar system. The value for this element is PROGRADE for counter -clockwise rotation, RETROGRADE for clockwise rotation and SYNCHRONOUS for satellites which are tidally locked with the primary. Sidereal_rotation_period and rotation_direction_type are unknown for a number of satellites, and are not applicable (N/A) for satellites which are tumbling.")
+	(single-slot geometry_collection_reference
+;+		(comment "The geometry collection reference attribute provides the logical_identifier for a geometry collection.")
 		(type STRING)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot reference_collection_reference
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot upper_110503_Slot_9
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot node_reference
-;+		(comment "The node reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier")
-		(create-accessor read-write))
-	(single-slot detector_number
-;+		(comment "The detector_number attribute provides the spectrometer detector number corresponding to a band of a spectral qube. Detector numbers are usually assigned consecutively from 1, in order of increasing wavelength.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot collected_under
-;+		(comment "The collected_under association is a relationship to circumstances of observation.")
-		(type INSTANCE)
-;+		(allowed-classes Context_Area)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot band_width
-;+		(comment "The band_width attributes provides the width, at half height, of the band.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot logical_volumes
-;+		(comment "This attribute is used in by the volume class. It is under review.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot max_inclusive
-;+		(comment "The max inclusive attribute provides a value that is greater than or equal to all the values in the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot UpperModel_140908c_1300_CCB63_Class1
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot model_object_type
-;+		(comment "The model_object_type attribute provides a classification for a modeled object.")
-		(type STRING)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(multislot supported_architecture_note
-;+		(comment "The supported architecture note attribute identifies  the hardware architecture that can process the software.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot observation_area
-;+		(comment "The observation_area association is a relationship to Observation_Area.")
-		(type INSTANCE)
-;+		(allowed-classes Context_Area)
-		(create-accessor read-write))
-	(single-slot version_id
-;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot easternmost_longitude
-;+		(comment "This attribute is used in the image map projection. Under review. xxx E. Rye xxx")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot fields
-;+		(comment "The fields attribute provides a count of the total number of scalar fields directly associated with a table record.  Fields within groups within the record are not included in this count.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot identifier
-;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot virtual_area
-;+		(comment "The virtual_area association is a relationship to Virtual Area")
-		(type INSTANCE)
-;+		(allowed-classes Virtual_Area)
-		(create-accessor read-write))
-	(multislot has_Table_Field_Grouped
-;+		(comment "The has_Table_Field_Grouped association is a relationship to the field types for a group.")
-		(type INSTANCE)
-;+		(allowed-classes Field_Binary Field_Bit)
-		(create-accessor read-write))
-	(single-slot bearing_reference_direction
-;+		(comment "The bearing_reference_direction attribute specifies the direction from which the bearing is measured.")
-		(type STRING)
-;+		(value "North" "South")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot mapping_type
-;+		(comment "The mapping type attribute indicates how two terms are related to each other.")
-		(type STRING)
-;+		(value "pds4_attribute_replaces_pds3_attribute" "pds4_attribute_replaces_pds4_attribute" "pds4_attribute_replaces_column" "pds4_attribute_replacedby_term")
-		(create-accessor read-write))
-	(single-slot manifest_product_reference
-;+		(comment "The manifest product reference attribute provides the logical_identifier and version id of a manifest product.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot positive_longitude_direction
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot citation
 ;+		(comment "The citation association is a relationship to the citation class.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot nil_reason
-;+		(comment "The nil_reason attribute provides the permissible values allowed as reasons when an attribute assigned a nil value.")
+	(multislot naif_instrument_id
+;+		(comment "The naif_instrument_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
 		(type STRING)
-;+		(value "inapplicable" "anticipated" "missing" "unknown")
+		(create-accessor read-write))
+	(multislot property_map_id
+;+		(comment "The identifier attribute provides the formal name used to refer to a property map.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot reference_type
+;+		(comment "The reference_type attribute provides the name of the association.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Gazetteer_Column
+;+		(comment "The has_Gazetteer_Column association is a relationship to gazetteer column.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(cardinality 20 20)
+		(create-accessor read-write))
+	(single-slot vertical_framelet_offset
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot context_area
-;+		(comment "The context_area association is a relationship to Context_Area.")
-		(type INSTANCE)
-;+		(allowed-classes Context_Area)
-		(create-accessor read-write))
-	(multislot reference
-;+		(comment "The reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+	(multislot field_data_type
+;+		(comment "The field_data_type attribute provides the machine  representation used to store the value.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot key_electronic_mail_address
-;+		(comment "The key electronic mail address attribute provides a unique identifier for each individual who is allowed access to the PDS.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot software_version_id
-;+		(comment "The software_version_id attribute provides the version of the software.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_Group_Facet2
-;+		(comment "The has_Group_Facet2 association is a relationship to Group_Facet2.")
+	(multislot has_Table_Binary_Grouped
+;+		(comment "The has_Table_Binary_Grouped association is a relationship to grouped sequence of fields.")
 		(type INSTANCE)
-;+		(allowed-classes Group_Facet2)
+;+		(allowed-classes Field_Bit)
 		(create-accessor read-write))
-	(multislot has_Group_Facet1
-;+		(comment "The has_Group_Facet1 association is a relationship to Group_Facet1.")
-		(type INSTANCE)
-;+		(allowed-classes Group_Facet1)
-		(create-accessor read-write))
-	(multislot has_document
-;+		(comment "The has_document association is a relationship to one Document.")
+	(multislot product_data_object
+;+		(comment "The product_data_object association is a relationship to a data object.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot UpperModel_180912x_1B00_Prov_Class5
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot unit
-;+		(comment "The unit attribute provides the unit of measurement.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot brick_number
-;+		(comment "An integer value indicating the sequence number of this brick. A SIP written to two bricks would use one (1) as the first brick number.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_Coordinate_Representation
-;+		(comment "The xxx association is a relationship to yyy.")
+	(multislot virtual_area
+;+		(comment "The virtual_area association is a relationship to Virtual Area")
 		(type INSTANCE)
-;+		(allowed-classes XSChoice%23)
+;+		(allowed-classes Virtual_Area)
 		(create-accessor read-write))
-	(multislot minimum_sampling_parameter
-;+		(comment "The minimum_sampling_parameter element identifies the minimum value at which a given data item was sampled. For example, a spectrum that was measured in the 0.4 to 3.5 micrometer spectral region would have a minimum_sampling_parameter value of 0.4. The sampling parameter constrained by this value is identified by the sampling_parameter_name element. Note: The unit of measure for the sampling parameter is provided by the unit element.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot data_object_description
-;+		(comment "Composition association for the Data Object Description.")
+	(multislot has_Delimited_Field
+;+		(comment "The has_Delimited_Field association is a relationship to field.")
 		(type INSTANCE)
 ;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot copyright
+;+		(comment "The copyright attribute is a character string giving  information about the exclusive right to make copies, license, and otherwise exploit an object, whether physical or digital.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot ldd_version_id
+;+		(comment "The ldd_version_id attribute provides the version of the Local Data Dictionary.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot UpperModel_191218_CCB-256_ReferenceTypes_Retry_Class0
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot lexical_identifier
 ;+		(comment "identifier = initial-letter-like, { pseudo-letter-like } ; initial-letter-like = letter-like | special-like ; letter-like = letter | ISO/IEC-10176-extended-letter ; pseudo-letter-like = letter-like | digit-like | underscore ; digit-like = digit | ISO/IEC-10176-extended-digit ; special-like = underscore | ISO/IEC-10176-extended-special ;")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot member_product_type
-;+		(comment "The member type attribute indicates the class name of the member.")
+	(single-slot discipline_desc
+;+		(comment "The discipline_desc attribute provides a description for the science discipline")
 		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot file_area
-;+		(comment "The file_area association is a relationship to File Area")
-		(type INSTANCE)
-;+		(allowed-classes)
+	(multislot first_line_sample
+;+		(comment "The first_line_sample attribute provides the sample within a source image line that corresponds to the first line in a sub-image.")
+		(type INTEGER)
 		(create-accessor read-write))
-	(multislot archive_colllection_entry
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot maximum_occurrences
-;+		(comment "The maximum occurrences attribute indicates the number of times something may occur. It is also called the maximum cardinality. The asterisk character is used as a value to indicate that no upper bound exists.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Field_Checksum
-;+		(comment "The has_Field_Checksum association is a relationship to Table_Field_Checksum.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot spheroid_name
-;+		(comment "The spheroid_name attribute provides the identification given to established representations of a planet%47s shape. ")
+	(single-slot software_type
+;+		(comment "The software type attribute identifies the class of which the software is a member.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -1693,134 +788,357 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot has_Element_Array
-;+		(comment "The has_Element_Array association is a relationship to Element_Array")
+	(multislot local_association_class
+;+		(comment "The local_association_class association provides a relationship to a class.")
 		(type INSTANCE)
-;+		(allowed-classes Element_Array)
+;+		(allowed-classes DD_Association)
+		(create-accessor read-write))
+	(multislot reference_relation_desc
+;+		(comment "The reference relation desc attribute provides a short description of the relationship between two objects.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot minimum_occurrences
+;+		(comment "The minimum occurrences attribute indicates the number of times something may occur. It is also called the minimum cardinality.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot software_version_id
+;+		(comment "The software_version_id attribute provides the version of the software.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot producer_full_name
+;+		(comment "The producer_full_name attribute provides the full_name of the individual mainly responsible for the production of the data set. This individual does not have to be registered with the PDS.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot pds_address_book_flag
-;+		(comment " The pds_address_book_flag data attribute indicates whether or not a registered PDS user will have an entry in the PDS telephone directory.")
-		(type SYMBOL)
-		(allowed-values N NULL Y)
+	(multislot has_Data_Brick_Sequence
+;+		(comment "The has_Data_Brick_Sequence association is a relationship to data brick.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot node_desc
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot has_Planar_Coordinate_Information
-;+		(comment "The xxx association is a relationship to yyy.")
+	(multislot keyword
+;+		(comment "The keyword attribute provides one or more words to be used for  keyword search.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot attribute_name
+;+		(comment "The attribute_name attribute provides the common name by which an attribute is known.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot data_type_length
+;+		(comment "The data type length attribute provides the extent from beginning to end of a series of units such as bytes.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot curated_by
+;+		(comment "Association for curation nodes.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot observed_ring_elevation
-;+		(comment "observed_ring_elevation is an angle measured at a point in the ring plane, starting from the ring plane to the direction of a photon heading to the observer. This angle is positive on the side of the ring plane defined by positive angular momentum, and negative on the opposite side. Values range from -90 to %2B90 in units of degrees. This angle is constant for stellar occultations, but may vary significantly during radio occultations. Note: The direction of positive angular momentum points toward the IAU-defined north side of the ring plane for Jupiter, Saturn and Neptune, but IAU-defined south side of the ring plane for Uranus. Required in the label if the value is constant for the observation. If the angle varies for the observation, the min and max attributes are required in the label, and observed_ring_elevation is strongly recommended as a field in the data table. The above definition of observed_ring_elevation is equivalent to the most common usage of the term 'ring open angle', B.")
+	(multislot choice_flag
+;+		(comment "The choice flag attribute indicates that the class is being used to group either classes or attributes to allow a choice. Choice flag is only included if the value 'true' is desired.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot sip_manifest_path
+;+		(comment "The relative path from the data brick mount point to and including the SIP manifiest directory. E.g. SIP_Manifest_Path = “./SIP_Manifest/” - indicates that the SIP_Manifest directory is at the mount point of the disk brick.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot volumes
+;+		(comment "An integer value indicating the number of archive volumes in this delivery.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot packet_map_mask
+;+		(comment "The packet_map_mask attribute is a binary or hexadecimal number identifying which of a data file's expected packets were actually received.  The digits correspond positionally with the relative packet numbers of the data file.  The bits are to be read left to right; i.e., the first %28left-most%29 digit of the number corresponds to the first packet of the data file.  A bit value of 1 indicates that the packet was received; a value of 0 indicates that it was not received.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot highest_detectable_opacity
+;+		(comment "highest_detectable_opacity indicates the sensitivity of a ring occultation data set to nearly opaque rings. It specifies the rough value for the largest normal ring opacity that can be detected in the data at the resolution provided, incorporating both statistical effects and calibration uncertainties. Strongly recommended in labels of ring occultation observations. Not intended as a value for a table field.")
 		(type FLOAT)
 		(create-accessor read-write))
-	(multislot ring_plane
-;+		(comment "ring_plane indicates the plane upon which parameters such as ring_radius are based. Possible values for the Saturn ring system are 'Equator', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'Phoebe'. For the Uranus ring system values are 'Equator', 'Six', 'Five', 'Four', 'Alpha', 'Beta', 'Eta', 'Gamma', 'Delta', 'Lambda','Epsilon',Nu, Mu. Required in labels of ring occultation observations.")
+	(multislot lidvid_reference
+;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
+		(type STRING)
+		(default "logical_identifier::version_id")
+		(create-accessor read-write))
+	(multislot collection_reference_a
+;+		(comment "The collection reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot attribute_relative_xpath
-;+		(comment "The attribute_relative_xpath attribute provides a location path for an attribute within a tree representation of an XML document. The location path includes the attribute name.")
+	(multislot operations_contact_puid
+;+		(comment "The operations_contact indicates the node person responsible for node operations.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot quote
-;+		(comment "quote = '\"' ; (* quotation mark *)")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot virtual_structure
-;+		(comment "The virtual_structure association is a relationship to Virtual Structure")
-		(type INSTANCE)
-;+		(allowed-classes Virtual_Structure)
-		(create-accessor read-write))
-	(multislot has_Transfer_Manifest
-;+		(comment "The has_Transfer_Manifest association is a relationship to Transfer_Manifest.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot sampling_parameter_base
-;+		(comment "The sampling_parameter_base attribute provides the base b by which exponentials are calculated in the definition of the attribute sampling_parameter_interval.")
+	(multislot local_reference_type
+;+		(comment "The local_reference_type attribute provides the name of an association between an entity identified by a local_identifier_reference and another corresponding entity identified by a local_identifier. The values for the local_reference_type are expected to be enumerated for appropriate contexts in the Schematron files of local (i.e., discipline and mission) data dictionaries.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot iso_iec_646_letters
-;+		(comment "ISO/IEC 10176 describes the notion of classes of letter-like characters (outside of ISO/IEC 646 letters A through Z), digit-like characters (outside of ISO/IEC 646 digits 0 through 9), and special characters that are all used in identifiers.")
+	(single-slot collection_id
+;+		(comment "The collection id attribute provides a unique identifier for a collection.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_State_Plane_Coordinate_System
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot data_location
-;+		(comment "The data_location association is a relationship to Data_Location or File_Location.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot has_Oblique_Line
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes XSChoice%23)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot digit_string
-;+		(comment "digit-string = digit-like, { digit-like } ; digit-like = digit | ISO/IEC-10176-extended-digit ;")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot type_list
-;+		(comment "The type_list attribute classifies the instrument according to its function. The values in this list are comma separated.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot b_axis_radius
-;+		(comment "This attribute is used in the image map projection. Under review. xxx DDWG;DS xxx Also check why minimum value is negative.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_Packed_Data_Fields
-;+		(comment "The has_Packed_Data_Fields association is a relationship to  Packed_Data_Fields.")
-		(type INSTANCE)
-;+		(allowed-classes Packed_Data_Fields)
-		(create-accessor read-write))
-	(single-slot line_projection_offset
+	(single-slot line_first_pixel
 ;+		(comment "This attribute is used in the image map projection. Under review.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot acknowledgement_text
-;+		(comment "The acknowledgement_text attribute is a character string which recognizes another's contribution, authority, or right.")
+	(multislot context_reference
+;+		(comment "The context reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot min_inclusive
+;+		(comment "The min inclusive attribute provides a value that is less than or equal to all the values in the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+	(single-slot unit
+;+		(comment "The unit attribute provides the unit of measurement.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot ups_zone_identifier
+;+		(comment "The ups_zone_identifier attribute provides an identifier for the UPS zone.")
+		(type STRING)
+;+		(value "A" "B" "Y" "Z")
+		(create-accessor read-write))
+	(multislot provider_site_id
+;+		(comment "The provider site id attribute provides an identifier for the provider.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot sample_last_pixel
-;+		(comment "This attribute is used in the image map projection. Under review.")
+	(single-slot ring_occultation_direction
+;+		(comment "ring_occultation_direction indicates the radial direction of an occultation track. This refers to the observed occultation track overall, not to the subset that might appear in a particular file. Permitted values are 'Ingress', 'Egress', 'Both', and 'Multiple'. The value 'multiple' is only used for some Hubble-based occultations where the occultation track is not monotonic over relatively short time scales. Required in labels of ring occultation observations. Nillable if the observation is not a ring occultation in which case the nil_reason should be 'inapplicable'. Not intended as a value for a table field. ")
+		(type STRING)
+;+		(value "Both" "Egress" "Ingress" "Multiple")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot saturated_constant
+;+		(comment "The saturated_constant attribute provides a value that indicates the original value was invalid because of sensor saturation.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot calibration_collection_reference
+;+		(comment "The calibration collection reference attribute provides the logical_identifier for a calibrartion collection.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot alias_list
+;+		(comment "The alias_list association is a relationship to Alias_List, a list of alternate names and identifications.")
+		(type INSTANCE)
+;+		(allowed-classes Alias_List)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot component
+		(type STRING)
+		(default "IM" "DD")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Property_Map_Entry
+;+		(comment "The has_Property_Map_Entry association is a relationship to property map entry.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot revision_comment
+;+		(comment "The revision comment attribute provides notes on the revision of the product.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot vertical_display_axis
+;+		(comment "The vertical_display_axis attribute identifies, by name, the axis of an Array %28or Array subclass%29 that is intended to be displayed in the vertical or 'line' dimension on a display device. The value of this attribute must match the value of one, and only one, axis_name attribute in an Axis_Array class of the associated Array.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot constant_value
-;+		(comment "The constant value attribute provides the value to be used if an attribute is static.")
+	(multislot sampling_parameter_scale
+;+		(comment "The sampling_parameter_scale element specifies whether the sampling interval is linear or something other such as logarithmic.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot upper_120214_Class0
+	(multislot quaternion_component
+;+		(comment "The quaternion_component association is a relationship to Quaternion_Component.")
+		(type INSTANCE)
+;+		(allowed-classes Quaternion_Component)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(multislot vector_component
+;+		(comment "The vector_component association is a relationship to the vector_component.")
+		(type INSTANCE)
+;+		(allowed-classes Vector_Component)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(multislot name_association_type
+;+		(comment "The name_association_type attribute indicates whether the name is a primary, alternate, or deprecated name.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Local_ID_Reference
+;+		(comment "The has_Local_ID_Reference association is a relationship to has_Local_ID_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Local_ID_Reference)
+		(create-accessor read-write))
+	(single-slot longitude_direction
+;+		(comment "The longitude_direction attribute identifies the direction of longitude %28e.g. POSITIVE_EAST or POSITIVE_WEST%29 for a planet. The IAU definition for direction of positive longitude is adopted. Typically, for planets with prograde rotations, positive longitude direction is to the west. For planets with retrograde rotations, positive longitude direction is to the east. Note: The longitude_direction attribute should be used for planetographc systems, but not for planetocentric.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot file_extension_token
+;+		(comment "The file extension token is a substring that provides a file extension. The maximum size of a directory name is tbd characters.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot schematronAssignPattern
-;+		(comment "The schematronAssignPattern attribute provides values for schemtron rule assignments at the pattern level.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot aip_lidvid
-;+		(comment "The aip_lidvid attribute provides the logical_identifier plus version_id, which uniquely identifies a Archival Information Package.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot sip_data_directory_specification_name
-;+		(comment "Relative path name to the data directory and indicates the directory being transferred in the SIP. E.g. SIP_Data_Directory_Specification_Name  = --Volume_ID-- .")
+	(single-slot date_time
+;+		(comment "The date_time attribute provides the date and time of an event.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot pds4_merge_flag
+;+		(comment "The PDS4 merge flag attribute indicates that the local data dictionary should be merged with the PDS4 data dictionary and accept the PDS as the data dictionary's registration authority. The merge process requires validation that the local data dictionary conforms to PDS data standards.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot application_process_id
+;+		(comment "The application_process_id attribute identifies the process, or source, which created the data.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot last_modification_date_time
+;+		(comment "The last_modification_date_time attribute gives the most recent date and time that a change was made.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot local_mean_solar_time
+;+		(comment "The local_mean_solar_time attribute provides the hour angle of the fictitious mean Sun at a fixed point on a rotating solar system body.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot agent_type
+;+		(comment "The agent_type attribute provides a classification for the agent.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot string_literal
+;+		(comment "string-literal = quote, { string-character }, quote ; string-character = non-quote-character | added-character | escape-character ;")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot telescope_altitude
+;+		(comment "The telescope_altitude attribute provides the height of the telescope above a plane tangent to the reference figure (or datum) at the telescope location.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Information_Package_Component
+;+		(comment "The has_Information_Package_Component association is a relationship to a Information_Package_Component.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot color_display_axis
+;+		(comment "The color_display_axis attribute identifies, by name, the axis of an Array %28or Array subclass%29 that is intended to be displayed in the color dimension of a display device. I.e., bands from this dimension will be loaded into the red, green, and blue bands of the display device. The value of this attribute must match the value of one, and only one, axis_name attribute in an Axis_Array class of the associated Array.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot property_name
+;+		(comment "The property name attribute provides a word or a combination of words by which a property is known.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot node_puid
+;+		(comment "The node_puid attribute provides a globally unique identifer for a node.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot longitude
+;+		(comment "The longitude attribute provides the angular distance east or west on the object's surface, measured by the angle contained between the meridian of a particular place and some prime meridian.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot minimum_observed_ring_azimuth
+;+		(comment "minimum_observed_ring_azimuth specifes the smallest value for observed_ring_azimuth in the data file. Values range from 0 to 360 in units of degrees. Required in label files for ring occultation data.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot volume_size
+;+		(comment "The volume size attribute provide the number of bytes in the volume.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot submitter_name
+;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot postal_address_text
+;+		(comment "The postal address text attribute provides a mailing address.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot mission_desc
+;+		(comment "The mission_desc attribute summarizes major aspects of a planetary mission or project, including the number and type of spacecraft, the target body or bodies and major accomplishments.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot field_bytes
+;+		(comment "The field bytes attribute provides the maximum number of bytes allowed for a field.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Axis_Array
+;+		(comment "The has_Axis_Array association is a relationship to Axis_Array.")
+		(type INSTANCE)
+;+		(allowed-classes Axis_Array)
+		(create-accessor read-write))
+	(multislot alwaysInclude
+;+		(comment "The alwaysInclude attribute indicates whether a rule should always be included.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot blue_channel_band
+;+		(comment "The blue_channel_band attribute identifies the number of the band, along the band axis, that should be loaded, by default, into the blue channel of a display device. The first band along the band axis has band number 1.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot derivation_reference
+;+		(comment "The derivation reference attribute provides the logical_identifier and version_id for a source product.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot resource_puid
+;+		(comment "The resource_puid attribute provides a globally unique identifer for a resource.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot permissible_value
+;+		(comment "The permissible_value association is a relationship to Permissible_Value.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot maximum_observed_event_time
+;+		(comment "maximum_observed_event_time gives the largest value for observed_event_time in the associated data file. It is given in numeric seconds as an offset from the specified UTC reference time. maximum_observed_event_time is optional in labels since the data file time interval end point values are given by the required start_date_time_utc and stop_date_time_utc attributes in the Time_Coordinates class.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot instrument_host_id
+;+		(comment "The instrument_host_id attribute provides a unique identifier for the host on which an instrument is located. This host can be either a spacecraft or an earth base (e.g. earth).")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot container_file_name
+;+		(comment "The file name attribute provides a word or a combination of words by which the file is known. The role of this file is a container.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot contained_product_reference
+;+		(comment "The contained product reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a product being packaged.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot referenced_object_type
+;+		(comment "The reference object type attribute indicates the type of the object being referenced.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_occultation_supplement
+;+		(comment "The has_occultation_supplement association is a relationship to occultation_supplement")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot utm_zone_number
+;+		(comment "The utm_zone_number attribute provides the identifier for the UTM zone.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot external_standard_version_id
+;+		(comment "The external_standard_version_id attribute provides the version of the external standard.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot file_name
 ;+		(comment "The file_name attribute provides the name of a file.")
@@ -1828,44 +1146,255 @@
 		(default "file_name-period-file_extension")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot document_id
-;+		(comment "The docuemnt id provides a formal name used to refer to a document.")
+	(multislot field_length
+;+		(comment "The field_length attribute provides the number of bytes in the field.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot facet2
+;+		(comment "The facet2 attribute provides a sub-categorization (under the discipline_name) of the type of data being described by Primary_Result_Summary.  The  facet1  and  factet2  values are intended to provide independent sub-categorizations. The values are restricted according to the value of discipline_name. Type: ASCII_Short_String_Collapsed")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot unit_of_measure_name
-;+		(comment "The unit_of_measure_name attribute indicates the units in which a value is given.")
+	(multislot occultation_direction
+;+		(comment "occultation_direction indicates the direction of an occultation track. This refers to the observed occultation track overall, not to the subset that might appear in a particular file (e.g., if an occultation includes both ingress and egress tracks, the value for occultation_direction will be both in the data products for each occultation profile. Permitted values are 'Ingress', 'Egress', 'Both', and 'Multiple'. The value 'Multiple' is only used for some Hubble-based occultations where the occultation track is not monotonic over relatively short time scales. Required in labels of ring occultation observations. Not intended as a value for a table field.")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(value "Both" "Egress" "Ingress" "Multiple")
 		(create-accessor read-write))
-	(single-slot spice_collection_reference
-;+		(comment "The spice collection reference attribute provides the logical_identifier for a spice collection.")
+	(multislot facet1
+;+		(comment "The facet1 attribute provides a sub-categorization under the discipline_name.  The values are restricted according to the value of discipline_name.")
 		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Table_Binary_Grouped
-;+		(comment "The has_Table_Binary_Grouped association is a relationship to grouped sequence of fields.")
-		(type INSTANCE)
-;+		(allowed-classes Field_Bit)
-		(create-accessor read-write))
-	(single-slot upper_101016_Slot_0
+	(multislot sampling_parameter_base
+;+		(comment "The sampling_parameter_base attribute provides the base b by which exponentials are calculated in the definition of the attribute sampling_parameter_interval.")
 		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot curated_by
-;+		(comment "Association for curation nodes.")
+	(multislot has_Field_LID
+;+		(comment "The has_Field_LID association is a relationship to an LID.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot loop_back_and_forth_flag
-;+		(comment "The loop_back_and_forth_flag attribute specifies whether or not a movie should only be 'looped' or played repeatedly in the forward direction, or whether it should be played forward followed by played in reverse, iteratively.")
+	(multislot md5_checksum
+;+		(comment "The md5_checksum attribute is the 32-character hexadecimal number computed using the MD5 algorithm for the contiguous bytes of single digital object (as stored) or for an entire file.")
 		(type STRING)
-;+		(value "false" "true")
-;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot instrument_host_logical_identifier
-;+		(comment "The instrument host logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
+	(multislot rule_assign
+;+		(comment "The rule_assign attribute provides an assignment statement for a schematron rule.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_band_bin
+;+		(comment "The has_band_bin association is a relationship to band bin.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot resource_name
+;+		(comment "The resource_name attribute provides a name for the resouce")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot observing_system_reference
+;+		(comment "The observing system reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier")
+		(create-accessor read-write))
+	(multislot maximum_observed_ring_elevation
+;+		(comment "maximum_observed_ring_elevation specifes the largest value for observed_ring_elevation in the data file. Only used if the value is not constant over the observation. Values range from -90 to %2B90 in units of degrees. Not intended for use in the data file.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot first_line
+;+		(comment "The first_line attribute provides the line within a source image that corresponds to the first line in a sub-image.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot has_Map_Projection
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes XSChoice%23)
+		(create-accessor read-write))
+	(single-slot fraction_digits
+;+		(comment "The fraction digits indicates the number of digits in the faction part of a real number.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot has_time_coordinates
+;+		(comment "The has_time_coordinates association is a relationship to Time_Coordinates.")
+		(type INSTANCE)
+;+		(allowed-classes Time_Coordinates)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_Horizontal_Coordate_System_Definition
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot nssdc
+;+		(comment "The nssdc association is a relationship to NSSDC.")
+		(type INSTANCE)
+;+		(allowed-classes NSSDC)
+		(create-accessor read-write))
+	(single-slot telemetry_format_id
+;+		(comment "The telemetry_format_id attribute supplies a telemetry format code.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot upper_111205b_Class0
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_Table_Field_Old
+;+		(comment "The has_Table_Field association is a relationship to field.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(multislot update_entry
+;+		(comment "The update_entry association is a relationship to Update_Entry.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot property_value
+;+		(comment "The property value attribute provides the value assigned to a property.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot west_bounding_coordinate
+;+		(comment "The west_bounding_coordinate attribute provides the western-most coordinate of the limit of coverage expressed in longitude.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot letter
+;+		(comment "letter = \"a\" | \"b\" | \"c\" | \"d\" | \"e\" | \"f\" | \"g\" | \"h\" | \"i\" | \"j\" | \"k\" | \"l\" | \"m\" | \"n\" | \"o\" | \"p\" | \"q\" | \"r\" | \"s\" | \"t\" | \"u\" | \"v\" | \"w\" | \"x\" | \"y\" | \"z\" | \"A\" | \"B\" | \"C\" | \"D\" | \"E\" | \"F\" | \"G\" | \"H\" | \"I\" | \"J\" | \"K\" | \"L\" | \"M\" | \"N\" | \"O\" | \"P\" | \"Q\" | \"R\" | \"S\" | \"T\" | \"U\" | \"V\" | \"W\" | \"X\" | \"Y\" | \"Z\" ;")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot maximum_radial_sampling_interval
+;+		(comment "maximum_radial_sampling_interval indicates the smallest radial spacing between consecutive points in a ring profile. In practice, this may be somewhat smaller than the radial_resolution because a profile may be over-sampled. If the value of radial_sampling_interval varies, the minimum and maximum attributes are required in labels. Not intended to be used as a table field.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot member_in_group
+;+		(comment "Associated Personnel")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot brick_identifier
+;+		(comment "The identifier of the data brick – Best practice is to use the data brick serial number.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot archive_colllection_entry
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot password
+;+		(comment "The password attribute provides a encrypted password used for authorization.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot fax_number
+;+		(comment "The fax_number data attribute provides the area code and telephone number needed to transmit data to an individual or a node via facsimile machine.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot instrument_host_version_id
+;+		(comment "The instrument_host_version_id attribute provides the version of the instrument host.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot lid_reference_from
+;+		(comment "The lid_reference_from provides the identifier of the starting object in a one  directional relationship.")
+		(type INSTANCE)
+;+		(allowed-classes LID_ID_Reference_From)
+		(create-accessor read-write))
+	(single-slot block_bytes
+;+		(comment "This attribute is used by the volume class. It is under review.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot brick_number
+;+		(comment "An integer value indicating the sequence number of this brick. A SIP written to two bricks would use one (1) as the first brick number.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot image_id
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot designation
+;+		(comment "The designation attribute provides a name for the term in the language selected.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot sequence_class_org
+;+		(comment "Housekeeping.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot mission_phase_identifier
+;+		(comment "The mission_phase_identifier attribute provides an identifier for a mission phase.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot external_namespace_id
+;+		(comment "The external_namespace_id attribute provides a namespace_id external to this context.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot field_number
+;+		(comment "The field_number attribute provides the position of a field, within a series of fields, counting from 1. If two fields within a record are physically separated by one or more groups, they have consecutive field numbers; the fields within the intervening group(s) are numbered separately.  Fields within a group separated by one or more (sub)groups, will also have consecutive field numbers.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(single-slot escape
+;+		(comment "escape = \"!\" ; (* exclamation point *)")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot instrument_host_desc
+;+		(comment "The instrument_host_desc provides a description of an instrument host")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot reference_latitude
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot upper_110503_Slot_9
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot refer_Context
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot data_set_logical_identifier
+;+		(comment "The data set logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot serial_number
+;+		(comment "The serial number attribute provides the manufacturer's serial number assigned to an instrument host.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot rights
+;+		(comment "Information about rights held in and over the resource. - Dublin Core")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot resource_id
+;+		(comment "The resource id provides a formal name used to refer to a resource.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot field_delimiter
+;+		(comment "The field_delimiter attribute provides the character that marks the boundary between two fields in a delimited table.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot line_display_direction
+;+		(comment "The line_display_direction element is the preferred orientation of lines within an image for viewing on a display device.  The default value is down, meaning lines are viewed top to bottom on the display. Note that if this keyword is present in a label, the SAMPLE_DISPLAY_DIRECTION keyword must also be present and must contain a value orthogonal to the value selected for this keyword.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot refer_reference_projection
 ;+		(comment "Associated Reference")
@@ -1873,201 +1402,286 @@
 ;+		(allowed-classes)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot min_inclusive
-;+		(comment "The min inclusive attribute provides a value that is less than or equal to all the values in the object.")
+	(single-slot electronic_mail_type
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot value_end_date
-;+		(comment "The value_end_date attribute provides the last date on which the permissible value is in effect.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
+	(multislot member_product_type
+;+		(comment "The member type attribute indicates the class name of the member.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot campaign_description
-;+		(comment "The campaign description attribute provides a statement, picture in words, or account that describes.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot users_manual_id
-;+		(comment "The users manual id attribute provides a formal name used to refer to a manual that describes how to use the software.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot member_relation_name
-;+		(comment "The member relation name provides the name of the relationship.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot source_product_internal
-;+		(comment "The source_product_internal association is a relationship to Source_Product_Internal.")
-		(type INSTANCE)
-;+		(allowed-classes Source_Product_Internal)
-		(create-accessor read-write))
-	(multislot has_Geographic
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes XSChoice%23)
-		(create-accessor read-write))
-	(single-slot resource_desc
-;+		(comment "The resource_desc attribute provides a description for the resource")
-		(type STRING)
-		(default "UNK")
-;+		(value "Text")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot volume_set_name
-;+		(comment "This attribute is used in by the volume class. It is under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot update_entry
-;+		(comment "The update_entry association is a relationship to Update_Entry.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot not_applicable_constant
-;+		(comment "The not_applicable_constant attribute provides a value that indicates the parameter is not applicable.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot annotation
-;+		(comment "The annotation attribute provides an explanatory note added to a text.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot first_standard_parallel
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot escape
-;+		(comment "escape = \"!\" ; (* exclamation point *)")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot instrument_puid
-;+		(comment "The instrument_puid attribute provides a globally unique identifer for an instrument.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot scale_factor_at_center_line
-;+		(comment "The scale_factor_at_center_line attribute provides a multiplier for reducing a distance obtained from a map by computation or scaling to the actual distance along the center line.")
+	(single-slot median
+;+		(comment "The median attribute provides the number separating the higher half of the values from the lower half; empty and Special_Constants values are excluded.")
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot field_description
-;+		(comment "The field description attribute provides a statement, picture in words, or account that describes a field.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot unknown_constant
-;+		(comment "The unknown_constant attribute provides a value that indicates the original value was unknown.")
-		(type STRING)
+	(single-slot document_format
+;+		(comment "The document_format attribute associates a Document_Format with the Document_Format_Set.")
+		(type INSTANCE)
+;+		(allowed-classes Document_Edition)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_band_bin
-;+		(comment "The has_band_bin association is a relationship to band bin.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot spacecraft_event_stop_time_utc
-;+		(comment "spacecraft_event_stop_time_utc gives the UTC time corresponding to the latest time given by spacecraft_event_time in the data table. However, while spacecraft_event_time is given as seconds offset from a reference time, spacecraft_event_stop_time_utc is given as a UTC date time. Required in the label for radio occultation data. Not used for stellar occultations.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot sample_first_pixel
-;+		(comment "This attribute is used in the image map projection. Under review.")
+	(single-slot target_type
+;+		(comment "The target_type attribute identifies the type of a named target.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot has_Software
-;+		(comment "The has_Software association is a relationship to Software.")
+	(single-slot directory_path_name
+;+		(comment "The directory_path_name attribute provides a sequence of names that locates a directory in a hierarchy of directories.")
+		(type STRING)
+		(default "_name-slash_*")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot supported_environment_note
+;+		(comment "The supported environment note attribute identifies  the environment  that can process the software.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot model_object_type
+;+		(comment "The model_object_type attribute provides a classification for a modeled object.")
+		(type STRING)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(multislot has_image_2d_display
+;+		(comment "The has_image_2d_display association is a relationship to Image_2D_Array.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot modification_date
-;+		(comment "The modification_date attribute provides date the modifications were completed")
+	(multislot spice_filename
+;+		(comment "spice_filename gives the file name%28s%29 of SPICE files used in the analysis. Only used if the SPICE files cannot be identified using a LID or LIDVID. Otherwise the association is made in the Reference_Class using the Internal_Reference class. Optional in labels for radio occultation. Nillable in which case the nil_reason should be 'inapplicable'.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot volume_series_name
-;+		(comment "This attribute is used in by the volume class. It is under review.")
+	(single-slot protocol_type
+;+		(comment "The prototype type attribute classifies a protocol.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot orbit_number
-;+		(comment "The orbit_number attribute provides the number of the orbital revolution of one body around another.")
+	(multislot software_language
+;+		(comment "The software language attribute identifies the language used to write the software.")
 		(type STRING)
-		(create-accessor read-write))
-	(multislot axis_name
-;+		(comment "The axis_name attribute provides a word or combination of words by which the axis is known.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot start_date
-;+		(comment "The start_date attribute provides the date when an activity began.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot telemetry_format_id
-;+		(comment "The telemetry_format_id attribute supplies a telemetry format code.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot release_date
-;+		(comment "The release_date attribute provides the date that the product was released.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_Member
-;+		(comment "The has_Member association is a relationship to members of a collection.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot string_literal
-;+		(comment "string-literal = quote, { string-character }, quote ; string-character = non-quote-character | added-character | escape-character ;")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot purpose
-;+		(comment "The purpose attribute provides an indication of the primary purpose of the observations included.")
-		(type STRING)
-;+		(value "Science" "Navigation" "Calibration" "Checkout" "Engineering")
 		(create-accessor read-write))
 	(multislot node_id
 ;+		(comment "The node id provides a formal name used to refer to a node.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot is_enumerated_flag
-;+		(comment "The is_enumerated_flag attribute indicates whether an attribute has an enumerated set of permissible values.")
+	(single-slot directory_name_token
+;+		(comment "The directory name token is a substring that names a directory. The maximum size of a directory name is thirty characters.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot special
-;+		(comment "special = \"(\" | (* left parenthesis *) \")\" | (* right parenthesis *) \".\" | (* full stop *) \",\" | (* comma *) \":\" | (* colon *) \";\" | (* semicolon *) \"=\" | (* equals sign *) \"/\" | (* solidus *) \"*\" | (* asterisk *) \"-\" | (* hyphen-minus *) \"{\" | (* left curly bracket *) \"}\" | (* right curly bracket *) \"[\" | (* left square bracket *) \"]\" ; (* right square bracket *)")
+	(single-slot flattened_class
+;+		(comment "Housekeeping.")
+		(type INSTANCE)
+;+		(allowed-classes Conceptual_Object)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot document_collection_reference
+;+		(comment "The document collection reference attribute provides the logical_identifier for a document collection.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot maximum_light_source_incidence_angle
+;+		(comment "maximum_light_source_incidence_angle specifes the largest value for observed_ring_elevation in the observation. Only used if the value is not constant over the observation. Values range from 0 to %2B90 in units of degrees. Not intended for use in the data file.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot node_reference
+;+		(comment "The node reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier")
+		(create-accessor read-write))
+	(single-slot min_exclusive
+;+		(comment "The min exclusive attribute provides a value that is less than all the values in the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot vertical_display_direction
-;+		(comment "The vertical_display_direction attribute specifies the direction along the screen of a display device that data along the vertical axis of an Array is supposed to be displayed.")
+	(multislot associated_optional_description
+;+		(comment "The associated_optional_description association is a relationship to optional descriptions.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot mission_logical_identifier
+;+		(comment "The mission logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot data_type_unit_of_measure_name
+;+		(comment "The data type unit of measurement name attribute provides the unit of measure used with a value.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot start_orbit_number
+;+		(comment "The start_orbit_number attribute provides the first in a series of numbers that represent a set of orbital revolutions of one body around another.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot instrument_version_id
+;+		(comment "The Instrument_Version_Id element identifies the specific model of an instrument used to obtain data. For example, this keyword could be used to distinguish between an engineering model of a camera used to acquire test data, and a flight model of a camera used to acquire science data during a mission.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot browse_reference
+;+		(comment "The browse reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier")
+		(create-accessor read-write))
+	(multislot da_contact_puid
+;+		(comment "The da_contact indicates the node person responsible for data administration.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot mission_stop_date
+;+		(comment "The mission_stop_date attribute provides the date of the end of a mission in UTC system format.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot id_reference_from
-;+		(comment "The id_reference_from provides the identifier of the starting object in a  one directional relationship.")
+	(multislot has_occultation_ring_profile
+;+		(comment "The has_occultation_ring_profile association is a relationship to occultation_ring_profile")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot has_Field_LIDVID
+;+		(comment "The has_Field_LIDVID association is a relationship to an LIDVID.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot product_creation_time
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot status
+;+		(comment "The status attribute indicates the condition of an object.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot checksum
-;+		(comment "The checksum attribute provides a computed value which depends on the contents of a block of data and is used to detect corruption of the data.")
+	(multislot observation_area
+;+		(comment "The observation_area association is a relationship to Observation_Area.")
+		(type INSTANCE)
+;+		(allowed-classes Context_Area)
+		(create-accessor read-write))
+	(multislot source
+;+		(comment "The bibliographic_reference association is a relationship to bibliographic reference.")
+		(type INSTANCE)
+;+		(allowed-classes External_Reference_Extended)
+		(create-accessor read-write))
+	(multislot maximum_observed_ring_azimuth
+;+		(comment "maximum_observed_ring_azimuth specifes the largest value for observed_ring_azimuth in the data file. Values range from 0 to 360 in units of degrees. Required in label files for ring occultation data.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot supported_operating_system_note
+;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Display_2d_Image
+;+		(comment "The has_Display_2d_Image association is a relationship to Display_2d_Image.")
+		(type INSTANCE)
+;+		(allowed-classes Display_2D_Image)
+		(create-accessor read-write))
+	(single-slot horizontal_display_axis
+;+		(comment "The horizontal_display_axis attribute identifies, by name, the axis of an Array %28or Array subclass%29 that is intended to be displayed in the horizontal or 'sample' dimension on a display device. The value of this attribute must match the value of one, and only one, axis_name attribute in an Axis_Array class of the associated Array.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot bound_character
+;+		(comment "bound-character = non-quote-character  |  quote ; The bound-characters, and the escape character, are required in any implementation to be associated with particular members of the implementation character set. - A bound-character is required to be associated with the member having the corresponding symbol, if any, in any implementation character-set derived from ISO/IEC 10646.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot Vz
-;+		(comment "The Vz attribute provides the value of the z coordinate in a velocity vector.")
+	(multislot high_instrument_saturation
+;+		(comment "The high_instrument_saturation attribute specifies a special value whose presence indicates the measuring instrument was saturated at the high end. The value must be less than the value of the valid_minimum attribute or more than the value of the valid_maximum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_tagged_data_object2
+;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot fields
+;+		(comment "The fields attribute provides a count of the total number of scalar fields directly associated with a table record.  Fields within groups within the record are not included in this count.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot center_latitude
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot product_id
+;+		(comment "The product id attribute provides a product identifier that is unique within an archive collection.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot start_bit_location
+;+		(comment "The start_bit_location attribute provides the position of the first bit in a bit field relative to the first bit in the parent packed data field. Bytes are sequential and bits are numbered continuously across byte boundaries within a single bit field. The first bit position in the packed data field is \"1\".")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot skos_relation_name
+;+		(comment "The attribute skos_relation_name provides a meaning of the relationship between two associated terms.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot confidence_level_note
+;+		(comment "The confidence_level_note attribute is a text field which characterizes the reliability of data within a data set or the reliability of a particular programming algorithm or software component. Essentially, this note discusses the level of confidence in the accuracy of the data or in the ability of the software to produce accurate results.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot mapping_type
+;+		(comment "The mapping type attribute indicates how two terms are related to each other.")
+		(type STRING)
+;+		(value "pds4_attribute_replaces_pds3_attribute" "pds4_attribute_replaces_pds4_attribute" "pds4_attribute_replaces_column" "pds4_attribute_replacedby_term")
+		(create-accessor read-write))
+	(multislot minimum_sampling_parameter
+;+		(comment "The minimum_sampling_parameter element identifies the minimum value at which a given data item was sampled. For example, a spectrum that was measured in the 0.4 to 3.5 micrometer spectral region would have a minimum_sampling_parameter value of 0.4. The sampling parameter constrained by this value is identified by the sampling_parameter_name element. Note: The unit of measure for the sampling parameter is provided by the unit element.")
 		(type FLOAT)
 		(create-accessor read-write))
-	(multislot funding_source
-;+		(comment "The funding_source attribute provides the identifier for an agency or other entity that provided financial assistance in the poroduction of the archival data.")
+	(single-slot upperleft_corner_x
+;+		(comment "The upperleft_corner_x and upperleft_corner_y attributes provide the projection x and y values, in meters, relative to the map projection origin, at sample 0.5 and line 0.5 (upper left corner of pixel 1,1 within image array).")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot upperleft_corner_y
+;+		(comment "The upperleft_corner_x and upperleft_corner_y attributes provide the projection x and y values, in meters, relative to the map projection origin, at sample 0.5 and line 0.5 (upper left corner of pixel 1,1 within image array).")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot campaign_description
+;+		(comment "The campaign description attribute provides a statement, picture in words, or account that describes.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot default_blue
+;+		(comment "The default_blue attribute provides the number of the plane along the axis that is to be loaded, by default, into the blue plane of a display device.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot constant_value
+;+		(comment "The constant value attribute provides the value to be used if an attribute is static.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot value_domain_external
+		(type INSTANCE)
+;+		(allowed-classes DD_Value_Domain)
+		(create-accessor read-write))
+	(multislot minimum_observed_ring_elevation
+;+		(comment "minimum_observed_ring_elevation specifes the smallest value for observed_ring_elevation in the data file. Only used if the value is not constant over the observation. Values range from -90 to %2B90 in units of degrees. Not intended for use in the data file.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot axis_name
+;+		(comment "The axis_name attribute provides a word or combination of words by which the axis is known.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot spcs_zone_identifier
+;+		(comment "The spcs_zone_identifier attribute identifies the SPCS zone.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot sampling_parameter_interval
+;+		(comment "The sampling_parameter_interval attribute provides the spacing of points at which data are sampled and at which values for an instrument or other parameter are available. If x1 and xn are the first and last sampling parameter values, respectively, xn is larger than x1, n is the number of sampling parameters, the caret symbol (^) denotes exponentiation, and b, a positive real number, is the base for exponentiation, then the value of sampling_parameter_interval is: (xn-x1)/(n-1) (for sampling_parameter_scale = Linear), (xn/x1)^(1/(n-1)) (for sampling_parameter_scale = Logarithmic), (b^xn-b^x1)/(n-1) (for sampling_parameter_scale = Exponential).")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot has_Field_File_Specification_Name
+;+		(comment "The has_Field_File_Specification_Name association is a relationship to Field_File_Specification_Name.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot sample_bit_mask
+;+		(comment "The sample_bit_mask attribute identifies the active bits in a sample. Note:  In the PDS, the domain of sample_bit_mask is dependent upon the currently-described value in the sample_bits attribute and only applies to integer values. For an 8-bit sample where all bits are active the sample_bit_mask would be 2#11111111#.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot reference_text
+;+		(comment "The reference_text attribute provides a complete bibliographic citation for a published work.")
 		(type STRING)
 		(create-accessor read-write))
 	(multislot Vx
@@ -2078,1133 +1692,172 @@
 ;+		(comment "The Vy attribute provides the value of the y coordinate in a velocity vector.")
 		(type FLOAT)
 		(create-accessor read-write))
+	(single-slot scaling_factor
+;+		(comment "The scaling_factor attribute is the scaling factor to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 1.")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot Vz
+;+		(comment "The Vz attribute provides the value of the z coordinate in a velocity vector.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot campaign_name
+;+		(comment "The campaign name attribute provides a word or a combination of words by which a campaign is designated, called, or known.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot UpperModel_180912x_1B00_Prov_Class5
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot target_desc
+;+		(comment "The target_desc attribute describes the characteristics of a particular target.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Table_Field_Grouped
+;+		(comment "The has_Table_Field_Grouped association is a relationship to the field types for a group.")
+		(type INSTANCE)
+;+		(allowed-classes Field_Binary Field_Bit)
+		(create-accessor read-write))
 	(multislot file_area_supplemental
 ;+		(comment "The file_area_supplemental association is a relationship to File Area Supplemental.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot bytes
-;+		(comment "The bytes attribute provides the number of bytes in the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot objectives_summary
-;+		(comment "The objectives_summary attribute describes the scientific objectives of an investigation")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot maximum_field_length
-;+		(comment "The maximum_field_length attribute sets an upper, inclusive bound on the number of bytes in the field.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(single-slot pds_version_id
-;+		(comment "The pds version id provides a formal name used to refer to a version of the PDS standards.")
-		(type STRING)
-;+		(value "PDS4.0")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot map_scale
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot logical_identifier
-;+		(comment "The logical_identifer attribute identifies the set of all versions of a product; it is a product identifier without a version.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot map_resolution
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot mission_name
-;+		(comment "The mission_name attribute identifies a major planetary mission or project. A given planetary mission may be associated with one or more spacecraft.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot upper_111230e_Class0
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot contained_product_reference
-;+		(comment "The contained product reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a product being packaged.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot map_projection_name
-;+		(comment "The map_projection_name attribute provides the name of the map projection.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot maximum_radial_sampling_interval
-;+		(comment "maximum_radial_sampling_interval indicates the smallest radial spacing between consecutive points in a ring profile. In practice, this may be somewhat smaller than the radial_resolution because a profile may be over-sampled. If the value of radial_sampling_interval varies, the minimum and maximum attributes are required in labels. Not intended to be used as a table field.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot character_literal
-;+		(comment "character-literal = apostrophe, any-character, apostrophe ; any-character = bound-character | added-character | escape-character ; escape-character = escape, character-name, escape ; character-name = identifier, { \" \", identifier } ;")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot associated_Coordinate_System
-;+		(comment "The associated_Coordinate_System association is a relationship to Coordinate System.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot id_reference
-;+		(comment "The id_reference provides the identifier of an object in a one  directional relationship.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot source_product_external
-;+		(comment "The source_product_external association is a relationship to Source Product External.")
-		(type INSTANCE)
-;+		(allowed-classes Source_Product_External)
-		(create-accessor read-write))
-	(multislot has_Table_Character_Field_Sequence
-;+		(comment "The has_Table_Character_Field_Sequence association is a relationship to field sequence.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot file_area_LID_Secondary
-;+		(comment "The file_area association is a relationship to File Area")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot targetclass_name
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Document_Section
-;+		(comment "The has_Document_Section association is a relationship to Document Sections.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot definition
-;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot volume_insert_text
-;+		(comment "This attribute is used in by the volume class. It is under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot file_size
-;+		(comment "The file_size attribute provides the size of the file.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(single-slot used
-		(type INSTANCE)
-;+		(allowed-classes Methods Config Input_Data)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot coordinate_system_type
-;+		(comment "This attribute is used in the image map projection. Under review. xxx E. RYE;DS xxx")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot elements
-;+		(comment "The elements attribute provides the count of the number of elements along an array axis.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot update_purpose
-;+		(comment "The update purpose attribute indicates the intended objective of this update.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot subscription_id
-;+		(comment "The subscriber_id provides the identification of a PDS subscription.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot release_medium
-;+		(comment "This attribute is used in by the data set release class. It is under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot affiliation_type
-;+		(comment "The affiliation type attribute describes the type of relationship an individual has with the PDS.  Individuals with PDS affiliations are generally listed in the PDS Phone Book.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot campaign_end_date
-;+		(comment "The campaign end date attribute provides the date when a campaign was completed.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot registration_authority_id
-;+		(comment "The registration_authority_id attribute provides the name of the organization that registered the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot terminological_entry
-;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
-		(type INSTANCE)
-;+		(allowed-classes Terminological_Entry)
-		(create-accessor read-write))
-	(multislot wavelength
-;+		(comment "wavelength of the observation. Optional in labels. If the observation is over a wavelength range, use the corresponding minimum and maximum attributes instead.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot refer_Context
-;+		(comment "This attribute is used in by the volume class. It is under review.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot facility_name
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot valid_maximum
-;+		(comment "The valid_maximum attribute specifies the maximum valid value in the field or digital object with which the Special_Constants class is associated. Values above the valid_maximum have a special meaning. Values of this attribute should be represented in the same data_type as the elements in the object or field described. (Note that PDS3 had no qube-related valid_maximum values because all special constants were set below the valid_minimum.)")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot has_identification_area
-;+		(comment "The has_identification_area association is a relationship to Identification Area.")
-		(type INSTANCE)
-;+		(allowed-classes Identification_Area)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_Band_Bin_Set
-;+		(comment "The has_Band_Bin_Set association is a relationship to Band_Bin_Set.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot longitude
-;+		(comment "The longitude attribute provides the angular distance east or west on the object's surface, measured by the angle contained between the meridian of a particular place and some prime meridian.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot registration_authority
-;+		(comment "The registration_authority attribute provides the name of the group  responsible for the terminological entry.")
-		(type STRING)
-;+		(value "PDS4" "PDS3" "VICAR")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot instrument_reference
-;+		(comment "The instrument  reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier")
-		(create-accessor read-write))
-	(multislot instrument_host_name
-;+		(comment "The instrument_host_name attribute provides the full name of the platform or facility upon which an instrument or other device is mounted. For example, the host can be a spacecraft, a ground-based telescope, or a laboratory.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot naif_instrument_id
-;+		(comment "The naif_instrument_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot collected_in
-;+		(comment "The collected_in association is a relationship to data set.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot nillable_flag
-;+		(comment "The nillable_flag attribute indicates whether an attribute is allowed to take on nil as a value.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot product_id
-;+		(comment "The product id attribute provides a product identifier that is unique within an archive collection.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot polar_radius
-;+		(comment "The polar_radius attribute provides the value of the semiminor axis of the ellipsoid that defines the approximate shape of a target body. The polar radius is normal to the plane defined by the semi-major and semi-minor axes.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot telescope_latitude
-;+		(comment "The telescope_latitude attribute provides the angular distance of the telescope north (positive) from the equator, measured on the meridian of the telescope.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot sclk_stop_time
-;+		(comment "sclk_stop_time is the value of the spacecraft clock corresponding to the stop_date_time given in the label.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot product_data_object
-;+		(comment "The product_data_object association is a relationship to a data object.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot collection_reference_a
-;+		(comment "The collection reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot low_instrument_saturation
-;+		(comment "The low_instrument_saturation attribute specifies a special value whose presence indicates the measuring instrument was saturated at the low end. The value must be less than the value of the valid_minimum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot element_bytes
-;+		(comment "The element_bytes attribute provides the  number of bytes in the array element.")
+	(single-slot expected_packets
+;+		(comment "The expected_packets attribute provides the total number of telemetry packets which constitute a complete data product, i.e., a data product without missing data.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Data_Brick_Sequence
-;+		(comment "The has_Data_Brick_Sequence association is a relationship to data brick.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(multislot standard_id
-;+		(comment "The standard_id attribute provides the formal name of an established norm or requirement.")
+	(multislot source_pds3_id
+;+		(comment "source_pds3_id is the PDS3 product identifier for the source product. If the source product has been archived under PDS4, use the Internal_Reference class in the Investigation_Area. source_pds3_id is constructed as PDS3 dataset_id, a colon, then the PDS3 product_id. The acceptable nil_reasons are 'inapplicable' and 'unknown'.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot has_type_list_entry
-;+		(comment "The has_type_list_entry association is a relationship to Type_List_Entry")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot archive_status
-;+		(comment "The ARCHIVE_STATUS attribute indicates the stage to which a data set has progressed in the archiving process, from IN QUEUE through ARCHIVED. It can also take on the values SUPERSEDED or SAFED, which indicate that the data set is not part of the active archive. ACCUMULATING can be appended to some values to indicate that the data set is incomplete and/or that not all components have reached the stage given by the root value; ACCUMULATING would be used, for example, when the archive is being delivered incrementally, as from a mission that lasts many months or years.")
-		(type STRING)
-;+		(value "ARCHIVED" "IN_LIEN_RESOLUTION" "IN_PEER_REVIEW" "IN_QUEUE" "LOCALLY_ARCHIVED" "PRE_PEER_REVIEW" "SAFED" "SUPERSEDED" "IN_QUEUE_ACCUMULATING" "PRE_PEER_REVIEW_ACCUMULATING" "IN_PEER_REVIEW_ACCUMULATING" "IN_LIEN_RESOLUTION_ACCUMULATING" "LOCALLY_ARCHIVED_ACCUMULATING" "ARCHIVED_ACCUMULATING")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot dictionary_id
+	(single-slot upper_110917_Class1
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot rule_description
-;+		(comment "The rule_description attribute provides a description of the rule statement suitable for  user documentation.")
+	(multislot record_delimiter
+;+		(comment "The record_delimiter attribute provides the character or characters used to indicate the end of a record.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot observed_event_start_time_utc
-;+		(comment "observed_event_start_time_utc indicates the UTC value for earliest time in the described data. It is part of a start/stop pair. If one of observed_event_start_time_utc and observed_event_stop_time_utc is used, both must be used.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot lidvid_refernce_to
-;+		(comment "The lidvid_refernce_to provides the identifier of the ending object in a  one directional relationship.")
-		(type INSTANCE)
-;+		(allowed-classes LIDVID_ID_Reference_To)
-		(create-accessor read-write))
-	(single-slot start_date_time
-;+		(comment "The start_date_time attribute provides the date and time at the beginning of a time interval of interest.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot aip_label_checksum
-;+		(comment "The aip_label_checksum attribute provides the checksum for the Archival Information Package label.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot refer_directory
-;+		(comment "This attribute is used in by the volume class. It is under review.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot has_image_2d_display
-;+		(comment "The has_image_2d_display association is a relationship to Image_2D_Array.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot green_channel_band
-;+		(comment "The green_channel_band attribute identifies the number of the band, along the band axis, that should be loaded, by default, into the green channel of a display device. The first band along the band axis has band number 1.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot alternate_designation
-;+		(comment "The alternate_designation attribute provides a known alternate name or identifier.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot calibration_reference
-;+		(comment "The calibration reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier::version_id")
-		(create-accessor read-write))
-	(multislot object_length
-;+		(comment "The object_length attribute provides the length of the digital object in bytes.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(single-slot pixel_scale_y
-;+		(comment " The pixel_scale_x and pixel_scale_y attributes indicate the image array pixel scale %28pixel%2Fdegree or pixel%2Fdistance%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y scale values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where scale may differ for each axis %28%47rectangular%47 pixels%29. NOTE1: For presentation of hard-copy maps, a map scale is traditionally expressed as a %47representative fraction%47 %28the ratio of a hard-copy map to the actual subject surface %28e.g. 1:250,000, where one unit of measure on the map equals 250,000 of the same unit on the body surface%29%29. This usage is relevant when map%2Fdata are presented on hard-copy media %28paper, computer screen,etc%29. When defining pixel scale within a stored image%2Farray context here, we are expressing a ratio between the image array and the actual surface %28thus, pixel%2Fdegree or pixel%2Fdistance units%29. NOTE2: Definition of this PDS4 attribute differs from how %47scale%47 was defined within PDS3 ")
+	(single-slot oblique_line_longitude
+;+		(comment "The oblique_line_longitude attribute provides the longitude of a point defining the oblique line.")
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot pixel_scale_x
-;+		(comment " The pixel_scale_x and pixel_scale_y attributes indicate the image array pixel scale %28pixel%2Fdegree or pixel%2Fdistance%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y scale values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where scale may differ for each axis %28%47rectangular%47 pixels%29. NOTE1: For presentation of hard-copy maps, a map scale is traditionally expressed as a %47representative fraction%47 %28the ratio of a hard-copy map to the actual subject surface %28e.g. 1:250,000, where one unit of measure on the map equals 250,000 of the same unit on the body surface%29%29. This usage is relevant when map%2Fdata are presented on hard-copy media %28paper, computer screen,etc%29. When defining pixel scale within a stored image%2Farray context here, we are expressing a ratio between the image array and the actual surface %28thus, pixel%2Fdegree or pixel%2Fdistance units%29. NOTE2: Definition of this PDS4 attribute differs from how %47scale%47 was defined within PDS3 ")
-		(type FLOAT)
-;+		(cardinality 1 1)
+	(multislot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
+		(type STRING)
 		(create-accessor read-write))
-	(single-slot spice_file_name
-;+		(comment "The spice_file_name attribute provides the names of the SPICE files used in processing the data.")
+	(single-slot acknowledgement_text
+;+		(comment "The acknowledgement_text attribute is a character string which recognizes another's contribution, authority, or right.")
 		(type STRING)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot file_extension_token
-;+		(comment "The file extension token is a substring that provides a file extension. The maximum size of a directory name is tbd characters.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot telescope_altitude
-;+		(comment "The telescope_altitude attribute provides the height of the telescope above a plane tangent to the reference figure (or datum) at the telescope location.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot west_bounding_coordinate
-;+		(comment "The west_bounding_coordinate attribute provides the western-most coordinate of the limit of coverage expressed in longitude.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot grid_coordinate_system_name
-;+		(comment "The grid_coordinate_system_name attribute provides the name of the grid coordinate system.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_Delivery_Manifest_Entry
-;+		(comment "The has_Delivery_Manifest_Entry association is a relationship to delivery manifest entry.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(multislot sample_display_direction
-;+		(comment "The sample_display_direction attribute provides the preferred orientation of samples within a line for viewing on a display device. The default is right, meaning samples are viewed from left to right on the display. sample_display_direction must be used with line_display_direction.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot os_version
-;+		(comment "The OS version attribute indicates the version of an operating system.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot reference_time_utc
-;+		(comment "reference_time_utc provides a date and time in UTC format. Given in a label when time values in a table are given as elapsed seconds offset from a reference time. Unless there are compelling reasons to do otherwise, reference_time_utc should correspond to the start of a day. Required anytime a table field is given relative to a specific date and time other than when Barycentric Dynamical Time is used (e.g., observed_event_tdb).")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot semi_minor_radius
-;+		(comment "The semi_minor_radius attribute provides the value of the intermediate axis of the ellipsoid that defines the approximate shape of a target body. The semi-minor axis is usually in the equatorial plane.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot sequence_class
-;+		(comment "Housekeeping.")
-		(type INSTANCE)
-;+		(allowed-classes Physical_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot has_Discipline_Facets
-;+		(comment "The has_Discipline_Facets association is a relationship to Discipline_Facets.")
-		(type INSTANCE)
-;+		(allowed-classes Discipline_Facets)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot vertical_display_axis
-;+		(comment "The vertical_display_axis attribute identifies, by name, the axis of an Array %28or Array subclass%29 that is intended to be displayed in the vertical or 'line' dimension on a display device. The value of this attribute must match the value of one, and only one, axis_name attribute in an Axis_Array class of the associated Array.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot refer_file
-;+		(comment "This attribute is used in by the volume class. It is under review.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot continuous_loop_flag
-;+		(comment "The continuous_loop_flag attribute indicates whether or not to keep replaying a movie.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot software_language
-;+		(comment "The software language attribute identifies the language used to write the software.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot dsn_station_number
-;+		(comment "dsn_station_number identifies the receiving DSN station. Required in labels for radio occultations; not used for stellar occultations. Nillable in which case the nil_reason should be 'inapplicable'.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot has_Delimited_Field_Grouped
-;+		(comment "The has_Delimited_Field_Grouped association is a relationship to the field types for a group.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot digit
-;+		(comment "digit = \"0\" | \"1\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" ;")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot date_time
-;+		(comment "The date_time attribute provides the date and time of an event.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot context_reference
-;+		(comment "The context reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot resource_reference
-;+		(comment "The resource reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier")
-		(create-accessor read-write))
-	(single-slot sort_name
-;+		(comment "The sort name attribute provides a string to be used in ordering. For people, the last name (surname) is typically first, followed by a comma and then other names.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot member_table
-;+		(comment "Associated table of member references.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot attribute_name
-;+		(comment "The attribute_name attribute provides the common name by which an attribute is known.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot record_length
-;+		(comment "The record_length attribute provides the length of a record, including a record delimiter if present.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot sclk_start_time
-;+		(comment "sclk_start_time is the value of the spacecraft clock corresponding to the start_date_time given in the label.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot steward_id
-;+		(comment "The steward_id attribute provides the abbreviation of the organization that manages the set of registered attributes and classes.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot relates_to_data_set
-;+		(comment "Associated data set.")
-		(type INSTANCE)
-;+		(allowed-classes Data_Set_PDS3)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot xml_schema_collection_reference
-;+		(comment "The xml schema collection reference attribute provides the logical_identifier for a xml schema collection.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot transfer_manifest_checksum
-;+		(comment "The transfer manifest checksum provides the checksum for the transfer manifest file.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot designation
-;+		(comment "The designation attribute provides a name for the term in the language selected.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot external_reference_extended
-;+		(comment "The external_reference_extended association is a relationship to external_reference_extended.")
-		(type INSTANCE)
-;+		(allowed-classes External_Reference_Extended)
-		(create-accessor read-write))
-	(multislot quaternion_components
-;+		(comment "The quaternion_components attribute provides a count of quaternion components.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot file_specification_name
-;+		(comment "The file_specification_name attribute provides the file_name prepended by the directory_path to the file.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot member_reference
-;+		(comment "The member reference attribute provides a identifier for a member.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot address
-;+		(comment "The address attribute provides a mailing address.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot domain
-;+		(comment "The radial ‘zone’ or ‘shell’ of the target for which the observations were collected or which are represented in the product(s).  The value may depend on wavelength_range and size of the target.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot was_generated_by
-		(type INSTANCE)
-;+		(allowed-classes Activity)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot has_Data_Object
-;+		(comment "The has_Data_Object association is a relationship to Data Object.")
-		(type INSTANCE)
-;+		(allowed-classes Data_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot spacecraft_event_start_time_utc
-;+		(comment "spacecraft_event_start_time_utc gives the UTC time corresponding to the earliest time given by spacecraft_event_time in the data table. However, while spacecraft_event_time is given as seconds offset from a reference time, spacecraft_event_start_time_utc is given as a UTC date time. Required in the label for radio occultation data. Not used for stellar occultations.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot reference_value_type
-;+		(comment "The reference_value_type attribute indicates whether the reference value is a logical_identifier or logical identifier plus a version_id.")
-		(type STRING)
-;+		(value "LID" "LID::VID")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot has_time_coordinates
-;+		(comment "The has_time_coordinates association is a relationship to Time_Coordinates.")
-		(type INSTANCE)
-;+		(allowed-classes Time_Coordinates)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot thumbnail_reference
-;+		(comment "The thumbnail reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier")
-		(create-accessor read-write))
-	(multislot has_observing_system
-;+		(comment "The has_observing_system association is a relationship to Observing_System.")
-		(type INSTANCE)
-;+		(allowed-classes Observing_System)
-		(create-accessor read-write))
-	(multislot maximum_observed_ring_elevation
-;+		(comment "maximum_observed_ring_elevation specifes the largest value for observed_ring_elevation in the data file. Only used if the value is not constant over the observation. Values range from -90 to %2B90 in units of degrees. Not intended for use in the data file.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot manifest_url
-;+		(comment "The manifest url provides the URL to the manifest file.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot conceptual_domain
-;+		(comment "The conceptual_domain attribute provides the domain to which the value has been assigned.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot target_type
-;+		(comment "The target_type attribute identifies the type of a named target.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot minimum_wavelength
-;+		(comment "minimum_wavelength is the smallest wavelength used in the observation. Optional in labels. Used with maximum_wavelength when the observation is over a wavelength range.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot curating_facility
-;+		(comment "The curating_facility attribute provides a unique name or identifier for the curating facility maintaining the source product.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_occultation_ring_profile
-;+		(comment "The has_occultation_ring_profile association is a relationship to occultation_ring_profile")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot has_Spatial_Domain
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes)
 		(create-accessor read-write))
 	(multislot associated_Header
 ;+		(comment "The associated_Header association is a relationship to header.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot replicate
-;+		(comment "The replicate attribute indicates whether the object is replicated.")
-		(type SYMBOL)
-		(allowed-values FALSE TRUE)
+	(single-slot maximum_latitude
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot has_geometry
-;+		(comment "The has_geometry association is a relationship to Geometry objects.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot local_reference_type
-;+		(comment "The local_reference_type attribute provides the name of an association between an entity identified by a local_identifier_reference and another corresponding entity identified by a local_identifier. The values for the local_reference_type are expected to be enumerated for appropriate contexts in the Schematron files of local (i.e., discipline and mission) data dictionaries.")
+	(multislot spacecraft_clock_count_partition
+;+		(comment "The spacecraft_clock_count_partition attribute provides the clock partition active for spacecraft_clock_start_count and spacecraft_clock_stop_count.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot quaternion_component
-;+		(comment "The quaternion_component association is a relationship to Quaternion_Component.")
+	(multislot distributed_by
+;+		(comment "The Nodes distributing the data set.")
 		(type INSTANCE)
-;+		(allowed-classes Quaternion_Component)
+;+		(allowed-classes)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(multislot subfacet2
-;+		(comment "The subfacet2 attribute provides a sub-categorization under the facet2 value.  The allowed values are restricted according to the value of facet2.")
+	(multislot earth_received_start_time_utc
+;+		(comment "earth_received_start_time_utc gives the UTC time corresponding to the earliest time for the data product at which telemetry or other photons were received on Earth. Optional for occultation data.")
 		(type STRING)
-		(create-accessor read-write))
-	(multislot subfacet1
-;+		(comment "The subfacet1 attribute provides a sub-categorization under the facet1 value.  The allowed values are restricted according to the value of facet1.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot associated_distributing_node
-;+		(comment "The associated_distributing_node association is a relationship to Nodes.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot has_Gazetteer_Column
-;+		(comment "The has_Gazetteer_Column association is a relationship to gazetteer column.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(cardinality 20 20)
-		(create-accessor read-write))
-	(single-slot kernel_type
-;+		(comment "The kernel_type attribute identifies the type of SPICE kernel.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot publication_date
-;+		(comment "The publication_date attribute provides the date on which an item was published.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot line_first_pixel
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot c_axis_radius
-;+		(comment "This attribute is used in the image map projection. Under review. xxx DDWG;DS xxx Also check why minimum value is negative.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot telemetry_provider_id
-;+		(comment "The telemetry_provider_id attribute identifies the provider and or version of the telemetry data used in the generation of this data.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot product_description
-;+		(comment "Description at the identifiable layer.")
-		(type INSTANCE)
-;+		(allowed-classes Tagged_NonDigital_Object Tagged_Digital_Object)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot image_id
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot start_orbit_number
-;+		(comment "The start_orbit_number attribute provides the first in a series of numbers that represent a set of orbital revolutions of one body around another.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot document_name
-;+		(comment "The document_name attribute provides the full name of the published document. This optional attribute is used only if the title in the identification area of the document product is not sufficient.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot maximum_scaled_value
-;+		(comment "The maximum_scaled_value attribute provides the maximum value after application of scaling_factor and value_offset (see their definitions; maximum_scaled_value is the maximum of Ov).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot primary_collection_reference
-;+		(comment "The primary collection reference provides a logical_identifier for  the primary collection this product is a member of.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot map_projection_desc
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_mission_area
-;+		(comment "The has_mission_area association is a relationship to Mission Area.")
-		(type INSTANCE)
-;+		(allowed-classes Mission_Area)
-		(create-accessor read-write))
-	(single-slot south_bounding_coordinate
-;+		(comment "The south_bounding_coordinate attribute provides the southern-most coordinate of the limit of coverage expressed in latitude.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot frame_rate
-;+		(comment "The frame_rate attribute provides the time, in specified units, between frames for display of a movie.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot was_informed_by
-;+		(comment "The was_informed_by association is a recursive relationship on activity.")
-		(type INSTANCE)
-;+		(allowed-classes Activity)
-		(create-accessor read-write))
-	(multislot minimum_value_exclusive_flag
-;+		(comment "The minimum_value_exclusive_flag attribute indicates that the  minimum_value is exclusive, when true.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Property_Map_Entry
-;+		(comment "The has_Property_Map_Entry association is a relationship to property map entry.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot brick_identifier
-;+		(comment "The identifier of the data brick – Best practice is to use the data brick serial number.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot product_subclass
-;+		(comment "The product_subclass attribute provides the name of a subclass under a product_class. For example, User_Manual is a subclass of Product_Document.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot stop_time
-;+		(comment "The stop_time element provides the date and time of the end of an observation or event (whether it be a spacecraft, ground-based, or system event) in UTC.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot first_line
-;+		(comment "The first_line attribute provides the line within a source image that corresponds to the first line in a sub-image.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot along_track_timing_offset
-;+		(comment "along_track_timing_offset is a timing offset to the along track spacecraft position. It is the value that minimizes differences in radii of matching circular ring features observed on the ingress and egress sides of the occultation track. Optional in labels for radio occultation. Nillable in which case the nil_reason should be 'inapplicable'. ")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot radial_sampling_interval
-;+		(comment "radial_sampling_interval indicates the radial spacing between consecutive points in a ring profile. In practice, this may be somewhat smaller than the radial_resolution because a profile may be over-sampled. Required in labels if the value is fixed. If the value varies, the corresponding minimum and and maximum attributes must be used instead. Not intended to be used as a table field.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot bit_string
-;+		(comment "The bit string attribute is a sequence of digital bits. It is the content of a digital object.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot preferred_flag
-;+		(comment "The preferred_flag indicates whether this entry is  preferred over all other entries.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot resource_logical_identifier
-;+		(comment "The resource logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
-		(type STRING)
-		(default "logical_identifier")
-		(create-accessor read-write))
-	(multislot observed_event_stop_time_utc
-;+		(comment "observed_event_stop_time_utc indicates the UTC value for latest time in the described data. It is part of a start/stop pair. If one of observed_event_start_time_utc and observed_event_stop_time_utc is used, both must be used.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot local_attribute
-;+		(comment "The local_attribute association is a relationship to Local_Attribute.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot alternate_id
-;+		(comment "The alternate_id attribute provides an additional identifier supplied by the data provider.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_document_edition
-;+		(comment "The has document edition association is a relationship to Document Edition.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot maximum
-;+		(comment "The maximum attribute provides the largest stored value which actually appears; empty and Special_Constant field values are excluded.")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot transfer_command_text
-;+		(comment "This attribute is used in by the volume class. It is under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot rule_context
-;+		(comment "The rule_context attribute provides the xpath for the rule.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot instrument_version_id
-;+		(comment "The Instrument_Version_Id element identifies the specific model of an instrument used to obtain data. For example, this keyword could be used to distinguish between an engineering model of a camera used to acquire test data, and a flight model of a camera used to acquire science data during a mission.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot instrument_logical_identifier
-;+		(comment "The instrument logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot install_note
-;+		(comment "The install note attribute provides a brief statement giving particulars about the installation of the software.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot map_projection_rotation
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot first_element
-;+		(comment "The first element attribute indicates the position of the first element of an array.")
-		(type STRING)
-;+		(value "TOPLEFT")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot horizontal_display_axis
-;+		(comment "The horizontal_display_axis attribute identifies, by name, the axis of an Array %28or Array subclass%29 that is intended to be displayed in the horizontal or 'sample' dimension on a display device. The value of this attribute must match the value of one, and only one, axis_name attribute in an Axis_Array class of the associated Array.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot min_index
-;+		(comment "The min index attribute provides a value that indicates the position of the element at the beginning of a sequence of elements. This value is typically 0 or 1.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot character_encoding
-;+		(comment "The character_encoding attribute identifies the standard that maps a set of allowed characters to their machine readable code.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot data_set_reference
-;+		(comment "Association for additional information.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot software_format_set
-;+		(comment "The software_format_set association is a relationship to a set of one or more software formats.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot campaign_name
-;+		(comment "The campaign name attribute provides a word or a combination of words by which a campaign is designated, called, or known.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot rotational_element_desc
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot target_logical_identifier
-;+		(comment "The target logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot field_unit
-;+		(comment "The field unit attribute indicates the unit of measurement associated with a field value.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot node_manager_puid
-;+		(comment "The node manager puid attribute indicates the node manager.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Group_Field_Binary
-;+		(comment "The has_Group_Field_Binary association is a relationship to the Group_Field_Binary.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot processing_level
-;+		(comment "The processing_level attribute provides a broad classification of data processing level.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot total_digits
-;+		(comment "The total digits attribute indicate the maximum count of digits allowed.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_Oblique_Line_Point_Group
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot referenced_identifier
-;+		(comment "The referenced identifier attribute provides the identifier of the entify being referenced.")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot has_Group_Field_Character
 ;+		(comment "The has_Group_Field_Character association is a relationship to the Group_Field_Character.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot has_discipline_area
-;+		(comment "The has_discipline_area association is a relationship to Discipline Area.")
-		(type INSTANCE)
-;+		(allowed-classes Discipline_Area)
-		(create-accessor read-write))
-	(multislot dd_association
-;+		(comment "The local_association_attribute association provides a relationship to an attribute.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot local_class
-;+		(comment "The local_class association is a relationship to Local_Class.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot records
-;+		(comment "The records attribute provides a count of records.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot classSteward
-;+		(comment "The classSteward attribute provides the name of the steward for this rule.")
+	(multislot instrument_puid
+;+		(comment "The instrument_puid attribute provides a globally unique identifer for an instrument.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot referenced_object_type
-;+		(comment "The reference object type attribute indicates the type of the object being referenced.")
+	(multislot element_flag
+;+		(comment "The element flag attribute indicates whether or not the class is defined as a xs:element in XML Schema.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot has_property_map
-;+		(comment "The has_property_map association is a relationship to Property_Map.")
-		(type INSTANCE)
-;+		(allowed-classes)
+	(multislot earth_received_stop_time_utc
+;+		(comment "earth_received_stop_time_utc gives the UTC time corresponding to the latest time for the data product at which telemetry or other photons were received on Earth. Optional for occultation data.")
+		(type STRING)
 		(create-accessor read-write))
-	(multislot minimum_observed_ring_elevation
-;+		(comment "minimum_observed_ring_elevation specifes the smallest value for observed_ring_elevation in the data file. Only used if the value is not constant over the observation. Values range from -90 to %2B90 in units of degrees. Not intended for use in the data file.")
-		(type FLOAT)
+	(multislot node_manager_puid
+;+		(comment "The node manager puid attribute indicates the node manager.")
+		(type STRING)
 		(create-accessor read-write))
-	(multislot associated_descriptive_files
-;+		(comment "The associated_descriptive_files association is a relationship to description files.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot namespace_id
-;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
+	(single-slot unknown_constant
+;+		(comment "The unknown_constant attribute provides a value that indicates the original value was unknown.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot abstract_desc
-;+		(comment "The abstract desc attribute provides a summary of a text, scientific article, or document.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot member_type
-;+		(comment "The member_type attribute indicates the type of member references that  are provided.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Delimited_Field
-;+		(comment "The has_Delimited_Field association is a relationship to field.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot specified_unit_id
-;+		(comment "The specified_unit_id attribute provides the unit chosen for maximum_value, minimum_value, and permissible_value.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot telescope_longitude
-;+		(comment "The telescope_longitude attribute provides the angular distance of the telescope east (positive), measured by the angle contained between the meridian of the telescope and the reference figure (or datum) prime meridian.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot upper_120127c_Class0
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot programmers_manual_id
-;+		(comment "The programmers manual id attribute provides an identifier to a document giving instruction about the programming of the software.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_Character_Field
-;+		(comment "The has_Character_Field association is a relationship to the field types.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot optional_data_object_set
-;+		(comment "Associated optional data object set.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot logical_volume_path_name
-;+		(comment "This attribute is used in by the volume class. It is under review.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot planet_day_number
-;+		(comment "The planet_day_number attribute provides the number of solar days (sols) on a rotating solar system body since a reference event, such as the landing of a spacecraft. The day of landing is usually defined as planet_day_number=0.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot application_process_id
-;+		(comment "The application_process_id attribute identifies the process, or source, which created the data.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot vector_components
-;+		(comment "The vector_components attribute provides a count of vector components.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot has_Map_Projection
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes XSChoice%23)
-		(create-accessor read-write))
-	(multislot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot second_standard_parallel
+	(single-slot rotational_element_desc
 ;+		(comment "This attribute is used in the image map projection. Under review.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot reference_association_type
-;+		(comment "The reference_association_type attribute provides the name of the association used in a reference.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Polyconic
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes XSChoice%23)
-		(create-accessor read-write))
-	(multislot observed_event_start_tdb
-;+		(comment "observed_event_start_tdb indicates the value for earliest time in the described data, and is given in elapsed seconds since the J2000 epoch. Optional in labels; not intended for use as a table field.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot has_Delimited_Group_Sequence
-;+		(comment "The has_Delimited_Group_Sequence association is a relationship to field sequence.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot node_name
-;+		(comment "The node_name attribute provides the name of a PDS Node.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot missing_constant
-;+		(comment "The missing_constant attribute provides a value that indicates the original value was missing, such as due to a gap in coverage.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot registered_by
-;+		(comment "The registered_by attribute provides the name of the person or organization that registered the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot sequence_number
-;+		(comment "The sequence_number attribute provides a number that is used to order axes in an array.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot document_logical_identifier
-;+		(comment "The document logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot produced_by
-;+		(comment "Association for mission.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot flatten_class_org
-;+		(comment "Housekeeping.")
-		(type INSTANCE)
-;+		(allowed-classes Element_Array Axis_Array)
+	(single-slot data_object_type
+;+		(comment "The data_object_type attribute identifies the data object type of a given set of data. Example values Within the PDS according to the standards outlined in the PDS Standards Reference. Note: within AMMOS and only for the Magellan catalog attribute is used as an alias for data_set_id. The use of data_object_type as such provides backward compatibility with earlier AMMOS conventions. The use of this attribute as an alias for data_set_id is not recommended for any new tables. See data_set_id.")
+		(type SYMBOL)
+		(allowed-values ARRAY CONTAINER CUBE FILE IMAGE INDEX_TABLE N%2FA SPECTRAL_QUBE SPICE_KERNEL TEXT TIME_SERIES)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot has_Science_Facet
-;+		(comment "The has_Science_Facet association is a relationship Science_Facet.")
+	(multislot has_Local_ID_Relation
+;+		(comment "The has_Local_ID_Relation association is a relationship to Local_ID_Relation.")
 		(type INSTANCE)
-;+		(allowed-classes Science_Facets)
+;+		(allowed-classes Local_ID_Relation)
 		(create-accessor read-write))
-	(single-slot band_number
-;+		(comment "The band_number attribute provides a number corresponding to the band in the spectral qube. The band number is equivalent to the instrument band number.")
+	(single-slot value_end_date
+;+		(comment "The value_end_date attribute provides the last date on which the permissible value is in effect.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot attribute_data_type
+;+		(comment "The attribute_data_type attribute provides the  data type used to represent the value.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot data_provider_name
+;+		(comment "The data_provider_name attribute provides the name of the individual responsible for providing the release object and data.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot electronic_mail_address
+;+		(comment "The electronic mail address attribute provides a multi-part email address: the first part (the user name), which identifies a unique user, is separated by an \"at sign\"  from the host name, which uniquely identifies the mail server.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot attrNameSpaceNC
+;+		(comment "The attrNameSpaceNC attribute provides the attribute name space Id without a colon.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot member_table
+;+		(comment "Associated table of member references.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot min_index
+;+		(comment "The min index attribute provides a value that indicates the position of the element at the beginning of a sequence of elements. This value is typically 0 or 1.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot file_area_LIDVID_Secondary
-;+		(comment "The file_area association is a relationship to File Area")
+	(multislot has_Delimited_Field_Grouped
+;+		(comment "The has_Delimited_Field_Grouped association is a relationship to the field types for a group.")
 		(type INSTANCE)
 ;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot sub_stellar_ring_azimuth
-;+		(comment "sub_stellar_ring_azimuth is an angle measured at a point in the ring plane, starting from the direction of a photon arriving from a star, and ending at the direction of a local radial vector. This angle is projected into the ring plane and measured in the prograde direction. Values range from 0 to 360 in units of degrees. For stellar occultation data, this angle is equal to %28observed_ring_azimuth %2B 180%29 mod 360. It is available only for backward compatibility with previously published Cassini UVIS occultation data analysis; observed_ring_azimuth is the preferred quantity for archiving. sub_stellar_ring_azimuth is an optional data table field for Cassini UVIS occultation data; not recommended for other occultation data. In a label, the min and max variation attributes are optional for Cassini UVIS occultation data; not recommended for other occultation data.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot instrument_serial_number
-;+		(comment "The instrument serial number element provides the manufacturer's serial number assigned to an instrument. This number may be used to uniquely identify a particular instrument for tracing its components or determining its calibration history, for example.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot facet1
-;+		(comment "The facet1 attribute provides a sub-categorization under the discipline_name.  The values are restricted according to the value of discipline_name.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot minimum_light_source_incidence_angle
-;+		(comment "minimum_light_source_incidence_angle specifes the smallest value for observed_ring_elevation in the observation. Only used if the value is not constant over the observation. Values range from 0 to %2B90 in units of degrees. Not intended for use in the data file.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot facet2
-;+		(comment "The facet2 attribute provides a sub-categorization (under the discipline_name) of the type of data being described by Primary_Result_Summary.  The  facet1  and  factet2  values are intended to provide independent sub-categorizations. The values are restricted according to the value of discipline_name. Type: ASCII_Short_String_Collapsed")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot local_georeference_information
-;+		(comment "The local_description attribute provides a description of the information provided to register the local system to a planet %28e.g. control points, satellite ephemeral data, inertial navigation data%29.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot md5_checksum
-;+		(comment "The md5_checksum attribute is the 32-character hexadecimal number computed using the MD5 algorithm for the contiguous bytes of single digital object (as stored) or for an entire file.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot campaign_start_date
-;+		(comment "The campaign start date attribute provides the date when a campaign began.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot unit_of_measure_type
-;+		(comment "The unit_of_measure_type attribute identifies the class from which the attribute being defined in this data dictionary draws its possible expressions for units.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot non_quote_character
-;+		(comment "non-quote-character = letter | digit | special | underscore | apostrophe | space ;")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot modification_history
 ;+		(comment "The modification_history association is a relationship to Modification_History, a history of changes made to the product.")
@@ -3212,219 +1865,92 @@
 ;+		(allowed-classes Modification_History)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Schematron_Assert
-		(type INSTANCE)
-;+		(allowed-classes Schematron_Assert)
+	(single-slot registration_authority_id
+;+		(comment "The registration_authority_id attribute provides the name of the organization that registered the object.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot standard_parallel_2
-;+		(comment "The standard_parallel_2 attribute defines the second standard parallel %28applicable only for specific projections, a subset of specific projections where a first standard parallel is applicable%29, the second line of constant latitude at which the surface of the planet and the plane or developable surface intersect. ")
+	(multislot collection_type
+;+		(comment "The collection_type attribute provides a classification for the collection.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot continuous_loop_flag
+;+		(comment "The continuous_loop_flag attribute indicates whether or not to keep replaying a movie.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot radial_resolution
+;+		(comment "radial_resolution indicates the nominal radial distance over which changes in ring properties can be detected within a data product. Note: this value may be larger than the radial_sampling_interval value, because a data product can be over-sampled. Required in labels if the value is fixed, as it is for stellar occultations. If the value varies, the corresponding minimum and maximum attributes must be used instead. Not intended to be used as a table field.")
 		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot red_channel_band
-;+		(comment "The red_channel_band attribute identifies the number of the band, along the band axis, that should be loaded, by default, into the red channel of a display device. The first band along the band axis has band number 1.")
-		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot standard_parallel_1
-;+		(comment "The standard_parallel_1 attribute defines the first standard parallel %28applicable only for specific projections%29, the first line of constant latitude at which the surface of the planet and the plane or developable surface intersect. ")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot assertMsg
-		(type STRING)
-		(create-accessor read-write))
-	(multislot instrument_host_id
-;+		(comment "The instrument_host_id attribute provides a unique identifier for the host on which an instrument is located. This host can be either a spacecraft or an earth base (e.g. earth).")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot sampling_parameter_unit
-;+		(comment "The sampling_parameter_unit element specifies the unit of measure of associated data sampling parameters.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot revision_comment
-;+		(comment "The revision comment attribute provides notes on the revision of the product.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot sequence_class_org
-;+		(comment "Housekeeping.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot value
-;+		(comment "The value attribute provides a single, allowed numerical or character string value.")
+	(single-slot manifest_checksum
+;+		(comment "The manifest checksum provides the checksum for the manifest file.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot information_model_version
-;+		(comment "The information_model_version attribute provides the  version identification of the PDS Information Model on which the label and schema are based.")
+	(multislot identifier
+;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
 		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot dd_Context_Value_List
-;+		(comment "The dd_Context_Value_List association is a relationship to dd_Context_Value_List.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Context_Value_List)
-;+		(cardinality 0 1)
+	(multislot member_reference
+;+		(comment "The member reference attribute provides a identifier for a member.")
+		(type STRING)
 		(create-accessor read-write))
-	(multislot has_Horizontal_Coordate_System_Definition
+	(multislot has_Equirectrangular
 ;+		(comment "The xxx association is a relationship to yyy.")
 		(type INSTANCE)
-;+		(allowed-classes)
+;+		(allowed-classes XSChoice%23)
 		(create-accessor read-write))
-	(multislot default_green
-;+		(comment "The default_green attribute provides  the number of the plane along the axis that is to be loaded, by default, into the green plane of a display device.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot occultation_direction
-;+		(comment "occultation_direction indicates the direction of an occultation track. This refers to the observed occultation track overall, not to the subset that might appear in a particular file (e.g., if an occultation includes both ingress and egress tracks, the value for occultation_direction will be both in the data products for each occultation profile. Permitted values are 'Ingress', 'Egress', 'Both', and 'Multiple'. The value 'Multiple' is only used for some Hubble-based occultations where the occultation track is not monotonic over relatively short time scales. Required in labels of ring occultation observations. Not intended as a value for a table field.")
-		(type STRING)
-;+		(value "Both" "Egress" "Ingress" "Multiple")
-		(create-accessor read-write))
-	(multislot status
-;+		(comment "The status attribute indicates the condition of an object.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_target_identification
-;+		(comment "The has_target_identification association is a relationship to Target_Identification.")
+	(multislot virtual_reference
+;+		(comment "The virtual_reference association is a relationship to Virtual_Reference.")
 		(type INSTANCE)
-;+		(allowed-classes Target_Identification)
+;+		(allowed-classes Virtual_Reference)
 		(create-accessor read-write))
-	(multislot data_set_puid
-;+		(comment "The data_set_puid attribute provides a globally unique identifer for a data set.")
+	(single-slot a_axis_radius
+;+		(comment "This attribute is used in the image map projection. Under review. xxx DDWG;DS xxx Also check why minimum value is negative.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot scale_factor_at_central_meridian
-;+		(comment "The scale_factor_at_central_meridian attribute provides a multiplier for reducing a distance obtained from a map by computation or scaling to the actual distance along the central meridian.")
+	(single-slot electronic_mail_id
+;+		(comment "The eletronic mail id provides a formal name used to refer to an electronic mail address.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot name_resolver_reference
+;+		(comment "The name_resolver_reference attribute provides a reference to a name resolution service.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot product_description
+;+		(comment "Description at the identifiable layer.")
+		(type INSTANCE)
+;+		(allowed-classes Tagged_NonDigital_Object Tagged_Digital_Object)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot south_bounding_coordinate
+;+		(comment "The south_bounding_coordinate attribute provides the southern-most coordinate of the limit of coverage expressed in latitude.")
 		(type FLOAT)
-		(create-accessor read-write))
-	(multislot data_regime
-;+		(comment "The data_regime attribute provides the wavelength (or an analogous concept for things like particle detectors) of the observations, stated as a category.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot character_constraint
-;+		(comment "The character_constraint attribute limits the characters allowed.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot resource_id
-;+		(comment "The resource id provides a formal name used to refer to a resource.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot frequency_band
-;+		(comment "The frequency_band attribute provides the one or two letter identifier for the frequency band associated with radio occultation data. Required in labels for radio occultations; not used for stellar occultations.")
-		(type STRING)
-;+		(value "C" "D" "E" "F" "G" "H" "K" "Ka" "Ku" "Q" "R" "S" "U" "V" "W" "X" "Y")
-		(create-accessor read-write))
-	(multislot local_rule
-;+		(comment "The local_rule association is a relationship to DD_Rule")
-		(type INSTANCE)
-;+		(allowed-classes DD_Rule)
-		(create-accessor read-write))
-	(single-slot spcs_zone_identifier
-;+		(comment "The spcs_zone_identifier attribute identifies the SPCS zone.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot low_representation_saturation
-;+		(comment "The low_representative_saturation attribute specifies a special value whose presence indicates the true value cannot be represented in the chosen data type and length -- in this case being below the allowable range -- which may happen during conversion from another data type. The value must be less than the value of the valid_minimum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
+	(multislot document_editions
+;+		(comment "The document_editions attribute provides a count of the total number of complete, distinct editions of the document.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot browse_reference
-;+		(comment "The browse reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+	(single-slot rotation_direction
+;+		(comment "The rotation_direction element provides the direction of rotation as viewed from the north pole of the 'invariable plane of the solar system', which is the plane passing through the center of mass of the solar system and perpendicular to the angular momentum vector of the solar system. The value for this element is PROGRADE for counter -clockwise rotation, RETROGRADE for clockwise rotation and SYNCHRONOUS for satellites which are tidally locked with the primary. Sidereal_rotation_period and rotation_direction_type are unknown for a number of satellites, and are not applicable (N/A) for satellites which are tumbling.")
 		(type STRING)
-		(default "logical_identifier")
+;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot software_dialect
-;+		(comment "The software dialect attribute indicates the variety of a language used to write the software.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot instance_id
-;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot files
-;+		(comment "The files attribute provides the number of files.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot has_Field_Bit
-;+		(comment "The has_Field_Bit association is a relationship to Field_Bits.")
+	(multislot associated_Camera_Model
+;+		(comment "The associated_Camera_Model association is a relationship to Camera Model.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot UpperModel_191218_CCB-256_ReferenceTypes_Retry_Class0
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot registration_date
-;+		(comment "The registration_date attribute provides the date of registration within the PDS system.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot western_most_longitude
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot associated_optional_folder
-;+		(comment "The associated_optional_folder association is a relationship to optional folders.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot minimum_observed_event_time
-;+		(comment "minimum_observed_event_time gives the smallest value for observed_event_time in the associated data file. It is given in numeric seconds as an offset from the specified UTC reference time. minimum_observed_event_time is optional in labels since the data file time interval end point values are given by the required start_date_time_utc and stop_date_time_utc attributes in the Time_Coordinates class.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot underscore
-;+		(comment "underscore = \"_\" ; (* low line *)")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot instrument_name
-;+		(comment "The instrument_name attribute provides a unique name for an instrument.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot dd_attribute_reference
-;+		(comment "The dd_attribute_reference association is a relationship to DD_Attribute_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Attribute_Reference)
-		(create-accessor read-write))
-	(single-slot flattened_class
-;+		(comment "Housekeeping.")
-		(type INSTANCE)
-;+		(allowed-classes Conceptual_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot scaling_factor
-;+		(comment "The scaling_factor attribute is the scaling factor to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 1.")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot name_type
-;+		(comment "The name type attribute provides reference information about the standard format and syntax used for a name.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot value_meaning
-;+		(comment "The value_meaning attribute provides the meaning, or semantic content, of the associated permissible value.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot lidvid_reference
-;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
-		(type STRING)
-		(default "logical_identifier::version_id")
-		(create-accessor read-write))
-	(single-slot delivery_identifier
-;+		(comment "The identifier for the delivery. Formation Rule: Curating_Node_Id + “_” + Subnode _Id + “_” +  yy-mm-ddThhmmss  - e.g. IMAGING_USGS_2008-06-23T120000.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot latitude_type
-;+		(comment " The latitude_type attribute defines the type of latitude %28planetographic, planetocentric%29 used within a cartographic product and as reflected in attribute values within associated PDS labels. The IAU definition for direction of positive longitude should be adopted: http:%2F%2Fastrogeology.usgs.gov%2Fgroups%2FIAU-WGCCRE. ")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot observing_system_source
-;+		(comment "Associated observing system sensor.")
+	(single-slot data_location
+;+		(comment "The data_location association is a relationship to Data_Location or File_Location.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 ;+		(cardinality 0 1)
@@ -3434,478 +1960,131 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot ring_event_start_time_utc
-;+		(comment "ring_event_start_time_utc gives the UTC time corresponding to the earliest time given by ring_event_time or ring_event_tdb in the data table. ring_event_start_time_utc is required for all ring occultation data. ring_event_start_time_utc is required label attribute for all ring occultation data.")
+	(multislot rule_context
+;+		(comment "The rule_context attribute provides the xpath for the rule.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot comment
-;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
+	(single-slot document_logical_identifier
+;+		(comment "The document logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot edition_name
+;+		(comment "The edition name attribute provides a name by which the edition is known.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot start_bit
-;+		(comment "The start_bit attribute provides the position of the first bit within an ordered sequence of bits.")
+	(multislot alternate_id
+;+		(comment "The alternate_id attribute provides an additional identifier supplied by the data provider.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot investigation_name
+;+		(comment "The investigation_name attribute provides a unique name for an investigation.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot low_instrument_saturation
+;+		(comment "The low_instrument_saturation attribute specifies a special value whose presence indicates the measuring instrument was saturated at the low end. The value must be less than the value of the valid_minimum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot thumbnail_reference
+;+		(comment "The thumbnail reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier")
+		(create-accessor read-write))
+	(single-slot referenced_identifier
+;+		(comment "The referenced identifier attribute provides the identifier of the entify being referenced.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot iso_iec_646_letters
+;+		(comment "ISO/IEC 10176 describes the notion of classes of letter-like characters (outside of ISO/IEC 646 letters A through Z), digit-like characters (outside of ISO/IEC 646 digits 0 through 9), and special characters that are all used in identifiers.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot modification_date
+;+		(comment "The modification_date attribute provides date the modifications were completed")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot data_set_id
+;+		(comment "The data set id provides a formal name used to refer to a data set.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot loop_flag
+;+		(comment "The loop_flag attribute specifies whether or not a movie object should be played repeatedly without prompting from the user.")
+		(type STRING)
+;+		(value "false" "true")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot alternative
+;+		(comment "An alternative name for the resource. Dublin Core.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot associated_with
+;+		(comment "The associated_with association is a relationship to contextual information.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot instance_id
+;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot directory_delimiter
+;+		(comment "The directory delimiter is a character that separates a directory name from another directory name or from a file name.")
+		(type STRING)
+		(default "<slash>")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot orbit_direction
+;+		(comment "The orbit_direction element provides the direction of movement along the orbit about the primary as seen from the north pole of the 'invariable plane of the solar system', which is the plane passing through the center of mass of the solar system and perpendicular to the angular momentum vector of the solar system orbit motion. PROGRADE for positive rotation according to the right-hand rule, RETROGRADE for negative rotation.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot instrument_reference
+;+		(comment "The instrument  reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier")
+		(create-accessor read-write))
+	(single-slot upper_120127c_Class0
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot group_length
+;+		(comment "The group_length attribute provides the total length, in bytes, of a repeating field and/or group structure. It is the number of bytes in the repeating fields/groups plus any embedded unused bytes that are also repeated multiplied by the number of repetitions.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot resource_name
-;+		(comment "The resource_name attribute provides a name for the resouce")
+	(multislot start_date
+;+		(comment "The start_date attribute provides the date when an activity began.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot maximum_wavelength
+;+		(comment "maximum_wavelength is the largest wavelength used in the observation. Optional in labels. Used with minimum_wavelength when the observation is over a wavelength range.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot institution_name
+;+		(comment "The institution_name attribute provides the name of the associated institution.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot spacecraft_clock_count_partition
-;+		(comment "The spacecraft_clock_count_partition attribute provides the clock partition active for spacecraft_clock_start_count and spacecraft_clock_stop_count.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot std_ref_version_id
-;+		(comment "The std ref version id attribute provides the version identifier for the standard reference document.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot has_display_direction
-;+		(comment "The has_display_direction association is a relationship to Display_Direction.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot release_parameter_text
-;+		(comment "This attribute is used in by the data set release class. It is under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot distance_resolution
-;+		(comment "The distance_resolution attribute provides the minimum distance measurable between two points, expressed in Planar Distance Units of measure.")
+	(single-slot north_bounding_coordinate
+;+		(comment "The north_bounding_coordinate attribute provides the northern-most coordinate of the limit of coverage expressed in latitude.")
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot product_class
-;+		(comment "The product_class attribute provides the name of the product class.")
-		(type STRING)
-		(default "class_name")
-		(create-accessor read-write))
-	(multislot sampling_parameter_scale
-;+		(comment "The sampling_parameter_scale element specifies whether the sampling interval is linear or something other such as logarithmic.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot producer_full_name
-;+		(comment "The producer_full_name attribute provides the full_name of the individual mainly responsible for the production of the data set. This individual does not have to be registered with the PDS.")
+	(single-slot volume_format
+;+		(comment "The volume_format attribute identifies the logical format used in writing a data volume.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot alternate_title
-;+		(comment "The alternate _title attribute provides an alternate title for the product.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot default_red
-;+		(comment "The default_red attribute provides the number of the plane along the axis that is to be loaded, by default, into the red plane of a display device.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot Term_Map_SKOS_to_Term_Entry_SKOS
-;+		(comment "The Term_Map_SKOS_to _Term_Entry_SKOS association is a relationship to Terminological_Entry_SKOS.")
-		(type INSTANCE)
-;+		(allowed-classes Terminological_Entry_SKOS)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(multislot refer_data_producer
-;+		(comment "This attribute is used in by the volume class. It is under review.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot discipline_desc
-;+		(comment "The discipline_desc attribute provides a description for the science discipline")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot delivery_description
-;+		(comment "A text description of the delivery.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot operations_contact_pds_users_id
-;+		(comment "The operations_contact slot indicates the person responsible for node operations.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Universal_Transverse_Mercator
+	(multislot has_Geographic
 ;+		(comment "The xxx association is a relationship to yyy.")
 		(type INSTANCE)
-;+		(allowed-classes)
+;+		(allowed-classes XSChoice%23)
 		(create-accessor read-write))
-	(single-slot has_Resource_Section
-;+		(comment "The has_Resource_Section association is a relationship to resources.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot testValArr
-;+		(comment "The testValArr attribute provides the values for the assert statement.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot vertical_framelet_offset
-;+		(comment "This attribute is used in the image map projection. Under review.")
+	(single-slot upper_111230e_Class0
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot maximum_observed_ring_azimuth
-;+		(comment "maximum_observed_ring_azimuth specifes the largest value for observed_ring_azimuth in the data file. Values range from 0 to 360 in units of degrees. Required in label files for ring occultation data.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot total_characters
-;+		(comment "The total characters attribute indicate the maximum count of charcters allowed.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot stop_orbit_number
-;+		(comment "The stop_orbit_number attribute provides the last in a series of numbers that represent s set of orbital revolutions of one body around another.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot bearing_resolution
-;+		(comment "The bearing_resolution attribute provides the minimum angle measurable between two points.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot data_type_length
-;+		(comment "The data type length attribute provides the extent from beginning to end of a series of units such as bytes.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot fax_number
-;+		(comment "The fax_number data attribute provides the area code and telephone number needed to transmit data to an individual or a node via facsimile machine.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot serial_number
-;+		(comment "The serial number attribute provides the manufacturer's serial number assigned to an instrument host.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot team_name
-;+		(comment "The team_name attribute provides the name of a group of individuals working together.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot rule_type
-;+		(comment "The rule_type attribute indicates the type of statement to be executed.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot copyright
-;+		(comment "The copyright attribute is a character string giving  information about the exclusive right to make copies, license, and otherwise exploit an object, whether physical or digital.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot instrument_host_puid
-;+		(comment "The instrument_host_puid attribute provides a globally unique identifer for an instrument_host.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot value_domain_entry
-;+		(comment "The value_domain_entry association is a relationship to Value_Domain.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot has_data_folder
-;+		(comment "The has_data_folder association is a relationship to data folder.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot telemetry_source_type
-;+		(comment "The telemetry_source_type attribute classifies the source of the telemetry used in creation of this data collection.")
-		(type STRING)
-;+		(value "SFDU" "DATA_PRODUCT")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot distributed_by
-;+		(comment "The Nodes distributing the data set.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot doi
-;+		(comment "The doi attribute provides the Digital Object Identifier for an object, assigned by the appropriate DOI System Registration Agency.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot minimum_latitude
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_property_map_external
-;+		(comment "The has_property_map_external association is a relationship to Property_Map_External")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot associated_Camera_Parameters
-;+		(comment "The associated_Camera_Parameters association is a relationship to Camera Parameters.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot virtual_reference
-;+		(comment "The virtual_reference association is a relationship to Virtual_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Virtual_Reference)
-		(create-accessor read-write))
-	(single-slot hardware_model_id
-;+		(comment "This attribute is used in by the volume class. It is under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot abstract_flag
-;+		(comment "The abstract flag attribute indicates whether or not the class can be instantiated. Abstract flag is only included if a value of 'true' is desired and indicates that the class is abstract and cannot be used in a label.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot value_offset
-;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot date
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot oblique_line_longitude
-;+		(comment "The oblique_line_longitude attribute provides the longitude of a point defining the oblique line.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot sampling_parameters
-;+		(comment "The sampling_parameters attribute provides the total number of sampling parameter values between first_sampling_parameter_value and last_sampling_parameter_value (inclusive).")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot name_association_type
-;+		(comment "The name_association_type attribute indicates whether the name is a primary, alternate, or deprecated name.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot name_resolver_reference
-;+		(comment "The name_resolver_reference attribute provides a reference to a name resolution service.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot max_exclusive
-;+		(comment "The max exclusive attribute provides a value that is greater than all the values in the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot file_area_inventory
-;+		(comment "The file_area association is a relationship to File Area")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot axis_index
-;+		(comment "The axis index attribute provides the index of the axis in an ordered set. The index of the first axis has a value of 1.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot upper_110917_Class1
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot curating_node_id
-;+		(comment "The curating_node_id attribute provides the id of the node currently maintaining the data set or volume and is responsible for maintaining catalog information.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot associated_Cartography
-;+		(comment "The associated_Cartography association is a relationship to Cartography.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot provider_site_id
-;+		(comment "The provider site id attribute provides an identifier for the provider.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot local_description
-;+		(comment "The local_description attribute provides a description of the coordinate system and its orientation to the surface of a planet.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot starting_point_identifier
-;+		(comment "The starting_point attribute provides the local_identifier of the object to be accessed first.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot supported_environment_note
-;+		(comment "The supported environment note attribute identifies  the environment  that can process the software.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_tagged_data_object2
-;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot file_URL
-;+		(comment "The file_URL holds a reference or link to a version of the data that can be downloaded, streamed, or even accessed/visualized via a Web service. URL stands for Uniform Resource Locator and is the address of a given unique resource on the Web, whether it is linked to an image, table, HTML page, or other Web resource.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot naif_host_id
-;+		(comment "The naif_host_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot software_format_type
-;+		(comment "The software format type attribute classifies the format of the software.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot desc
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot data_set_logical_identifier
-;+		(comment "The data set logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot activity_type
-;+		(comment "The activity_type attribute provides a classification for the activity.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot has_zip
-;+		(comment "The has_ZIP association is a relationship to ZIP")
-		(type INSTANCE)
-;+		(allowed-classes Zip)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot mission_phase_identifier
-;+		(comment "The mission_phase_identifier attribute provides an identifier for a mission phase.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot editor_list
-;+		(comment "The editor_list attribute contains a semi-colon-separated list of names of people to be cited as editors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final editor. All editors should be listed explicitly - do not elide the list using \"et al.\".")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot roleId
-;+		(comment "The roleId attribute provides the role performed by this object.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot lid_reference_to
-;+		(comment "The lid_reference_to provides the identifier of the ending object in a  one directional relationship.")
-		(type INSTANCE)
-;+		(allowed-classes LID_ID_Reference_To)
-		(create-accessor read-write))
-	(single-slot bricks
-;+		(comment "An integer value indicating the number of data bricks in this delivery. xxx OPS;DS, check steward, negative values xxx")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot telemetry_source_name
-;+		(comment "The telemetry_source_name attribute identifies the telemetry source used in creation of a data set.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot ring_observation_id
-;+		(comment "The ring_observation_id uniquely identifies a single experiment or observation %28image, occultation profile, spectrum, etc.%29 within a rings-related data set. This is the common id by which data are identified within the Rings Node catalog. It describes the smallest quantity of data that can be usefully cataloged or analyzed by itself. Note that a single observation may be associated with multiple data products %28e.g. raw and calibrated versions of an image%29. Note also that a single data product may be associated with multiple observations %28e.g. a single WFPC2 image file containing four different images%29. A ring observation id is constructed using numbers, upper case letters, forward slash, colon, period, dash, and underscore as follows: p%2Ftype%2Fhost%2Finst%2Ftime%2F... where p is a single-letter planet id %28one of J, S, U, or N%29; type is IMG for images, OCC for occultation profile, etc.; host is the instrument host id, inst is the instrument id; time is the observation time as a date or instrument clock count; further information identifying the observation can then be appended as appropriate. Optional in labels. Nillable, in which case the nil_reason should be 'inapplicable'. Examples: J%2FIMG%2FVG2%2FISS%2F20693.01%2FN J%2FIMG%2FVG2%2FISS%2F20693.02%2FW S%2FIMG%2FHST%2FWFPC2%2F1995-08-10%2FU2TF020B%2FPC1 U%2FOCC%2FVG2%2FRSS%2F1986-01-24%2FS U%2FOCC%2FVG2%2FRSS%2F1986-01-24%2FX N%2FOCC%2FVG2%2FPPS%2F1989-08-25%2FSIGMA_SGR ")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot volume_name
-;+		(comment "The volume_name attribute contains the name of a data volume.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot software_id
-;+		(comment "The software id attribute provides a formal name used to refer to the software.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot scale_type
-;+		(comment "The scale_type attribute is an attribute proposed for use in those cases where the physical dimensions of the axes do not vary linearly. xxx TBD A. Raugh; MG xxx")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot value_syntax
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot associated_recommended_folder
-;+		(comment "The associated_recommended_folder association is a relationship to recommended folders.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot alwaysInclude
-;+		(comment "The alwaysInclude attribute indicates whether a rule should always be included.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot rule_value
-;+		(comment "The rule_value attribute provides values to be used to complete certain schematon statements.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot stop_bit_location
-;+		(comment "The stop_bit_location attribute provides the position of the last bit in a bit field relative to the first bit in the parent packed data field. Bytes are sequential and bits are numbered continuously across byte boundaries within a single bit field. The first bit position in the packed data field is \"1\".")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot copied_to
-;+		(comment "Associated physical volumes.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot operating_system_id
-;+		(comment "This attribute is used in by the volume class. It is under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot coordinate_source
-;+		(comment "The coordinate_source attribute provides the reference figure or datum.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot derivation_reference
-;+		(comment "The derivation reference attribute provides the logical_identifier and version_id for a source product.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot field_data_type
-;+		(comment "The field_data_type attribute provides the machine  representation used to store the value.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot primary_body_name
-;+		(comment "The primary_body_name attribute identifies the primary body with which a given target body is associated as a secondary body.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot sampling_parameter_interval
-;+		(comment "The sampling_parameter_interval attribute provides the spacing of points at which data are sampled and at which values for an instrument or other parameter are available. If x1 and xn are the first and last sampling parameter values, respectively, xn is larger than x1, n is the number of sampling parameters, the caret symbol (^) denotes exponentiation, and b, a positive real number, is the base for exponentiation, then the value of sampling_parameter_interval is: (xn-x1)/(n-1) (for sampling_parameter_scale = Linear), (xn/x1)^(1/(n-1)) (for sampling_parameter_scale = Logarithmic), (b^xn-b^x1)/(n-1) (for sampling_parameter_scale = Exponential).")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot spice_kernel_file_name
-;+		(comment "The spice_kernel_file_name attribute is used to identify SPICE kernel files used in the production of the product.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot original_band
-;+		(comment "The original_band attribute of a spectral qube provides the sequence of band numbers in the qube relative to some original qube. In the original qube, the values are just consecutive integers beginning with 1. In a qube which contains a subset of the bands in the original qube, the values are the original sequence numbers from that qube.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot file_local_identifier
-;+		(comment "The file local identifier attribute provides a formal name used to refer to a file description within the label. A file local identifier is unique within a label.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot record_type
-;+		(comment "The record type attribute classifies a record.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot assertStmt
-		(type STRING)
-		(create-accessor read-write))
-	(multislot security_roles
-;+		(comment "The security roles attribute indicates the function performed associated with security.")
-		(type STRING)
-;+		(value "Create" "Retrieve" "Update" "Delete")
-		(create-accessor read-write))
-	(multislot other_data_object_set
-;+		(comment "Aggregation association for other data objects.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot value_domain_external
-		(type INSTANCE)
-;+		(allowed-classes DD_Value_Domain)
-		(create-accessor read-write))
-	(multislot high_instrument_saturation
-;+		(comment "The high_instrument_saturation attribute specifies a special value whose presence indicates the measuring instrument was saturated at the high end. The value must be less than the value of the valid_minimum attribute or more than the value of the valid_maximum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
+	(multislot specified_unit_id
+;+		(comment "The specified_unit_id attribute provides the unit chosen for maximum_value, minimum_value, and permissible_value.")
 		(type STRING)
 		(create-accessor read-write))
 	(single-slot instrument_host_type
@@ -3913,64 +2092,1571 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot document_puid
-;+		(comment "The document_puid attribute provides a globally unique identifer for a document.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot mission_objectives_summary
-;+		(comment "The mission_objectives_summary attribute describes the major scientific objectives of a planetary mission or project.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot sub_stellar_clock_angle
-;+		(comment "sub_stellar_clock_angle is an angle measured at a point in the ring plane, from the direction toward a star to the local radial direction. This angle is projected into the ring plane and measured in the clockwise %28retrograde%29 direction. Equivalently, this is the prograde angle from the local radial direction to the direction toward the star. For stellar occultation data, this angle is equal to %28180 - OBSERVED_RING_AZIMUTH%29 mod 360. It is available only for backward compatibility with previously published Cassini VIMS occultation data analysis; observed_ring_azimuth is the preferred quantity for archiving. sub_stellar_clock_angle is an optional data table field for Cassini VIMS occultation data; not recommended for other occultation data. In a label, the min and max variation attributes are optional for Cassini VIMS occultation data; not recommended for other occultation data. ")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot mission_desc
-;+		(comment "The mission_desc attribute summarizes major aspects of a planetary mission or project, including the number and type of spacecraft, the target body or bodies and major accomplishments.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot latitude_of_projection_origin
-;+		(comment "The latitude_of_projection_origin attribute defines the latitude chosen as the origin of rectangular coordinates for a map projection.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot oblique_line_latitude
-;+		(comment "The oblique_line_latitude attribute provides the latitude of a point defining the oblique line.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_occultation_time_series
-;+		(comment "The has_occultation_time_series association is a relationship to occultation_time_series")
+	(single-slot operations_contact_pds_users_id
+;+		(comment "The operations_contact slot indicates the person responsible for node operations.")
 		(type INSTANCE)
 ;+		(allowed-classes)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot altitude
+;+		(comment "The altitude attribute provides the height of anything above a given reference plane.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot spheroid_name
+;+		(comment "The spheroid_name attribute provides the identification given to established representations of a planet%47s shape. ")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot class_name
 ;+		(comment "The class_name attribute provides the common name by which the class is identified, as well as the class within which the attribute is used.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Field_LIDVID
-;+		(comment "The has_Field_LIDVID association is a relationship to an LIDVID.")
+	(single-slot cross_reference_area
+;+		(comment "The cross_reference_area association is a relationship to Cross_Reference_Area a set of identifiers that reference other products.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot has_Element_Array
+;+		(comment "The has_Element_Array association is a relationship to Element_Array")
+		(type INSTANCE)
+;+		(allowed-classes Element_Array)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot campaign_end_date
+;+		(comment "The campaign end date attribute provides the date when a campaign was completed.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot maximum_ring_longitude
+;+		(comment "maximum_ring_longitude specifies one boundary for the ring longitude range in the data; normally the largest value. However, for ranges that cross the prime meridian, the maximum ring longitude will have a value less than the minimum ring longitude. Values range from 0 to 360 in units of degrees. Required in label files for ring occultation data.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot associated_Property_Map
+;+		(comment "The associated_Property_Map association is a relationship to property map.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot lid_reference
-;+		(comment "The lid_reference attribute provides the logical_identifier for a  product.")
+	(single-slot bearing_reference_meridian
+;+		(comment "The bearing_reference_meridian attribute specifies the axis from which the bearing is measured.")
+		(type STRING)
+;+		(value "Assumed" "Astronomic" "Geodetic" "Grid" "Magnetic")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot has_color_display_settings
+;+		(comment "The has_color_display_settings association is a relationship to Color_Display_Settings.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot subscription_id
+;+		(comment "The subscriber_id provides the identification of a PDS subscription.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Delimited_Group_Sequence
+;+		(comment "The has_Delimited_Group_Sequence association is a relationship to field sequence.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot first_element
+;+		(comment "The first element attribute indicates the position of the first element of an array.")
+		(type STRING)
+;+		(value "TOPLEFT")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot context_area
+;+		(comment "The context_area association is a relationship to Context_Area.")
+		(type INSTANCE)
+;+		(allowed-classes Context_Area)
+		(create-accessor read-write))
+	(single-slot used
+		(type INSTANCE)
+;+		(allowed-classes Methods Config Input_Data)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot data_set_name
+;+		(comment "The data_set_name attribute provides the full name given to a data set or a data product. The data_set_name typically identifies the instrument that acquired the data of that instrument Example value data_set_id. Note This attribute is defined in the AMMOS Magellan catalog as an alias for file_name to provide backward compatibility")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot spacecraft_event_start_time_utc
+;+		(comment "spacecraft_event_start_time_utc gives the UTC time corresponding to the earliest time given by spacecraft_event_time in the data table. However, while spacecraft_event_time is given as seconds offset from a reference time, spacecraft_event_start_time_utc is given as a UTC date time. Required in the label for radio occultation data. Not used for stellar occultations.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot member_relation_name
+;+		(comment "The member relation name provides the name of the relationship.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Coordinate_Representation
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes XSChoice%23)
+		(create-accessor read-write))
+	(multislot subscriber
+;+		(comment "The subscriber association is a relationship to a Subscriber_PDS3 class.")
+		(type INSTANCE)
+;+		(allowed-classes Subscriber_PDS3)
+		(create-accessor read-write))
+	(single-slot mean
+;+		(comment "The mean attribute provides the sum of the values divided by the number of values (empty or Special_Constants values are excluded).")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot associated_Cartography
+;+		(comment "The associated_Cartography association is a relationship to Cartography.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot resource_reference
+;+		(comment "The resource reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
 		(type STRING)
 		(default "logical_identifier")
 		(create-accessor read-write))
-	(multislot parsing_standard_id
-;+		(comment "The parsing_standard_id attribute provides the formal name of a standard used for the structure of a Parsable Byte Stream digital object.")
+	(single-slot volume_set_id
+;+		(comment "The volume_set_id attribute identifies a data volume or a set of volumes. Volume sets are normally considered as a single orderable entity. Examples: USA_NASA_PDS_MG_1001, USA_NASA_PDS_GR_0001_TO_GR_0009")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot dictionary_id
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot software_format_set
+;+		(comment "The software_format_set association is a relationship to a set of one or more software formats.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot document_standard_id
+;+		(comment "The document_standard_id attribute provides the formal name of a standard used for the structure of a document file.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot axis_storage_order
-;+		(comment "The axis_storage_order attribute associates a name with each of the axis.")
+	(multislot product_class
+;+		(comment "The product_class attribute provides the name of the product class.")
+		(type STRING)
+		(default "class_name")
+		(create-accessor read-write))
+	(multislot security_roles
+;+		(comment "The security roles attribute indicates the function performed associated with security.")
+		(type STRING)
+;+		(value "Create" "Retrieve" "Update" "Delete")
+		(create-accessor read-write))
+	(multislot spacecraft_event_stop_time_utc
+;+		(comment "spacecraft_event_stop_time_utc gives the UTC time corresponding to the latest time given by spacecraft_event_time in the data table. However, while spacecraft_event_time is given as seconds offset from a reference time, spacecraft_event_stop_time_utc is given as a UTC date time. Required in the label for radio occultation data. Not used for stellar occultations.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot highest_detectable_opacity
-;+		(comment "highest_detectable_opacity indicates the sensitivity of a ring occultation data set to nearly opaque rings. It specifies the rough value for the largest normal ring opacity that can be detected in the data at the resolution provided, incorporating both statistical effects and calibration uncertainties. Strongly recommended in labels of ring occultation observations. Not intended as a value for a table field.")
+	(multislot terminological_entry
+;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
+		(type INSTANCE)
+;+		(allowed-classes Terminological_Entry)
+		(create-accessor read-write))
+	(multislot external_property_map_id
+;+		(comment "The external_property_map_id attribute provides the identifier of a property_map instance external to this context.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot alias
+;+		(comment "The alias association is a relationship to Alias, an alternate name and identification.")
+		(type INSTANCE)
+;+		(allowed-classes Alias)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot has_identification_area
+;+		(comment "The has_identification_area association is a relationship to Identification Area.")
+		(type INSTANCE)
+;+		(allowed-classes Identification_Area)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot second_standard_parallel
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot telemetry_source_type
+;+		(comment "The telemetry_source_type attribute classifies the source of the telemetry used in creation of this data collection.")
+		(type STRING)
+;+		(value "SFDU" "DATA_PRODUCT")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot vertical_display_direction
+;+		(comment "The vertical_display_direction attribute specifies the direction along the screen of a display device that data along the vertical axis of an Array is supposed to be displayed.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot total_characters
+;+		(comment "The total characters attribute indicate the maximum count of charcters allowed.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot nil_reason
+;+		(comment "The nil_reason attribute provides the permissible values allowed as reasons when an attribute assigned a nil value.")
+		(type STRING)
+;+		(value "inapplicable" "anticipated" "missing" "unknown")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot flatten_class_org
+;+		(comment "Housekeeping.")
+		(type INSTANCE)
+;+		(allowed-classes Element_Array Axis_Array)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot delivery_identifier
+;+		(comment "The identifier for the delivery. Formation Rule: Curating_Node_Id + “_” + Subnode _Id + “_” +  yy-mm-ddThhmmss  - e.g. IMAGING_USGS_2008-06-23T120000.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot time_series_direction
+;+		(comment "time_series_direction indicates the direction the occultation proceeds through the target within a particular data product. Possible values are 'ingress', 'egress', 'both' or 'multiple'. The value 'Multiple' is only used for some Hubble-based occultations where the occultation track is not monotonic over relatively short time scales. Not intended as a value for a table field.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Table_Field
+;+		(comment "The has_Table_Field association is a relationship to the field types.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot has_mission_area
+;+		(comment "The has_mission_area association is a relationship to Mission Area.")
+		(type INSTANCE)
+;+		(allowed-classes Mission_Area)
+		(create-accessor read-write))
+	(single-slot minimum_scaled_value
+;+		(comment "The minimum_scaled_value attribute provides the minimum value after application of scaling_factor and value_offset (see their definitions; minimum_scaled_value is the minimum of Ov).")
 		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_Packed_Data_Fields
+;+		(comment "The has_Packed_Data_Fields association is a relationship to  Packed_Data_Fields.")
+		(type INSTANCE)
+;+		(allowed-classes Packed_Data_Fields)
+		(create-accessor read-write))
+	(single-slot maximum
+;+		(comment "The maximum attribute provides the largest stored value which actually appears; empty and Special_Constant field values are excluded.")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot delivery_description
+;+		(comment "A text description of the delivery.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot axis_unit
+;+		(comment "The axis_unit attribute is the units of each axis (the units associated with axis_name) (e.g., pixels, seconds, degrees, etc.).")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot title
+;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_Transfer_Manifest
+;+		(comment "The has_Transfer_Manifest association is a relationship to Transfer_Manifest.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot curating_facility
+;+		(comment "The curating_facility attribute provides a unique name or identifier for the curating facility maintaining the source product.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot replicate
+;+		(comment "The replicate attribute indicates whether the object is replicated.")
+		(type SYMBOL)
+		(allowed-values FALSE TRUE)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot file_URL
+;+		(comment "The file_URL holds a reference or link to a version of the data that can be downloaded, streamed, or even accessed/visualized via a Web service. URL stands for Uniform Resource Locator and is the address of a given unique resource on the Web, whether it is linked to an image, table, HTML page, or other Web resource.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot domain
+;+		(comment "The radial ‘zone’ or ‘shell’ of the target for which the observations were collected or which are represented in the product(s).  The value may depend on wavelength_range and size of the target.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot operating_system_id
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot mission_start_date
+;+		(comment "The mission_start_date attribute provides the date of the beginning of a mission in UTC system format.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot nssdc_collection_id
+;+		(comment "An NSSDC Collection ID is an NSSDC assigned identifier for a collection of PDS datasets.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot observed_ring_elevation
+;+		(comment "observed_ring_elevation is an angle measured at a point in the ring plane, starting from the ring plane to the direction of a photon heading to the observer. This angle is positive on the side of the ring plane defined by positive angular momentum, and negative on the opposite side. Values range from -90 to %2B90 in units of degrees. This angle is constant for stellar occultations, but may vary significantly during radio occultations. Note: The direction of positive angular momentum points toward the IAU-defined north side of the ring plane for Jupiter, Saturn and Neptune, but IAU-defined south side of the ring plane for Uranus. Required in the label if the value is constant for the observation. If the angle varies for the observation, the min and max attributes are required in the label, and observed_ring_elevation is strongly recommended as a field in the data table. The above definition of observed_ring_elevation is equivalent to the most common usage of the term 'ring open angle', B.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot underscore
+;+		(comment "underscore = \"_\" ; (* low line *)")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot cs_local_identifier_reference
+;+		(comment "The cs_local_identifier_reference attribute is used to reference one component of a composite structure.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot reference_association_type
+;+		(comment "The reference_association_type attribute provides the name of the association used in a reference.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot stop_orbit_number
+;+		(comment "The stop_orbit_number attribute provides the last in a series of numbers that represent s set of orbital revolutions of one body around another.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot associated_Coordinate_System
+;+		(comment "The associated_Coordinate_System association is a relationship to Coordinate System.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot stop_time
+;+		(comment "The stop_time element provides the date and time of the end of an observation or event (whether it be a spacecraft, ground-based, or system event) in UTC.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot character_encoding
+;+		(comment "The character_encoding attribute identifies the standard that maps a set of allowed characters to their machine readable code.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot minimum_observed_event_time
+;+		(comment "minimum_observed_event_time gives the smallest value for observed_event_time in the associated data file. It is given in numeric seconds as an offset from the specified UTC reference time. minimum_observed_event_time is optional in labels since the data file time interval end point values are given by the required start_date_time_utc and stop_date_time_utc attributes in the Time_Coordinates class.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot software_id
+;+		(comment "The software id attribute provides a formal name used to refer to the software.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot byte_order
+;+		(comment "The byte order attribute indicates whether the most siginificant or the least significant byte is placed first in the sequence of bytes that comprise an element.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot occultation_type
+;+		(comment "occultation_type distinguishes between three types of occultation experiments: Stellar, Solar, or Radio. Stellar occultations involve observing a star as a targeted ring or body passes in front, as seen from either a spacecraft or Earth-based observatory. Solar occultations are similar to stellar occultations except that the Sun is used in place of a star. Radio occultations typically involve observing the continuous-wave radio transmissions from a spacecraft as it passes behind the target as seen from a radio telescope on Earth or another spacecraft. Required in labels of occultation observations. Normally not intended as a value for a table field.")
+		(type STRING)
+;+		(value "Radio" "Solar" "Stellar")
+		(create-accessor read-write))
+	(single-slot instrument_desc
+;+		(comment "The instrument_desc attribute describes a given instrument.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot sequence_number
+;+		(comment "The sequence_number attribute provides a number that is used to order axes in an array.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot target_puid
+;+		(comment "The target_puid attribute provides a globally unique identifer for a target.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot local_attribute_id
+;+		(comment "The local_attribute_id provides the identifier of an attribute and indicates membership in a class.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot programmers_manual_id
+;+		(comment "The programmers manual id attribute provides an identifier to a document giving instruction about the programming of the software.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot language
+;+		(comment "The language attribute provides the language used for definition and designation of the term.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot latitude_of_projection_origin
+;+		(comment "The latitude_of_projection_origin attribute defines the latitude chosen as the origin of rectangular coordinates for a map projection.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot green_channel_band
+;+		(comment "The green_channel_band attribute identifies the number of the band, along the band axis, that should be loaded, by default, into the green channel of a display device. The first band along the band axis has band number 1.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot coordinate_system_name
+;+		(comment "This attribute is used in the image map projection. Under review. xxx E. RYE;DS xxx")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot browse_collection_reference
+;+		(comment "The browse collection reference attribute provides the logical_identifier for a browse collection.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot local_identifier_reference
+;+		(comment "The local_identifier_reference attribute provides the value of the local_identifier of the entity described by the referencing class. Note that a local_identifier attribute, with the same value as this local_identifier_reference, must be present within the label.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot publication_year
+;+		(comment "The publication_year attribute provides the year in which the product should be considered as published. Generally, this will be the year the data were declared \"Certified\" or \"Archived\".")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot registration_date
+;+		(comment "The registration_date attribute provides the date of registration within the PDS system.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot observing_system_component_type
+;+		(comment "The observing_system_component_type attribute provides the function or role of the component in the observing system.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot format_type
+;+		(comment "The format_type attribute provides the format, protocol, or language within which an entire document is constructed (e.g., TEXT, PDF-A, HTML).  This is distinct from encoding_type and external_standard_id, which are used to describe component files within the document.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot observing_system_component
+;+		(comment "The observing_system_component association is a relationship to Observing_System_Component.")
+		(type INSTANCE)
+;+		(allowed-classes Observing_System_Component)
+		(create-accessor read-write))
+	(single-slot was_generated_by
+		(type INSTANCE)
+;+		(allowed-classes Activity)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot model_object_id
+;+		(comment "The model_object_id attribute provides the unique identifier of a class, attribute, or value that is defined in the information model.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot data_set_release_date
+;+		(comment "The data_set_release_date attribute provides the date when a data set is released by the data producer for archive or publication. In many systems this represents the end of a proprietary or validation period. Formation rule In AMMOS identify the date at which a product may be released to the general public from proprietary access. AMMOS-related systems should apply this attribute only to proprietary data.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot abstract_desc
+;+		(comment "The abstract desc attribute provides a summary of a text, scientific article, or document.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot file_area_LIDVID_Secondary
+;+		(comment "The file_area association is a relationship to File Area")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot local_georeference_information
+;+		(comment "The local_description attribute provides a description of the information provided to register the local system to a planet %28e.g. control points, satellite ephemeral data, inertial navigation data%29.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot object_length
+;+		(comment "The object_length attribute provides the length of the digital object in bytes.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(single-slot stop_date_time
+;+		(comment "The stop_date_time attribute provides the date and time at the end of a time interval of interest.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot center_longitude
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot maximum_field_length
+;+		(comment "The maximum_field_length attribute sets an upper, inclusive bound on the number of bytes in the field.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot collected_by
+;+		(comment "The collected_by association is a relationship to instrument.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot earth_received_stop_date_time
+;+		(comment "The earth_received_stop_date_time attribute provides the latest time at which any component telemetry data for a particular product was received.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot spice_collection_reference
+;+		(comment "The spice collection reference attribute provides the logical_identifier for a spice collection.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot character_literal
+;+		(comment "character-literal = apostrophe, any-character, apostrophe ; any-character = bound-character | added-character | escape-character ; escape-character = escape, character-name, escape ; character-name = identifier, { \" \", identifier } ;")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot transfer_object_id
+;+		(comment "The transfer_object_id is an NSSDC provided identifier for the digital information object within a SIP that is to be preserved in an AIP.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot geometry_reference
+;+		(comment "The geometry reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier::version_id")
+		(create-accessor read-write))
+	(single-slot member_status
+;+		(comment "The member_status attribute indicates whether the collection is a primary or secondary member of the bundle.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot author_list
+;+		(comment "The author_list attribute contains a semi-colon-separated list of names of people to be cited as authors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final author. All authors should be listed explicitly - do not elide the list using \"et al.\".")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot bearing_reference_direction
+;+		(comment "The bearing_reference_direction attribute specifies the direction from which the bearing is measured.")
+		(type STRING)
+;+		(value "North" "South")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_property_map
+;+		(comment "The has_property_map association is a relationship to Property_Map.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot schematronAssign
+;+		(comment "The schematronAssign attribute provides values for schemtron rule assignments at the rule level.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot roleId
+;+		(comment "The roleId attribute provides the role performed by this object.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot digit_string
+;+		(comment "digit-string = digit-like, { digit-like } ; digit-like = digit | ISO/IEC-10176-extended-digit ;")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot calibration_reference
+;+		(comment "The calibration reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier::version_id")
+		(create-accessor read-write))
+	(single-slot node_manager_pds_users_id
+;+		(comment "The da_contact indicates the node person responsible for data administration.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot sample_first_pixel
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot minimum_radial_sampling_interval
+;+		(comment "minimum_radial_sampling_interval indicates the smallest radial spacing between consecutive points in a ring profile. In practice, this may be somewhat smaller than the radial_resolution because a profile may be over-sampled. If the value of radial_sampling_interval varies, the minimum and maximum attributes are required in labels. Not intended to be used as a table field.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot file_name_token
+;+		(comment "The file name token is a substring that names a directory. The maximum size of a file name is thirty characters.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot standard_id
+;+		(comment "The standard_id attribute provides the formal name of an established norm or requirement.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot map_projection_desc
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot users_manual_id
+;+		(comment "The users manual id attribute provides a formal name used to refer to a manual that describes how to use the software.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot specMesg
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot sip_manifest_file_specification_name
+;+		(comment "Relative path name of the SIP manifest file in the SIP_Manifest directory. Formation Rule: --volume_id-- + “_SIP_Manifest”.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot pds_version_id
+;+		(comment "The pds version id provides a formal name used to refer to a version of the PDS standards.")
+		(type STRING)
+;+		(value "PDS4.0")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot reference_time_utc
+;+		(comment "reference_time_utc provides a date and time in UTC format. Given in a label when time values in a table are given as elapsed seconds offset from a reference time. Unless there are compelling reasons to do otherwise, reference_time_utc should correspond to the start of a day. Required anytime a table field is given relative to a specific date and time other than when Barycentric Dynamical Time is used (e.g., observed_event_tdb).")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot activity_type
+;+		(comment "The activity_type attribute provides a classification for the activity.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot data_reference
+;+		(comment "The data reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier::version_id")
+		(create-accessor read-write))
+	(multislot has_Science_Facet
+;+		(comment "The has_Science_Facet association is a relationship Science_Facet.")
+		(type INSTANCE)
+;+		(allowed-classes Science_Facets)
+		(create-accessor read-write))
+	(multislot encoding_standard_id
+;+		(comment "The encoding_standard_id attribute provides the formal name of a standard used for the structure of an Encoded Byte Stream digital object.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot publication_date
+;+		(comment "The publication_date attribute provides the date on which an item was published.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot interface_type
+;+		(comment "The interface type attribute identifies the class of interconnection provided.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Polyconic
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes XSChoice%23)
+		(create-accessor read-write))
+	(multislot local_true_solar_time
+;+		(comment "The local_true_solar_time (LTST) attribute provides the local time on a rotating solar system body where LTST is 12 h at the sub-solar point (SSP) and increases 1 h for each 15 degree increase in east longitude away from the SSP for prograde rotation.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot update_purpose
+;+		(comment "The update purpose attribute indicates the intended objective of this update.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Funding_Acknowledgement
+;+		(comment "The has_Funding_Acknowledgement association is a relationship to Funding_Acknowledgement.")
+		(type INSTANCE)
+;+		(allowed-classes Funding_Acknowledgement)
+		(create-accessor read-write))
+	(single-slot repertoire_list
+;+		(comment "UTF-8 (8-bit UCS/Unicode Transformation Format) is a variable-length character encoding for Unicode. It is able to represent any character in the Unicode standard, yet is backwards compatible with ASCII.")
+		(type STRING)
+;+		(value "UTF-8")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot rule_description
+;+		(comment "The rule_description attribute provides a description of the rule statement suitable for  user documentation.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot volume_de_fullname
+;+		(comment "The volume_de_fullname attribute provide the full name of the data engineer.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot funding_source
+;+		(comment "The funding_source attribute provides the identifier for an agency or other entity that provided financial assistance in the poroduction of the archival data.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot product_type
+;+		(comment "The product type attribute provides the name of a class of which this object is a member.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot target_reference
+;+		(comment "The target reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier")
+		(create-accessor read-write))
+	(multislot sclk_start_time
+;+		(comment "sclk_start_time is the value of the spacecraft clock corresponding to the start_date_time given in the label.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot external_reference_extended
+;+		(comment "The external_reference_extended association is a relationship to external_reference_extended.")
+		(type INSTANCE)
+;+		(allowed-classes External_Reference_Extended)
+		(create-accessor read-write))
+	(single-slot earth_received_start_date_time
+;+		(comment "The earth_received_start_date_time attribute provides the earliest time at which any component telemetry data for a particular product was received.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot orbit_number
+;+		(comment "The orbit_number attribute provides the number of the orbital revolution of one body around another.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot contains_primary_member
+;+		(comment "The contains_primary_member attribute indicates whether a collection contains products that are primary members of the collection.")
+		(type SYMBOL)
+		(allowed-values FALSE TRUE)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot axis_display
+;+		(comment "The has_Axis_Display association is a relationship to Axis_Display.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot max_bytes
+;+		(comment "The maximum number of bytes allowed on a physical volume.")
+		(type STRING)
+;+		(value "2TB")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot alternate_telephone_number
+;+		(comment "The alternate_telephone_number attribute provides a telephone number (in addition to telephone_number) in international notation which complies with the ITU-T E.164 format recommendation.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot supported_architecture_note
+;+		(comment "The supported architecture note attribute identifies  the hardware architecture that can process the software.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Character_Field_Grouped
+;+		(comment "The has_Table_Field_Grouped association is a relationship to the field types for a group.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot volume_insert_text
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot digit
+;+		(comment "digit = \"0\" | \"1\" | \"2\" | \"3\" | \"4\" | \"5\" | \"6\" | \"7\" | \"8\" | \"9\" ;")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot instrument_type
+;+		(comment "The instrument_type attribute identifies the type of an instrument. Example values: POLARIMETER SPECTROMETER")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot minimum_light_source_incidence_angle
+;+		(comment "minimum_light_source_incidence_angle specifes the smallest value for observed_ring_elevation in the observation. Only used if the value is not constant over the observation. Values range from 0 to %2B90 in units of degrees. Not intended for use in the data file.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot virtual_reference_type
+;+		(comment "The virtual_reference_type attribute provides the name of an association between two objects.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot dd_association
+;+		(comment "The local_association_attribute association provides a relationship to an attribute.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot sequence_class
+;+		(comment "Housekeeping.")
+		(type INSTANCE)
+;+		(allowed-classes Physical_Object)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot vector_components
+;+		(comment "The vector_components attribute provides a count of vector components.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot has_Geo_Transformation
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot invalid_constant
+;+		(comment "The invalid_constant attribute provides a value that indicates the original value was outside the valid range for the parameter.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot lidvid_refernce_to
+;+		(comment "The lidvid_refernce_to provides the identifier of the ending object in a  one directional relationship.")
+		(type INSTANCE)
+;+		(allowed-classes LIDVID_ID_Reference_To)
+		(create-accessor read-write))
+	(single-slot band_width
+;+		(comment "The band_width attributes provides the width, at half height, of the band.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot horizontal_framelet_offset
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_Property_Maps
+;+		(comment "The has_Property_Maps association is a relationship to a Property Maps class")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot azimuth_measure_point_longitude
+;+		(comment "The azimuth_measure_point_longitude attribute provides the longitude of the map projection origin.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot refer_data_set_projection
+;+		(comment "Associated Data Set Projection.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot phone_book_flag
+;+		(comment "The phone_book_flag attribute indicates whether or not this person should be included in the phone book.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot rule_message
+;+		(comment "The rule_message attribute provides a message to be displayed by the schematron processor when the test condition is  met.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot citation_text
+;+		(comment "The citation_text attribute provides a character string containing a literature or other citation in sufficient detail that the material  could be located in PDS or elsewhere.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot associated_Statistics
+;+		(comment "The associated_Object_Statistics association is a relationship to object statistics.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot instrument_host_puid
+;+		(comment "The instrument_host_puid attribute provides a globally unique identifer for an instrument_host.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot upper_120106b_Class1
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot lid_reference_to
+;+		(comment "The lid_reference_to provides the identifier of the ending object in a  one directional relationship.")
+		(type INSTANCE)
+;+		(allowed-classes LID_ID_Reference_To)
+		(create-accessor read-write))
+	(single-slot bytes
+;+		(comment "The bytes attribute provides the number of bytes in the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot radial_sampling_interval
+;+		(comment "radial_sampling_interval indicates the radial spacing between consecutive points in a ring profile. In practice, this may be somewhat smaller than the radial_resolution because a profile may be over-sampled. Required in labels if the value is fixed. If the value varies, the corresponding minimum and and maximum attributes must be used instead. Not intended to be used as a table field.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot axis_index_order
+;+		(comment "The axis_index_order attribute provides the axis index that varies fastest with respect to storage order.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot subtype
+		(type STRING)
+		(create-accessor read-write))
+	(multislot associated_recommended_folder
+;+		(comment "The associated_recommended_folder association is a relationship to recommended folders.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot install_note
+;+		(comment "The install note attribute provides a brief statement giving particulars about the installation of the software.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot node_name
+;+		(comment "The node_name attribute provides the name of a PDS Node.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot name_type
+;+		(comment "The name type attribute provides reference information about the standard format and syntax used for a name.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot sampling_parameters
+;+		(comment "The sampling_parameters attribute provides the total number of sampling parameter values between first_sampling_parameter_value and last_sampling_parameter_value (inclusive).")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot sipid
+;+		(comment "SIP Identifier - Producer Archive Project ID (PAPID) in conjunction with a unique integer. PAPID is assigned by the NSSDC.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot grating_position
+;+		(comment "The grating_position attribute of a spectral qube describes the grating position which corresponds to the band. Grating positions are usually assigned consecutively from 0, and increasing position causes increasing wavelength for each detector.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot bits
+;+		(comment "The bits attribute provides the number of bits in the object.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot has_Planar_Coordinate_Information
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot document_name
+;+		(comment "The document_name attribute provides the full name of the published document. This optional attribute is used only if the title in the identification area of the document product is not sufficient.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot pixel_resolution_x
+;+		(comment " The pixel_resolution_x and pixel_resolution_y attributes indicate the image array pixel resolution %28distance%2Fpixel or degree%2Fpixel%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y resolution values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where resolution may differ for each axis %28%47rectangular%47 pixels%29. NOTE: Definition of this PDS4 attribute differs from how %47resolution%47 was defined within PDS3. ")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot pixel_resolution_y
+;+		(comment " The pixel_resolution_x and pixel_resolution_y attributes indicate the image array pixel resolution %28distance%2Fpixel or degree%2Fpixel%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y resolution values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where resolution may differ for each axis %28%47rectangular%47 pixels%29. NOTE: Definition of this PDS4 attribute differs from how %47resolution%47 was defined within PDS3. ")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot aip_lidvid
+;+		(comment "The aip_lidvid attribute provides the logical_identifier plus version_id, which uniquely identifies a Archival Information Package.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot field_format
+;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot was_associated_with
+		(type INSTANCE)
+;+		(allowed-classes Agent)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot certified_flag
+;+		(comment "The certified flag attribute indicates that the data is sufficiently complete, formatted, and documented for use by scientists who are not directly affiliated with the providers. An archive_status of \"In Peer Review\" indicates that the data product or release is not yet certified by the PDS.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot home
+;+		(comment "The home attribute indicates where  an object resides. It provides sufficient information to be able to access the object.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_composite_structure
+;+		(comment "The has_Composite_Structure association is a relationship to Composite_Structure.")
+		(type INSTANCE)
+;+		(allowed-classes Composite_Structure)
+		(create-accessor read-write))
+	(multislot display_direction
+;+		(comment "The display_direction attribute provides the preferred direction for displaying on a display device.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Polar_Stereographic
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot data_standards
+;+		(comment "The data standards association is a relationship to information about the controlling data standards.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot discipline_name
+;+		(comment "The discipline_name attribute describes the observing discipline (as opposed to a PDS Discipline Node Name, though the concepts and values are similar). Some of these values are, with respect to the PDS Nodes, inter-disciplinary and should be used when they are applicable in perference to the more restrictive values.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot stop_bit
+;+		(comment "The stop-bit attribute provides the location of the last bit in this bit field relative to the first bit in the packed_data field.  Bits are numbered continuously across byte boundaries.  The first bit location in the packed data field is \"1\".")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot telescope_longitude
+;+		(comment "The telescope_longitude attribute provides the angular distance of the telescope east (positive), measured by the angle contained between the meridian of the telescope and the reference figure (or datum) prime meridian.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot abstract_flag
+;+		(comment "The abstract flag attribute indicates whether or not the class can be instantiated. Abstract flag is only included if a value of 'true' is desired and indicates that the class is abstract and cannot be used in a label.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot reference_value_type
+;+		(comment "The reference_value_type attribute indicates whether the reference value is a logical_identifier or logical identifier plus a version_id.")
+		(type STRING)
+;+		(value "LID" "LID::VID")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot horizontal_display_direction
+;+		(comment "The horizontal_display_direction attribute specifies the direction across the screen of a display device that data along the horizontal axis of an Array is supposed to be displayed.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot polar_radius
+;+		(comment "The polar_radius attribute provides the value of the semiminor axis of the ellipsoid that defines the approximate shape of a target body. The polar radius is normal to the plane defined by the semi-major and semi-minor axes.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot was_informed_by
+;+		(comment "The was_informed_by association is a recursive relationship on activity.")
+		(type INSTANCE)
+;+		(allowed-classes Activity)
+		(create-accessor read-write))
+	(single-slot label_revision_note
+;+		(comment "The label revision note attribute provides a history of changes to the label.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot produced_by
+;+		(comment "Association for mission.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot has_Oblique_Line_Point_Group
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot registration_authority
+;+		(comment "The registration_authority attribute provides the name of the group  responsible for the terminological entry.")
+		(type STRING)
+;+		(value "PDS4" "PDS3" "VICAR")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot checksum_manifest_checksum
+;+		(comment "The checksum manifest checksum provides the checksum for the checksum manifest file.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot c_axis_radius
+;+		(comment "This attribute is used in the image map projection. Under review. xxx DDWG;DS xxx Also check why minimum value is negative.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot value_meaning
+;+		(comment "The value_meaning attribute provides the meaning, or semantic content, of the associated permissible value.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot light_source_incidence_angle
+;+		(comment "light_source_incidence_angle is an angle measured from the local surface normal vector to the direction of a photon arriving from the light source. For rings, the normal vector is that on the same side of the rings as the light source, so values always range between 0 and 90 in units of degrees. The value is always equal to 90 - %7C observed_ring_elevation %7C This will enable users to perform database searches based on the effective ring opening angle when they are not concerned about the the distinction between north-side and southside viewpoints. We have included the 'light source' prefix to the term so that this quantity is not confused with 'incidence angle', a term that is generally associated with sunlight rather than stars or radio transmitters. Required in the label if the value is constant for the observation. If the angle varies for the observation, the min and max attributes are required in the label. Optional as a field in the data table.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot observing_system_source
+;+		(comment "Associated observing system sensor.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot doi
+;+		(comment "The doi attribute provides the Digital Object Identifier for an object, assigned by the appropriate DOI System Registration Agency.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot trajectory_reference
+;+		(comment "The trajectory reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot logical_identifier
+;+		(comment "The logical_identifer attribute identifies the set of all versions of a product; it is a product identifier without a version.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot data_object
+;+		(comment "The data_object association is a relationship to Data Object.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot file_area_LID_Secondary
+;+		(comment "The file_area association is a relationship to File Area")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot alternate_title
+;+		(comment "The alternate _title attribute provides an alternate title for the product.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot optional_data_object_set
+;+		(comment "Associated optional data object set.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot first_standard_parallel
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot lidvid_reference_from
+;+		(comment "The lid_reference_from provides the identifier of the starting object in a one  directional relationship.")
+		(type INSTANCE)
+;+		(allowed-classes LIDVID_ID_Reference_From)
+		(create-accessor read-write))
+	(single-slot western_most_longitude
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot associated_nested_data_folder
+;+		(comment "The associated_nested_data_folder association is a relationship to data folders.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot total_digits
+;+		(comment "The total digits attribute indicate the maximum count of digits allowed.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_discipline_area
+;+		(comment "The has_discipline_area association is a relationship to Discipline Area.")
+		(type INSTANCE)
+;+		(allowed-classes Discipline_Area)
+		(create-accessor read-write))
+	(single-slot loop_back_and_forth_flag
+;+		(comment "The loop_back_and_forth_flag attribute specifies whether or not a movie should only be 'looped' or played repeatedly in the forward direction, or whether it should be played forward followed by played in reverse, iteratively.")
+		(type STRING)
+;+		(value "false" "true")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot archive_status
+;+		(comment "The ARCHIVE_STATUS attribute indicates the stage to which a data set has progressed in the archiving process, from IN QUEUE through ARCHIVED. It can also take on the values SUPERSEDED or SAFED, which indicate that the data set is not part of the active archive. ACCUMULATING can be appended to some values to indicate that the data set is incomplete and/or that not all components have reached the stage given by the root value; ACCUMULATING would be used, for example, when the archive is being delivered incrementally, as from a mission that lasts many months or years.")
+		(type STRING)
+;+		(value "ARCHIVED" "IN_LIEN_RESOLUTION" "IN_PEER_REVIEW" "IN_QUEUE" "LOCALLY_ARCHIVED" "PRE_PEER_REVIEW" "SAFED" "SUPERSEDED" "IN_QUEUE_ACCUMULATING" "PRE_PEER_REVIEW_ACCUMULATING" "IN_PEER_REVIEW_ACCUMULATING" "IN_LIEN_RESOLUTION_ACCUMULATING" "LOCALLY_ARCHIVED_ACCUMULATING" "ARCHIVED_ACCUMULATING")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot oblique_line_latitude
+;+		(comment "The oblique_line_latitude attribute provides the latitude of a point defining the oblique line.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot rule_type
+;+		(comment "The rule_type attribute indicates the type of statement to be executed.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot file
+;+		(comment "The file association is a relationship to File.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot brick_description
+;+		(comment "The brick_description provides a text description of the storage brick and includes at least the brick's storage format.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot data_path
+;+		(comment "The relative path from the data brick mount point to the data directories. E.g. Data_Path = \"./\" indicates that the data directories are at the mount point of the disk brick. xxx ddwg;RS xxx")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot steward_id
+;+		(comment "The steward_id attribute provides the abbreviation of the organization that manages the set of registered attributes and classes.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot local_planar_georeference_information
+;+		(comment "The local_planar_georeference_information attribute provides a description of the information provided to register the local planar system to a planet %28e.g. control points, satellite ephemeral data, inertial navigation data%29.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot scale_factor_at_center_line
+;+		(comment "The scale_factor_at_center_line attribute provides a multiplier for reducing a distance obtained from a map by computation or scaling to the actual distance along the center line.")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot url
+;+		(comment "The url attribute provides a Uniform Resource Identifier (URI) that specifies where a resource is available and the mechanism for retrieving it.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot external_source_product_identifier
+;+		(comment "The external_source_product_identifier provides unique identifiers for one or more source products that are not in the PDS4 Registry. For guidelines on the construction of this identifier, refer to section E.2.6.1.2 of the Data Provider's Handbook.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot frequency_band
+;+		(comment "The frequency_band attribute provides the one or two letter identifier for the frequency band associated with radio occultation data. Required in labels for radio occultations; not used for stellar occultations.")
+		(type STRING)
+;+		(value "C" "D" "E" "F" "G" "H" "K" "Ka" "Ku" "Q" "R" "S" "U" "V" "W" "X" "Y")
+		(create-accessor read-write))
+	(multislot isMissionOnly
+;+		(comment "The isMissionOnly attribute indicates whether a rule is for mission level dictionaries only.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot attribute_concept
+;+		(comment "The attribute_concept attribute provides the type of information (classification) conveyed by the attribute -- e.g., stop_date_time has  attribute_concept = date_time.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot max_inclusive
+;+		(comment "The max inclusive attribute provides a value that is greater than or equal to all the values in the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot relates_to_data_set
+;+		(comment "Associated data set.")
+		(type INSTANCE)
+;+		(allowed-classes Data_Set_PDS3)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot along_track_timing_offset
+;+		(comment "along_track_timing_offset is a timing offset to the along track spacecraft position. It is the value that minimizes differences in radii of matching circular ring features observed on the ingress and egress sides of the occultation track. Optional in labels for radio occultation. Nillable in which case the nil_reason should be 'inapplicable'. ")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot ring_event_stop_tdb
+;+		(comment "ring_event_stop_tdb indicates the value for latest time in the described data, and is given in ring_event_tdb format. Optional in labels; not intended for use as a table field.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot pds_address_book_flag
+;+		(comment " The pds_address_book_flag data attribute indicates whether or not a registered PDS user will have an entry in the PDS telephone directory.")
+		(type SYMBOL)
+		(allowed-values N NULL Y)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot line_projection_offset
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot maximum_record_bytes
+;+		(comment "The maximum_record_bytes atrtribute provides the maximum number of bytes that may be contained in a record.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(single-slot has_zip
+;+		(comment "The has_ZIP association is a relationship to ZIP")
+		(type INSTANCE)
+;+		(allowed-classes Zip)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot volume_id
+;+		(comment "The volume_id attribute provides a unique identifier for a data volume. Example: MG_1001.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot personnel_reference
+;+		(comment "The personnel reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier")
+		(create-accessor read-write))
+	(multislot os_version
+;+		(comment "The OS version attribute indicates the version of an operating system.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot azimuthal_angle
+;+		(comment "The azimuthal_angle attribute provides the angle measured clockwise from north, and expressed in degrees.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Group_Facet1
+;+		(comment "The has_Group_Facet1 association is a relationship to Group_Facet1.")
+		(type INSTANCE)
+;+		(allowed-classes Group_Facet1)
+		(create-accessor read-write))
+	(multislot dictionary_type
+;+		(comment "The dictionary_type attribute provides the name of a dictionary category.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Group_Facet2
+;+		(comment "The has_Group_Facet2 association is a relationship to Group_Facet2.")
+		(type INSTANCE)
+;+		(allowed-classes Group_Facet2)
+		(create-accessor read-write))
+	(multislot local_attribute
+;+		(comment "The local_attribute association is a relationship to Local_Attribute.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot associated_Special_Constants
+;+		(comment "The associated_Special_Constants association is a relationship to special constants.")
+		(type INSTANCE)
+;+		(allowed-classes Special_Constants)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot manifest_url
+;+		(comment "The manifest url provides the URL to the manifest file.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot bricks
+;+		(comment "An integer value indicating the number of data bricks in this delivery. xxx OPS;DS, check steward, negative values xxx")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot bit_string
+;+		(comment "The bit string attribute is a sequence of digital bits. It is the content of a digital object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot minimum_ring_radius
+;+		(comment "minimum_ring_radius indicates the smallest ring radius value in the data table. Units are km and are always positive. Required in label files for ring occultation data.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot resource_logical_identifier
+;+		(comment "The resource logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
+		(type STRING)
+		(default "logical_identifier")
+		(create-accessor read-write))
+	(single-slot map_resolution
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot naif_target_id
+;+		(comment "The naif_target_id element provides the numeric ID used within the SPICE system to identify the target..")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot testValArr
+;+		(comment "The testValArr attribute provides the values for the assert statement.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_document
+;+		(comment "The has_document association is a relationship to one Document.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot has_Table_Binary_Field_Sequence
+;+		(comment "The has_Table_Binary_Field_Sequence association is a relationship to field sequence.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot product_subclass
+;+		(comment "The product_subclass attribute provides the name of a subclass under a product_class. For example, User_Manual is a subclass of Product_Document.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot standard_deviation
+;+		(comment "The standard_deviation attribute provides the standard deviation of values in the associated object; empty and Special_Constants values are excluded.")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot node_logical_identifier
+;+		(comment "The node logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot spice_reference
+;+		(comment "The spice reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier::version_id")
+		(create-accessor read-write))
+	(single-slot release_parameter_text
+;+		(comment "This attribute is used in by the data set release class. It is under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot curating_node_id
+;+		(comment "The curating_node_id attribute provides the id of the node currently maintaining the data set or volume and is responsible for maintaining catalog information.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot nillable_flag
+;+		(comment "The nillable_flag attribute indicates whether an attribute is allowed to take on nil as a value.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot spice_kernel_file_name
+;+		(comment "The spice_kernel_file_name attribute is used to identify SPICE kernel files used in the production of the product.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot release_id
+;+		(comment "This attribute is used in by the data set release class. It is under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot release_medium
+;+		(comment "This attribute is used in by the data set release class. It is under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot information_model_version
+;+		(comment "The information_model_version attribute provides the  version identification of the PDS Information Model on which the label and schema are based.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot longitude_resolution
+;+		(comment "The longitude_resolution attribute indicates the minimum difference between two adjacent longitude values expressed in angular units of measure.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot mission_name
+;+		(comment "The mission_name attribute identifies a major planetary mission or project. A given planetary mission may be associated with one or more spacecraft.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot wavelength
+;+		(comment "wavelength of the observation. Optional in labels. If the observation is over a wavelength range, use the corresponding minimum and maximum attributes instead.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot classTitle
+;+		(comment "The classTitle attribute provides the name of the class to be used for display.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot bit_fields
+;+		(comment "The bit_fields attribute provides the number of defined bit fields (Field_Bit definitions) within the Packed_Data_Field.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot logical_volume_path_name
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Transverse_Mercator
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot value_offset
+;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot version_id
+;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot transfer_command_text
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot internal_reference
+;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Internal_Reference)
+		(create-accessor read-write))
+	(multislot xpath
+		(type STRING)
+		(create-accessor read-write))
+	(multislot data_set_puid
+;+		(comment "The data_set_puid attribute provides a globally unique identifer for a data set.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot east_bounding_coordinate
+;+		(comment "The east_bounding_coordinate attribute provides the eastern-most coordinate of the limit of coverage expressed in longitude.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot latitude_resolution
+;+		(comment "The latitude_resolution attribute indicates the minimum difference between two adjacent latitude values expressed in angular units of measure.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot ring_event_start_time_utc
+;+		(comment "ring_event_start_time_utc gives the UTC time corresponding to the earliest time given by ring_event_time or ring_event_tdb in the data table. ring_event_start_time_utc is required for all ring occultation data. ring_event_start_time_utc is required label attribute for all ring occultation data.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_type_list_area
+;+		(comment "The has_type_list_area association is a relationship to Type_List_Area.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot resource_desc
+;+		(comment "The resource_desc attribute provides a description for the resource")
+		(type STRING)
+		(default "UNK")
+;+		(value "Text")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot reference_collection_reference
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot detector_number
+;+		(comment "The detector_number attribute provides the spectrometer detector number corresponding to a band of a spectral qube. Detector numbers are usually assigned consecutively from 1, in order of increasing wavelength.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot planar_coordinate_encoding_method
+;+		(comment "The planar_coordinate_encoding_method attribute indicates the means used to represent horizontal positions.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot volume_set_name
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot apostrophe
+;+		(comment "apostrophe = \"'\" ; (* apostrophe *)")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot distance_resolution
+;+		(comment "The distance_resolution attribute provides the minimum distance measurable between two points, expressed in Planar Distance Units of measure.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot center_wavelength
+;+		(comment "The center_wavelength attribute provides the wavelength or frequency describing the center of a bin along the band axis of a spectral qube. When describing data from a spectrometer, the value corresponds to the peak of the response function for a particular detector and%2For grating position.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot refer_data_producer
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot map_scale
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_tagged_data_object
+;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot id_reference_from
+;+		(comment "The id_reference_from provides the identifier of the starting object in a  one directional relationship.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot member_entry
+;+		(comment "The member_entry association is a relationship to Member_Entry.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot entity_type
+;+		(comment "The entity_type attribute provides a classification for the entity.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot local_value_domain
+;+		(comment "The local_value_domain association is a relationship to Value_Domain.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot any_attribute
+;+		(comment "xxx ddwg;DS xxx")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot processing_level_id
+;+		(comment "The processing_level_id attribute provides a broad indication of data processing level.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot category
+;+		(comment "The category attribute identifies the type of function that the tool or service performs.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot reference_entry
+;+		(comment "The reference_entry association is a relationship to Reference_Entry.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot registered_by
+;+		(comment "The registered_by attribute provides the name of the person or organization that registered the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot row_bytes
+;+		(comment "The row bytes attribute provides the count of the bytes in a row.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot comment
+;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot earth_received_stop_time
+;+		(comment "The earth_received_stop_time attribute gives the ending time at which a signal (such a telemetry) was received on Earth")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot semi_major_radius
+;+		(comment "The semi_major_axis attribute provides the radius of the equatorial axis of the ellipsoid.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot validation_format
+;+		(comment "The validation_format attribute gives the magnitude and precision of the data value with the expectation that both will be validated exactly. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section \"Field Formats\" for details.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot software_dialect
+;+		(comment "The software dialect attribute indicates the variety of a language used to write the software.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot longitude_of_central_meridian
+;+		(comment "The longitude_of_central_meridian attribute defines the line of longitude at the center of a map projection generally used as the basis for constructing the projection.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot property_map_type
+;+		(comment "The property_map_type attribute indicates the category of the property map.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot coordinate_source
+;+		(comment "The coordinate_source attribute provides the reference figure or datum.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot puid
 ;+		(comment "The puid (planetary unique identifier) attribute provides a globally unique identifer for an object.")
@@ -3983,84 +3669,229 @@
 ;+		(allowed-classes Citation_Information)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot latitude
-;+		(comment "The latitude attribute provides the angular distance north or south from the equator of a point on the object's surface, measured on the meridian of the point.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot alternative
-;+		(comment "An alternative name for the resource. Dublin Core.")
+	(multislot sample_display_direction
+;+		(comment "The sample_display_direction attribute provides the preferred orientation of samples within a line for viewing on a display device. The default is right, meaning samples are viewed from left to right on the display. sample_display_direction must be used with line_display_direction.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot brick_description
-;+		(comment "The brick_description provides a text description of the storage brick and includes at least the brick's storage format.")
+	(multislot has_Software
+;+		(comment "The has_Software association is a relationship to Software.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot virtual_relation
+;+		(comment "The virtual_relation association is a relationship to Virtual_Relation.")
+		(type INSTANCE)
+;+		(allowed-classes Virtual_Relation)
+		(create-accessor read-write))
+	(single-slot not_applicable_constant
+;+		(comment "The not_applicable_constant attribute provides a value that indicates the parameter is not applicable.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot planet_day_number
+;+		(comment "The planet_day_number attribute provides the number of solar days (sols) on a rotating solar system body since a reference event, such as the landing of a spacecraft. The day of landing is usually defined as planet_day_number=0.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot missing_constant
+;+		(comment "The missing_constant attribute provides a value that indicates the original value was missing, such as due to a gap in coverage.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot associated_Electronic_Mail
+;+		(comment "The associated_Electronic_Mail association is a relationship to Electronic Mail.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot line_last_pixel
+;+		(comment "This attribute is used in the image map projection. Under review.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot default_green
+;+		(comment "The default_green attribute provides  the number of the plane along the axis that is to be loaded, by default, into the green plane of a display device.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(single-slot archive_status_note
+;+		(comment "The archive status note attribute provides a comment about the archive status.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot element_bytes
+;+		(comment "The element_bytes attribute provides the  number of bytes in the array element.")
+		(type INTEGER)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot medium_format
 ;+		(comment "This attribute is used in by the volume class. It is under review.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot data_set_desc
-;+		(comment "The data_set_desc attribute describes the content and type of a data set and provides information required to use the data (such as binning information).")
+	(single-slot group_location
+;+		(comment "The group_location attribute provides the starting position for a Group_Field within the containing Record or Group_Field class, in bytes. Location '1' indicates the first byte of the containing class.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot property_map_subtype
+;+		(comment "The property_map_subtype attribute indicates the subcategory of the property map.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot observed_event_start_tdb
+;+		(comment "observed_event_start_tdb indicates the value for earliest time in the described data, and is given in elapsed seconds since the J2000 epoch. Optional in labels; not intended for use as a table field.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot full_name
+;+		(comment "The full_name attribute provides the complete name for a person and includes titles and suffixes.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Schematron_Assert
+		(type INSTANCE)
+;+		(allowed-classes Schematron_Assert)
+		(create-accessor read-write))
+	(multislot vector
+;+		(comment "The vector assocation is a relationship to Vector objects.")
+		(type INSTANCE)
+;+		(allowed-classes Vector)
+		(create-accessor read-write))
+	(multislot instrument_host_reference
+;+		(comment "The instrument host  reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier")
+		(create-accessor read-write))
+	(multislot associated_descriptive_files
+;+		(comment "The associated_descriptive_files association is a relationship to description files.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(multislot instrument_host_name
+;+		(comment "The instrument_host_name attribute provides the full name of the platform or facility upon which an instrument or other device is mounted. For example, the host can be a spacecraft, a ground-based telescope, or a laboratory.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot record_bytes
+;+		(comment "The record_bytes attribute provides a count of the bytes in a record, including a record delimiter if present.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot maximum_value_exclusive_flag
+;+		(comment "The maximum_value_exclusive_flag attribute indicates that the  maximum_value is exclusive, when true.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot dd_class_reference
+;+		(comment "The dd_class_reference association is a relationship to DD_Class_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes DD_Class_Reference)
+		(create-accessor read-write))
+	(single-slot UpperModel_140908c_1300_CCB63_Class1
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot pixel_scale_y
+;+		(comment " The pixel_scale_x and pixel_scale_y attributes indicate the image array pixel scale %28pixel%2Fdegree or pixel%2Fdistance%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y scale values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where scale may differ for each axis %28%47rectangular%47 pixels%29. NOTE1: For presentation of hard-copy maps, a map scale is traditionally expressed as a %47representative fraction%47 %28the ratio of a hard-copy map to the actual subject surface %28e.g. 1:250,000, where one unit of measure on the map equals 250,000 of the same unit on the body surface%29%29. This usage is relevant when map%2Fdata are presented on hard-copy media %28paper, computer screen,etc%29. When defining pixel scale within a stored image%2Farray context here, we are expressing a ratio between the image array and the actual surface %28thus, pixel%2Fdegree or pixel%2Fdistance units%29. NOTE2: Definition of this PDS4 attribute differs from how %47scale%47 was defined within PDS3 ")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot pixel_scale_x
+;+		(comment " The pixel_scale_x and pixel_scale_y attributes indicate the image array pixel scale %28pixel%2Fdegree or pixel%2Fdistance%29 relative to the Cartesian %28x,y%29 coordinate system as defined by the map projection. Due to varying properties across different map projections, actual surface distances for an individual pixel may be accurate only at specific location%28s%29 within the image array %28e.g. reference latitude or longitude, standard parallels, etc%29. For most PDS products, x and y scale values are equal %28%47square%47 pixels%29. The inclusion of both x and y attributes allows for anticipated products where scale may differ for each axis %28%47rectangular%47 pixels%29. NOTE1: For presentation of hard-copy maps, a map scale is traditionally expressed as a %47representative fraction%47 %28the ratio of a hard-copy map to the actual subject surface %28e.g. 1:250,000, where one unit of measure on the map equals 250,000 of the same unit on the body surface%29%29. This usage is relevant when map%2Fdata are presented on hard-copy media %28paper, computer screen,etc%29. When defining pixel scale within a stored image%2Farray context here, we are expressing a ratio between the image array and the actual surface %28thus, pixel%2Fdegree or pixel%2Fdistance units%29. NOTE2: Definition of this PDS4 attribute differs from how %47scale%47 was defined within PDS3 ")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot revision_id
+;+		(comment "The revision_id attribute provides the revision level of a document, which may be set outside PDS and may be different from its version_id.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot virtual_structure
+;+		(comment "The virtual_structure association is a relationship to Virtual Structure")
+		(type INSTANCE)
+;+		(allowed-classes Virtual_Structure)
+		(create-accessor read-write))
+	(multislot license_information
+;+		(comment "The license_information is a relationship to License_Information.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot group_number
+;+		(comment "The group_number attribute provides the position of a group, within a series of groups, counting from 1.  If two groups within a record are physically separated by one or more fields, they have consecutive group numbers; the intervening fields are numbered separately.  Groups within a parent group, but separated by one or more fields, will also have consecutive group numbers.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(single-slot start_time
+;+		(comment "The start_time attribute provides the date and time of the beginning of an event or observation (whether it be a spacecraft, ground-based, or system event) in UTC.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot data_set_reference
+;+		(comment "Association for additional information.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot data_set_terse_desc
+;+		(comment "A one line description of the data set")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot product_type
-;+		(comment "The product type attribute provides the name of a class of which this object is a member.")
+	(single-slot desc
 		(type STRING)
-;+		(cardinality 1 1)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot has_movie_display_settings
-;+		(comment "The has_movie_display_settings association is a relationship to Movie_Display_Settings.")
+	(single-slot field_location
+;+		(comment "The field_location attribute provides the starting byte for a field within a record or group, counting from '1'.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_manifest
+;+		(comment "The has_manifest association is a relationship to a manifest.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot elements
+;+		(comment "The elements attribute provides the count of the number of elements along an array axis.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot associated_data_object
+;+		(comment "The associated_data_object association is a relationship to data object.")
+		(type INSTANCE)
+;+		(allowed-classes Tagged_Digital_Object Tagged_NonDigital_Object)
+		(create-accessor read-write))
+	(single-slot has_Resource_Section
+;+		(comment "The has_Resource_Section association is a relationship to resources.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot has_File
-;+		(comment "The has_File association is a relationship to File.")
-		(type INSTANCE)
-;+		(allowed-classes File)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot last_modification_date_time
-;+		(comment "The last_modification_date_time attribute gives the most recent date and time that a change was made.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot data_standards
-;+		(comment "The data standards association is a relationship to information about the controlling data standards.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot reference_text
-;+		(comment "The reference_text attribute provides a complete bibliographic citation for a published work.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot data_collection_reference
-;+		(comment "The data collection reference attribute provides the logical_identifier for a data collection.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot stop_date_time
-;+		(comment "The stop_date_time attribute provides the date and time at the end of a time interval of interest.")
+	(single-slot telemetry_source_name
+;+		(comment "The telemetry_source_name attribute identifies the telemetry source used in creation of a data set.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot ring_profile_direction
-;+		(comment "ring_profile_direction indicates the radial direction of a ring occultation within a particular data product. Possible values are 'Ingress', 'Egress', or 'Multiple'. The value 'Multiple' is only used for some Hubble-based occultations where the occultation track is not monotonic over relatively short time scales. Required in labels of ring occultation observations. Not intended as a value for a table field.")
-		(type STRING)
-;+		(value "Egress" "Ingress" "Multiple")
-		(create-accessor read-write))
-	(multislot rights
-;+		(comment "Information about rights held in and over the resource. - Dublin Core")
+	(multislot id_reference_type
+;+		(comment "The id_reference_type attribute provides the name of an association between two objects.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot longitude_direction
-;+		(comment "The longitude_direction attribute identifies the direction of longitude %28e.g. POSITIVE_EAST or POSITIVE_WEST%29 for a planet. The IAU definition for direction of positive longitude is adopted. Typically, for planets with prograde rotations, positive longitude direction is to the west. For planets with retrograde rotations, positive longitude direction is to the east. Note: The longitude_direction attribute should be used for planetographc systems, but not for planetocentric.")
+	(multislot instrument_serial_number
+;+		(comment "The instrument serial number element provides the manufacturer's serial number assigned to an instrument. This number may be used to uniquely identify a particular instrument for tracing its components or determining its calibration history, for example.")
 		(type STRING)
+		(create-accessor read-write))
+	(single-slot refer_discipline
+;+		(comment "Associated Discipline")
+		(type INSTANCE)
+;+		(allowed-classes)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot container_file_name
-;+		(comment "The file name attribute provides a word or a combination of words by which the file is known. The role of this file is a container.")
+	(multislot quaternion_components
+;+		(comment "The quaternion_components attribute provides a count of quaternion components.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(single-slot hardware_model_id
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot source_product_external
+;+		(comment "The source_product_external association is a relationship to Source Product External.")
+		(type INSTANCE)
+;+		(allowed-classes Source_Product_External)
+		(create-accessor read-write))
+	(single-slot max_exclusive
+;+		(comment "The max exclusive attribute provides a value that is greater than all the values in the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -4069,300 +3900,79 @@
 		(type INSTANCE)
 ;+		(allowed-classes Target_Identification)
 		(create-accessor read-write))
-	(single-slot instrument_desc
-;+		(comment "The instrument_desc attribute describes a given instrument.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot instrument_type
-;+		(comment "The instrument_type attribute identifies the type of an instrument. Example values: POLARIMETER SPECTROMETER")
+	(multislot ring_event_stop_time_utc
+;+		(comment "ring_event_stop_time_utc gives the UTC time corresponding to the latest time given by ring_event_time or ring_event_tdb in the data table. ring_event_stop_time_utc is required for all ring occultation data. ring_event_stop_time_utc is required label attribute for all ring occultation data.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot fraction_digits
-;+		(comment "The fraction digits indicates the number of digits in the faction part of a real number.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot bearing_reference_meridian
-;+		(comment "The bearing_reference_meridian attribute specifies the axis from which the bearing is measured.")
-		(type STRING)
-;+		(value "Assumed" "Astronomic" "Geodetic" "Grid" "Magnetic")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot associated_Statistics
-;+		(comment "The associated_Object_Statistics association is a relationship to object statistics.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot checksum_type
-;+		(comment "The checksum type attribute provides the name of the checksum algorithm used to calculate the checksum value.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot format_type
-;+		(comment "The format_type attribute provides the format, protocol, or language within which an entire document is constructed (e.g., TEXT, PDF-A, HTML).  This is distinct from encoding_type and external_standard_id, which are used to describe component files within the document.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_Transverse_Mercator
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot directory_path_name
-;+		(comment "The directory_path_name attribute provides a sequence of names that locates a directory in a hierarchy of directories.")
-		(type STRING)
-		(default "_name-slash_*")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot target_reference
-;+		(comment "The target reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier")
-		(create-accessor read-write))
-	(single-slot node_logical_identifier
-;+		(comment "The node logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot spacecraft_clock_stop_count
-;+		(comment "The spacecraft_clock_stop_count attribute provides the value of the spacecraft clock at the end of a time period of interest.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot a_axis_radius
-;+		(comment "This attribute is used in the image map projection. Under review. xxx DDWG;DS xxx Also check why minimum value is negative.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot observing_system_reference
-;+		(comment "The observing system reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier")
-		(create-accessor read-write))
-	(multislot line_display_direction
-;+		(comment "The line_display_direction element is the preferred orientation of lines within an image for viewing on a display device.  The default value is down, meaning lines are viewed top to bottom on the display. Note that if this keyword is present in a label, the SAMPLE_DISPLAY_DIRECTION keyword must also be present and must contain a value orthogonal to the value selected for this keyword.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot center_latitude
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot upper_110304_forked_DONesting_Slot_12
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot transfer_object_id
-;+		(comment "The transfer_object_id is an NSSDC provided identifier for the digital information object within a SIP that is to be preserved in an AIP.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot field_delimiter
-;+		(comment "The field_delimiter attribute provides the character that marks the boundary between two fields in a delimited table.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot rule_assign
-;+		(comment "The rule_assign attribute provides an assignment statement for a schematron rule.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot funding_year
-;+		(comment "The funding_year attribute provides the year that funding was awarded.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot nssdc
-;+		(comment "The nssdc association is a relationship to NSSDC.")
-		(type INSTANCE)
-;+		(allowed-classes NSSDC)
-		(create-accessor read-write))
-	(single-slot institution_name
-;+		(comment "The institution_name attribute provides the name of the associated institution.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot element_flag
-;+		(comment "The element flag attribute indicates whether or not the class is defined as a xs:element in XML Schema.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot node_desc
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot pds4_merge_flag
-;+		(comment "The PDS4 merge flag attribute indicates that the local data dictionary should be merged with the PDS4 data dictionary and accept the PDS as the data dictionary's registration authority. The merge process requires validation that the local data dictionary conforms to PDS data standards.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot minimum_ring_radius
-;+		(comment "minimum_ring_radius indicates the smallest ring radius value in the data table. Units are km and are always positive. Required in label files for ring occultation data.")
+	(multislot latitude
+;+		(comment "The latitude attribute provides the angular distance north or south from the equator of a point on the object's surface, measured on the meridian of the point.")
 		(type FLOAT)
 		(create-accessor read-write))
-	(single-slot archive_bundle
-;+		(comment "The archive bundle association is a relationship to the archive bundle class.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot groups
-;+		(comment "The groups attribute provides a count of the total number of groups directly associated with a table record.  Groups within groups within the record are not included in this count.")
-		(type INTEGER)
-		(create-accessor read-write))
-	(multislot has_Equirectrangular
-;+		(comment "The xxx association is a relationship to yyy.")
-		(type INSTANCE)
-;+		(allowed-classes XSChoice%23)
-		(create-accessor read-write))
-	(multislot star_name
-;+		(comment "star_name provides the identifying name of star, including the catalog name if necessary. Examples include 'sigma Sgr' and 'SAO 123456' %28for star number 123456 in the Smithsonian Astrophysical Observatory catalog%29. Use 'Sun' for solar occultations. Required in labels for stellar and solar occultations. Not used for radio occultations.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot record_bytes
-;+		(comment "The record_bytes attribute provides a count of the bytes in a record, including a record delimiter if present.")
+	(single-slot start_bit
+;+		(comment "The start_bit attribute provides the position of the first bit within an ordered sequence of bits.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot electronic_mail_type
+	(single-slot time_display_axis
+;+		(comment "The time_display_axis attribute identifies, by name, the axis of an Array %28or Array subclass%29, the bands of which are intended to be displayed sequentially in time on a display device. The frame_rate attribute, if present, provides the rate at which these bands are to be displayed.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot external_reference
+;+		(comment "The external_reference association is a relationship to External_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes External_Reference)
+		(create-accessor read-write))
+	(multislot local_rule
+;+		(comment "The local_rule association is a relationship to DD_Rule")
+		(type INSTANCE)
+;+		(allowed-classes DD_Rule)
+		(create-accessor read-write))
+	(multislot team_name
+;+		(comment "The team_name attribute provides the name of a group of individuals working together.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot discipline_name_2
+;+		(comment "The discipline_name attribute identifies the major academic or scientific domain or specialty of interest to an individual or to a PDS Node.")
+		(type STRING)
+;+		(value "Engineering" "Geosciences" "Imaging" "Navigation_Ancillary_Information_Facility" "Planetary_Atmospheres" "Planetary_Plasma_Interactions" "Planetary_Rings" "Radio_Science" "Small_Bodies")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot country
+;+		(comment "The country attribute provides the full  name of a country.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot property_map_subtype
-;+		(comment "The property_map_subtype attribute indicates the subcategory of the property map.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot rule_message
-;+		(comment "The rule_message attribute provides a message to be displayed by the schematron processor when the test condition is  met.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot std_ref_version_id
+;+		(comment "The std ref version id attribute provides the version identifier for the standard reference document.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot repertoire_list
-;+		(comment "UTF-8 (8-bit UCS/Unicode Transformation Format) is a variable-length character encoding for Unicode. It is able to represent any character in the Unicode standard, yet is backwards compatible with ASCII.")
-		(type STRING)
-;+		(value "UTF-8")
+	(single-slot received_packets
+;+		(comment "The received_packets attribute provides the total number of telemetry packets which constitute a reconstructed data product, cf. expected_packets.")
+		(type INTEGER)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot rule_statement
+;+		(comment "The rule_statement association is a relationship to DD_Rule_Statement")
+		(type INSTANCE)
+;+		(allowed-classes DD_Rule_Statement)
+		(create-accessor read-write))
+	(multislot mission_phase_name
+;+		(comment "The mission_phase_name attribute provides the commonly recognized name for a mission phase.")
+		(type STRING)
 		(create-accessor read-write))
 	(multislot has_Bounding_Coordinates
 ;+		(comment "The xxx association is a relationship to yyy.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot any_attribute
-;+		(comment "xxx ddwg;DS xxx")
+	(multislot spacecraft_clock_start_count
+;+		(comment "The spacecraft_clock_start_count attribute provides the value of the spacecraft clock at the beginning of a time period of interest.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot document_standard_id
-;+		(comment "The document_standard_id attribute provides the formal name of a standard used for the structure of a document file.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Funding_Acknowledgement
-;+		(comment "The has_Funding_Acknowledgement association is a relationship to Funding_Acknowledgement.")
-		(type INSTANCE)
-;+		(allowed-classes Funding_Acknowledgement)
-		(create-accessor read-write))
-	(multislot minimum_radial_sampling_interval
-;+		(comment "minimum_radial_sampling_interval indicates the smallest radial spacing between consecutive points in a ring profile. In practice, this may be somewhat smaller than the radial_resolution because a profile may be over-sampled. If the value of radial_sampling_interval varies, the minimum and maximum attributes are required in labels. Not intended to be used as a table field.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot certified_flag
-;+		(comment "The certified flag attribute indicates that the data is sufficiently complete, formatted, and documented for use by scientists who are not directly affiliated with the providers. An archive_status of \"In Peer Review\" indicates that the data product or release is not yet certified by the PDS.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot publication_year
-;+		(comment "The publication_year attribute provides the year in which the product should be considered as published. Generally, this will be the year the data were declared \"Certified\" or \"Archived\".")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot member_status
-;+		(comment "The member_status attribute indicates whether the collection is a primary or secondary member of the bundle.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot data_provider_name
-;+		(comment "The data_provider_name attribute provides the name of the individual responsible for providing the release object and data.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot light_source_incidence_angle
-;+		(comment "light_source_incidence_angle is an angle measured from the local surface normal vector to the direction of a photon arriving from the light source. For rings, the normal vector is that on the same side of the rings as the light source, so values always range between 0 and 90 in units of degrees. The value is always equal to 90 - %7C observed_ring_elevation %7C This will enable users to perform database searches based on the effective ring opening angle when they are not concerned about the the distinction between north-side and southside viewpoints. We have included the 'light source' prefix to the term so that this quantity is not confused with 'incidence angle', a term that is generally associated with sunlight rather than stars or radio transmitters. Required in the label if the value is constant for the observation. If the angle varies for the observation, the min and max attributes are required in the label. Optional as a field in the data table.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot enumeration_flag
-;+		(comment "The enumeration_flag attribute indicates whether there is an enumerated set of permissible values.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot reference_relation_desc
-;+		(comment "The reference relation desc attribute provides a short description of the relationship between two objects.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Information_Package_Component
-;+		(comment "The has_Information_Package_Component association is a relationship to a Information_Package_Component.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot validation_format
-;+		(comment "The validation_format attribute gives the magnitude and precision of the data value with the expectation that both will be validated exactly. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section \"Field Formats\" for details.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot node_manager_pds_users_id
-;+		(comment "The da_contact indicates the node person responsible for data administration.")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot data_path
-;+		(comment "The relative path from the data brick mount point to the data directories. E.g. Data_Path = \"./\" indicates that the data directories are at the mount point of the disk brick. xxx ddwg;RS xxx")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot altitude
-;+		(comment "The altitude attribute provides the height of anything above a given reference plane.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot note
-;+		(comment "The note attribute provides an explanatory or critical comment.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot field_bytes
-;+		(comment "The field bytes attribute provides the maximum number of bytes allowed for a field.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot apostrophe
-;+		(comment "apostrophe = \"'\" ; (* apostrophe *)")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot personnel_reference
-;+		(comment "The personnel reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(default "logical_identifier")
-		(create-accessor read-write))
-	(multislot target_name
-;+		(comment "The target_name attribute provides a name by which the target is formally known.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot maximum_sampling_parameter
-;+		(comment "The maximum_sampling_parameter element identifies the maximum value at which a given data item was sampled. For example, a spectrum that was measured in the 0.4 to 3.5 micrometer spectral region would have a maximum_sampling_parameter value of 3.5. The sampling parameter constrained by this value is identified by the sampling_parameter_name element. Note: The unit of measure for the sampling parameter is provided by the unit element.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot maximum_observed_event_time
-;+		(comment "maximum_observed_event_time gives the largest value for observed_event_time in the associated data file. It is given in numeric seconds as an offset from the specified UTC reference time. maximum_observed_event_time is optional in labels since the data file time interval end point values are given by the required start_date_time_utc and stop_date_time_utc attributes in the Time_Coordinates class.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(single-slot maximum_latitude
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot resource_puid
-;+		(comment "The resource_puid attribute provides a globally unique identifer for a resource.")
+	(multislot sclk_stop_time
+;+		(comment "sclk_stop_time is the value of the spacecraft clock corresponding to the stop_date_time given in the label.")
 		(type STRING)
 		(create-accessor read-write))
 	(multislot has_Checksum_Manifest
@@ -4370,189 +3980,374 @@
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot title
-;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot wavelength_range
-;+		(comment "The wavelength range attribute specifies the wavelength range over which the data were collected or which otherwise characterizes the observation(s). Boundaries are vague, and there is overlap.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot display_direction
-;+		(comment "The display_direction attribute provides the preferred direction for displaying on a display device.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot associated_Special_Constants
-;+		(comment "The associated_Special_Constants association is a relationship to special constants.")
+	(multislot local_static_permissible_value
 		(type INSTANCE)
-;+		(allowed-classes Special_Constants)
-;+		(cardinality 0 1)
+;+		(allowed-classes DD_Static_Permissible_Value)
 		(create-accessor read-write))
-	(multislot associated_Property_Map
-;+		(comment "The associated_Property_Map association is a relationship to property map.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot observed_event_stop_tdb
-;+		(comment "observed_event_stop_tdb indicates the value for latest time in the described data, and is given in elapsed seconds since the J2000 epoch. Optional in labels; not intended for use as a table field.")
-		(type FLOAT)
-		(create-accessor read-write))
-	(multislot target_puid
-;+		(comment "The target_puid attribute provides a globally unique identifer for a target.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot center_wavelength
-;+		(comment "The center_wavelength attribute provides the wavelength or frequency describing the center of a bin along the band axis of a spectral qube. When describing data from a spectrometer, the value corresponds to the peak of the response function for a particular detector and%2For grating position.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot standard_deviation
-;+		(comment "The standard_deviation attribute provides the standard deviation of values in the associated object; empty and Special_Constants values are excluded.")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot refer_discipline
-;+		(comment "Associated Discipline")
-		(type INSTANCE)
-;+		(allowed-classes)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot specMesg
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot mission_logical_identifier
-;+		(comment "The mission logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot map_projection_type
-;+		(comment "This attribute is used in the image map projection. Under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot filter_number
-;+		(comment "The filter_number attribute of a spectral qube describes the physical location of a band %28identified by the band_number%29 in a detector array. Filter 1 is on the leading edge of the array.")
+	(single-slot records
+;+		(comment "The records attribute provides a count of records.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Universal_Polar_Stereographic
-;+		(comment "The xxx association is a relationship to yyy.")
+	(multislot standard_parallel_1
+;+		(comment "The standard_parallel_1 attribute defines the first standard parallel %28applicable only for specific projections%29, the first line of constant latitude at which the surface of the planet and the plane or developable surface intersect. ")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot standard_parallel_2
+;+		(comment "The standard_parallel_2 attribute defines the second standard parallel %28applicable only for specific projections, a subset of specific projections where a first standard parallel is applicable%29, the second line of constant latitude at which the surface of the planet and the plane or developable surface intersect. ")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot id_reference_to
+;+		(comment "The id_reference_to provides the identifier of the ending object in a one  directional relationship.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot reference_frame_id
+;+		(comment "The reference frame id attribute identifies a reference frame, an origin and set of axes, the physical realization of a reference system, i.e., the reference frame orientation and axes are established by the reported coordinates of datum points in the reference system.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot definition
+;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot grid_coordinate_system_name
+;+		(comment "The grid_coordinate_system_name attribute provides the name of the grid coordinate system.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot valid_minimum
+;+		(comment "The valid_minimum attribute specifies the minimum valid value in the field or digital object with which the Special_Constants class is associated. Values below the valid_minimum have a special meaning. Values of this attribute should be represented in the same data_type as the elements in the object or field described.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot program_notes_id
+;+		(comment "The program notes id attribute provides an identifier to a brief statement giving particulars about a software program.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot value_data_type
+;+		(comment "The value_data_type attribute is used in a data dictionary to specify the data type of an attribute's value.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot compile_note
+;+		(comment "The compile note attribute provides a brief statement giving particulars about the compilation of the software source.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Document_Section
+;+		(comment "The has_Document_Section association is a relationship to Document Sections.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot has_investigation_area
-;+		(comment "The hsa_investigation_area association is a relationship to Investigation_Area.")
-		(type INSTANCE)
-;+		(allowed-classes Investigation_Area)
+	(multislot alternate_designation
+;+		(comment "The alternate_designation attribute provides a known alternate name or identifier.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot checksum_type
+;+		(comment "The checksum type attribute provides the name of the checksum algorithm used to calculate the checksum value.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot original_band
+;+		(comment "The original_band attribute of a spectral qube provides the sequence of band numbers in the qube relative to some original qube. In the original qube, the values are just consecutive integers beginning with 1. In a qube which contains a subset of the bands in the original qube, the values are the original sequence numbers from that qube.")
+		(type INTEGER)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot collected_about
 ;+		(comment "The collected_about association is a relationship to target.")
 		(type INSTANCE)
 ;+		(allowed-classes Target)
 		(create-accessor read-write))
-	(single-slot line_last_pixel
-;+		(comment "This attribute is used in the image map projection. Under review.")
+	(multislot type_description
+;+		(comment "The type_description attribute provides a description of the object's type.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot minimum_occurrences
-;+		(comment "The minimum occurrences attribute indicates the number of times something may occur. It is also called the minimum cardinality.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot local_value_domain
-;+		(comment "The local_value_domain association is a relationship to Value_Domain.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot collected_from
-;+		(comment "The collected_from association is a relationship to target.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot file
-;+		(comment "The file association is a relationship to File.")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(multislot mission_puid
-;+		(comment "The mission_puid attribute provides a globally unique identifer for a mission.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot trajectory_reference
-;+		(comment "The trajectory reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot start_time
-;+		(comment "The start_time attribute provides the date and time of the beginning of an event or observation (whether it be a spacecraft, ground-based, or system event) in UTC.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_delimited_record
-;+		(comment "The has_delimited_record association is a relationship to record.")
-		(type INSTANCE)
-;+		(allowed-classes)
 		(create-accessor read-write))
 	(multislot was_derived_from
 ;+		(comment "The was_derived_from association is a recursive relationship on entity.")
 		(type INSTANCE)
 ;+		(allowed-classes Entity)
 		(create-accessor read-write))
-	(single-slot stop_bit
-;+		(comment "The stop-bit attribute provides the location of the last bit in this bit field relative to the first bit in the packed_data field.  Bits are numbered continuously across byte boundaries.  The first bit location in the packed data field is \"1\".")
+	(single-slot unit_id
+;+		(comment "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot reference_key_id
+;+		(comment "The reference_key_id attribute provides the catalog with an identifier for a reference document.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot volume_version_id
+;+		(comment "The volume_version_id attribute identifies the version of a data volume. All original volumes should use a volume_version_id of 'Version 1'.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot bearing_resolution
+;+		(comment "The bearing_resolution attribute provides the minimum angle measurable between two points.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot ring_plane
+;+		(comment "ring_plane indicates the plane upon which parameters such as ring_radius are based. Possible values for the Saturn ring system are 'Equator', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'Phoebe'. For the Uranus ring system values are 'Equator', 'Six', 'Five', 'Four', 'Alpha', 'Beta', 'Eta', 'Gamma', 'Delta', 'Lambda','Epsilon',Nu, Mu. Required in labels of ring occultation observations.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot xml_schema_collection_reference
+;+		(comment "The xml schema collection reference attribute provides the logical_identifier for a xml schema collection.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot scale_factor_at_central_meridian
+;+		(comment "The scale_factor_at_central_meridian attribute provides a multiplier for reducing a distance obtained from a map by computation or scaling to the actual distance along the central meridian.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot record_length
+;+		(comment "The record_length attribute provides the length of a record, including a record delimiter if present.")
 		(type INTEGER)
+		(create-accessor read-write))
+	(multislot minimum_wavelength
+;+		(comment "minimum_wavelength is the smallest wavelength used in the observation. Optional in labels. Used with maximum_wavelength when the observation is over a wavelength range.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot target_name
+;+		(comment "The target_name attribute provides a name by which the target is formally known.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot last_sampling_parameter_value
+;+		(comment "The last_sampling_parameter_value element provides the last value in an ascending series and is therefore the maximum value at which a given data item was sampled.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot has_observing_system
+;+		(comment "The has_observing_system association is a relationship to Observing_System.")
+		(type INSTANCE)
+;+		(allowed-classes Observing_System)
+		(create-accessor read-write))
+	(multislot sub_stellar_ring_azimuth
+;+		(comment "sub_stellar_ring_azimuth is an angle measured at a point in the ring plane, starting from the direction of a photon arriving from a star, and ending at the direction of a local radial vector. This angle is projected into the ring plane and measured in the prograde direction. Values range from 0 to 360 in units of degrees. For stellar occultation data, this angle is equal to %28observed_ring_azimuth %2B 180%29 mod 360. It is available only for backward compatibility with previously published Cassini UVIS occultation data analysis; observed_ring_azimuth is the preferred quantity for archiving. sub_stellar_ring_azimuth is an optional data table field for Cassini UVIS occultation data; not recommended for other occultation data. In a label, the min and max variation attributes are optional for Cassini UVIS occultation data; not recommended for other occultation data.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot lid_reference
+;+		(comment "The lid_reference attribute provides the logical_identifier for a  product.")
+		(type STRING)
+		(default "logical_identifier")
+		(create-accessor read-write))
+	(single-slot map_projection_type
+;+		(comment "This attribute is used in the image map projection. Under review.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Table_Binary_Field_Sequence
-;+		(comment "The has_Table_Binary_Field_Sequence association is a relationship to field sequence.")
+	(multislot maximum_ring_radius
+;+		(comment "maximum_ring_radius indicates the largest ring radius value in the data table. Units are km and are always positive. Required in label files for ring occultation data.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot has_Discipline_Facets
+;+		(comment "The has_Discipline_Facets association is a relationship to Discipline_Facets.")
+		(type INSTANCE)
+;+		(allowed-classes Discipline_Facets)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot Term_Map_SKOS_to_Term_Entry_SKOS
+;+		(comment "The Term_Map_SKOS_to _Term_Entry_SKOS association is a relationship to Terminological_Entry_SKOS.")
+		(type INSTANCE)
+;+		(allowed-classes Terminological_Entry_SKOS)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot value
+;+		(comment "The value attribute provides a single, allowed numerical or character string value.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot logical_volumes
+;+		(comment "This attribute is used in by the volume class. It is under review.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot has_primary_result_description
+;+		(comment "The has_primary_result_description association is a relationship to Primary_Result_Description.")
+		(type INSTANCE)
+;+		(allowed-classes Primary_Result_Summary)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot data_regime
+;+		(comment "The data_regime attribute provides the wavelength (or an analogous concept for things like particle detectors) of the observations, stated as a category.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot file_area_inventory
+;+		(comment "The file_area association is a relationship to File Area")
 		(type INSTANCE)
 ;+		(allowed-classes)
 		(create-accessor read-write))
-	(single-slot file_name_delimiter
-;+		(comment "The file name delimiter separates the file name from the file extension.")
+	(multislot source_product_internal
+;+		(comment "The source_product_internal association is a relationship to Source_Product_Internal.")
+		(type INSTANCE)
+;+		(allowed-classes Source_Product_Internal)
+		(create-accessor read-write))
+	(multislot solar_longitude
+;+		(comment "The solar_longitude attribute provides the angle between the body-Sun line at the time of interest and the body-Sun line at its vernal equinox.")
 		(type STRING)
-		(default "<period>")
+		(create-accessor read-write))
+	(multislot collected_in
+;+		(comment "The collected_in association is a relationship to data set.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot maximum_scaled_value
+;+		(comment "The maximum_scaled_value attribute provides the maximum value after application of scaling_factor and value_offset (see their definitions; maximum_scaled_value is the maximum of Ov).")
+		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot letter
-;+		(comment "letter = \"a\" | \"b\" | \"c\" | \"d\" | \"e\" | \"f\" | \"g\" | \"h\" | \"i\" | \"j\" | \"k\" | \"l\" | \"m\" | \"n\" | \"o\" | \"p\" | \"q\" | \"r\" | \"s\" | \"t\" | \"u\" | \"v\" | \"w\" | \"x\" | \"y\" | \"z\" | \"A\" | \"B\" | \"C\" | \"D\" | \"E\" | \"F\" | \"G\" | \"H\" | \"I\" | \"J\" | \"K\" | \"L\" | \"M\" | \"N\" | \"O\" | \"P\" | \"Q\" | \"R\" | \"S\" | \"T\" | \"U\" | \"V\" | \"W\" | \"X\" | \"Y\" | \"Z\" ;")
+	(multislot frame_rate
+;+		(comment "The frame_rate attribute provides the time, in specified units, between frames for display of a movie.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_investigation_area
+;+		(comment "The hsa_investigation_area association is a relationship to Investigation_Area.")
+		(type INSTANCE)
+;+		(allowed-classes Investigation_Area)
+		(create-accessor read-write))
+	(single-slot error_constant
+;+		(comment "The error_constant attribute provides a value that indicates the original value was in error.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot password
-;+		(comment "The password attribute provides a encrypted password used for authorization.")
+	(single-slot unit_of_measure_name
+;+		(comment "The unit_of_measure_name attribute indicates the units in which a value is given.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot minimum
+;+		(comment "The minimum attribute provides the largest stored value which actually appears; empty and Special_Constant values are excluded.")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_Group_Field_Binary
+;+		(comment "The has_Group_Field_Binary association is a relationship to the Group_Field_Binary.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot upper_110304_forked_DONesting_Slot_12
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot primary_body_name
+;+		(comment "The primary_body_name attribute identifies the primary body with which a given target body is associated as a secondary body.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot agent_type
-;+		(comment "The agent_type attribute provides a classification for the agent.")
+	(multislot rule_test
+;+		(comment "The rule_test attribute provides the body of the statement to be executed by the schematron processor.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot associated_nested_data_folder
-;+		(comment "The associated_nested_data_folder association is a relationship to data folders.")
+	(multislot type
+;+		(comment "The type attribute provides a classification for the resource.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_tracking_detail
+;+		(comment "The has_tracking_detail association is a relationship to tracking_detail.")
 		(type INSTANCE)
-;+		(allowed-classes)
+;+		(allowed-classes Tracking_Detail)
 		(create-accessor read-write))
-	(single-slot value_begin_date
-;+		(comment "The value_begin_date attribute provides the first date on which the permissible value is in effect.")
-		(type STRING)
+	(single-slot has_Oblique_Line
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes XSChoice%23)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Property_Maps
-;+		(comment "The has_Property_Maps association is a relationship to a Property Maps class")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot ring_occultation_direction
-;+		(comment "ring_occultation_direction indicates the radial direction of an occultation track. This refers to the observed occultation track overall, not to the subset that might appear in a particular file. Permitted values are 'Ingress', 'Egress', 'Both', and 'Multiple'. The value 'multiple' is only used for some Hubble-based occultations where the occultation track is not monotonic over relatively short time scales. Required in labels of ring occultation observations. Nillable if the observation is not a ring occultation in which case the nil_reason should be 'inapplicable'. Not intended as a value for a table field. ")
+	(single-slot facility_name
 		(type STRING)
-;+		(value "Both" "Egress" "Ingress" "Multiple")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot min_exclusive
-;+		(comment "The min exclusive attribute provides a value that is less than all the values in the object.")
+	(single-slot sip_data_directory_specification_name
+;+		(comment "Relative path name to the data directory and indicates the directory being transferred in the SIP. E.g. SIP_Data_Directory_Specification_Name  = --Volume_ID-- .")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot b_axis_radius
+;+		(comment "This attribute is used in the image map projection. Under review. xxx DDWG;DS xxx Also check why minimum value is negative.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot spacecraft_clock_stop_count
+;+		(comment "The spacecraft_clock_stop_count attribute provides the value of the spacecraft clock at the end of a time period of interest.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot axes
+;+		(comment "The axes attribute provides a count of the axes.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot container_type
+;+		(comment "The container type attribute indicates the method used to package the components.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot volume_name
+;+		(comment "The volume_name attribute contains the name of a data volume.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Character_Field
+;+		(comment "The has_Character_Field association is a relationship to the field types.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot campaign_objectives_summary
+;+		(comment "The campaign objectives summary attribute provides a comprehensive and brief abstract of a campaigns objectives.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot local_description
+;+		(comment "The local_description attribute provides a description of the coordinate system and its orientation to the surface of a planet.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot assertType
+		(type STRING)
+		(create-accessor read-write))
+	(multislot associated_object_local_id
+;+		(comment "The associated_object_local_id associates another object using its local identifier.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot files
+;+		(comment "The files attribute provides the number of files.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(single-slot upper_110421_test_Slot_0
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot minimum_ring_longitude
+;+		(comment "minimum_ring_longitude specifes one boundary for the ring longitude range in the data; normally the smallest value. However, for ranges that cross the prime meridian, the minimum ring longitude will have a value greater than the maximum ring longitude. Values range from 0 to 360 in units of degrees. Required in label files for ring occultation data.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot classSteward
+;+		(comment "The classSteward attribute provides the name of the steward for this rule.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_target_identification
+;+		(comment "The has_target_identification association is a relationship to Target_Identification.")
+		(type INSTANCE)
+;+		(allowed-classes Target_Identification)
+		(create-accessor read-write))
+	(multislot star_name
+;+		(comment "star_name provides the identifying name of star, including the catalog name if necessary. Examples include 'sigma Sgr' and 'SAO 123456' %28for star number 123456 in the Smithsonian Astrophysical Observatory catalog%29. Use 'Sun' for solar occultations. Required in labels for stellar and solar occultations. Not used for radio occultations.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Deleted_Grouped_Sequence
+;+		(comment "The has_Deleted_Grouped_Sequence association is a relationship to field sequence.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot has_display_direction
+;+		(comment "The has_display_direction association is a relationship to Display_Direction.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot funding_year
+;+		(comment "The funding_year attribute provides the year that funding was awarded.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot enumeration_flag
+;+		(comment "The enumeration_flag attribute indicates whether there is an enumerated set of permissible values.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot reference_list
 ;+		(comment "The reference_list association is a relationship to Reference_List.")
@@ -4560,82 +4355,292 @@
 ;+		(allowed-classes Reference_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot protocol_type
-;+		(comment "The prototype type attribute classifies a protocol.")
+	(multislot instrument_id
+;+		(comment "The instrument id provides a formal name used to refer to an instrument.")
 		(type STRING)
-;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot has_occultation_supplement
-;+		(comment "The has_occultation_supplement association is a relationship to occultation_supplement")
-		(type INSTANCE)
-;+		(allowed-classes)
-		(create-accessor read-write))
-	(single-slot language
-;+		(comment "The language attribute provides the language used for definition and designation of the term.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot sip_manifest_path
-;+		(comment "The relative path from the data brick mount point to and including the SIP manifiest directory. E.g. SIP_Manifest_Path = “./SIP_Manifest/” - indicates that the SIP_Manifest directory is at the mount point of the disk brick.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot block_bytes
-;+		(comment "This attribute is used by the volume class. It is under review.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot mean
-;+		(comment "The mean attribute provides the sum of the values divided by the number of values (empty or Special_Constants values are excluded).")
+	(single-slot loop_delay
+;+		(comment "The loop_delay attribute specifies the amount of time to pause between 'loops' or repeated playbacks of a movie.")
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot white_space
-;+		(comment "A sequence of one or more space characters, horizontal tabs, end of line characters, or newline characters except within a character-literal or string-literal (see 7.3), shall be considered whitespace. Any use of this International Standard may define any other characters or sequences of characters not in the above character set to be whitespace as well, such as vertical tabulators, end of page indicators, etc.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot solar_longitude
-;+		(comment "The solar_longitude attribute provides the angle between the body-Sun line at the time of interest and the body-Sun line at its vernal equinox.")
+	(multislot high_representation_saturation
+;+		(comment "The high_representative_saturation attribute specifies a special value whose presence indicates the true value cannot be represented in the chosen data type and length -- in this case being above the allowable range -- which may happen during conversion from another data type. The value must be less than the value of the valid_minimum attribute or more than the value of the valid_maximum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot archive_status_note
-;+		(comment "The archive status note attribute provides a comment about the archive status.")
-		(type STRING)
-;+		(cardinality 1 1)
+	(multislot first_sampling_parameter_value
+;+		(comment "The first_sampling_parameter_value element provides the first value in an ascending series and is therefore the minimum value at which a given data item was sampled.")
+		(type FLOAT)
 		(create-accessor read-write))
-	(single-slot nssdc_collection_id
-;+		(comment "An NSSDC Collection ID is an NSSDC assigned identifier for a collection of PDS datasets.")
+	(single-slot address
+;+		(comment "The address attribute provides a mailing address.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot vector
-;+		(comment "The vector assocation is a relationship to Vector objects.")
+	(single-slot offset
+;+		(comment "The offset attribute provides the displacement of the object starting position from the beginning of the parent structure (file, record, etc.).  If there is no displacement, offset=0.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot associated_Camera_Parameters
+;+		(comment "The associated_Camera_Parameters association is a relationship to Camera Parameters.")
 		(type INSTANCE)
-;+		(allowed-classes Vector)
+;+		(allowed-classes)
 		(create-accessor read-write))
-	(multislot ldd_version_id
-;+		(comment "The ldd_version_id attribute provides the version of the Local Data Dictionary.")
+	(single-slot processing_level_id_old
+;+		(comment "The processing_level_id attribute provides the state to which data have been processed.")
+		(type STRING)
+;+		(value "RAW" "RDC" "CLB" "DRV")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot scale_type
+;+		(comment "The scale_type attribute is an attribute proposed for use in those cases where the physical dimensions of the axes do not vary linearly. xxx TBD A. Raugh; MG xxx")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot axis_unit
-;+		(comment "The axis_unit attribute is the units of each axis (the units associated with axis_name) (e.g., pixels, seconds, degrees, etc.).")
+	(multislot purpose
+;+		(comment "The purpose attribute provides an indication of the primary purpose of the observations included.")
+		(type STRING)
+;+		(value "Science" "Navigation" "Calibration" "Checkout" "Engineering")
+		(create-accessor read-write))
+	(single-slot start_date_time
+;+		(comment "The start_date_time attribute provides the date and time at the beginning of a time interval of interest.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot member_type
+;+		(comment "The member_type attribute indicates the type of member references that  are provided.")
 		(type STRING)
 		(create-accessor read-write))
-	(multislot maximum_light_source_incidence_angle
-;+		(comment "maximum_light_source_incidence_angle specifes the largest value for observed_ring_elevation in the observation. Only used if the value is not constant over the observation. Values range from 0 to %2B90 in units of degrees. Not intended for use in the data file.")
+	(multislot subfacet2
+;+		(comment "The subfacet2 attribute provides a sub-categorization under the facet2 value.  The allowed values are restricted according to the value of facet2.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot subfacet1
+;+		(comment "The subfacet1 attribute provides a sub-categorization under the facet1 value.  The allowed values are restricted according to the value of facet1.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot da_contact_pds_users_id
+;+		(comment "The da_contact slot indicates the person responsible for data administration.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_geometry
+;+		(comment "The has_geometry association is a relationship to Geometry objects.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot ring_event_start_tdb
+;+		(comment "ring_event_start_tdb indicates the value for earliest time in the described data, and is given in ring_event_tdb format. Optional in labels; not intended for use as a table field.")
 		(type FLOAT)
 		(create-accessor read-write))
-	(single-slot has_color_display_settings
-;+		(comment "The has_color_display_settings association is a relationship to Color_Display_Settings.")
+	(multislot manifest_reference
+;+		(comment "The manifest reference attribute provides a reference to a manifest product.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Delivery_Manifest_Entry
+;+		(comment "The has_Delivery_Manifest_Entry association is a relationship to delivery manifest entry.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(multislot publication_reference
+;+		(comment "The publication reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(default "logical_identifier")
+		(create-accessor read-write))
+	(single-slot ring_observation_id
+;+		(comment "The ring_observation_id uniquely identifies a single experiment or observation %28image, occultation profile, spectrum, etc.%29 within a rings-related data set. This is the common id by which data are identified within the Rings Node catalog. It describes the smallest quantity of data that can be usefully cataloged or analyzed by itself. Note that a single observation may be associated with multiple data products %28e.g. raw and calibrated versions of an image%29. Note also that a single data product may be associated with multiple observations %28e.g. a single WFPC2 image file containing four different images%29. A ring observation id is constructed using numbers, upper case letters, forward slash, colon, period, dash, and underscore as follows: p%2Ftype%2Fhost%2Finst%2Ftime%2F... where p is a single-letter planet id %28one of J, S, U, or N%29; type is IMG for images, OCC for occultation profile, etc.; host is the instrument host id, inst is the instrument id; time is the observation time as a date or instrument clock count; further information identifying the observation can then be appended as appropriate. Optional in labels. Nillable, in which case the nil_reason should be 'inapplicable'. Examples: J%2FIMG%2FVG2%2FISS%2F20693.01%2FN J%2FIMG%2FVG2%2FISS%2F20693.02%2FW S%2FIMG%2FHST%2FWFPC2%2F1995-08-10%2FU2TF020B%2FPC1 U%2FOCC%2FVG2%2FRSS%2F1986-01-24%2FS U%2FOCC%2FVG2%2FRSS%2F1986-01-24%2FX N%2FOCC%2FVG2%2FPPS%2F1989-08-25%2FSIGMA_SGR ")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot data_type_concept
+;+		(comment "Associated data type concept.")
+		(type INSTANCE)
+;+		(allowed-classes)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot reference
+;+		(comment "The reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot data_object_description
+;+		(comment "Composition association for the Data Object Description.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot maximum_sampling_parameter
+;+		(comment "The maximum_sampling_parameter element identifies the maximum value at which a given data item was sampled. For example, a spectrum that was measured in the 0.4 to 3.5 micrometer spectral region would have a maximum_sampling_parameter value of 3.5. The sampling parameter constrained by this value is identified by the sampling_parameter_name element. Note: The unit of measure for the sampling parameter is provided by the unit element.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot aip_label_checksum
+;+		(comment "The aip_label_checksum attribute provides the checksum for the Archival Information Package label.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot field_unit
+;+		(comment "The field unit attribute indicates the unit of measurement associated with a field value.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot has_movie_display_settings
+;+		(comment "The has_movie_display_settings association is a relationship to Movie_Display_Settings.")
 		(type INSTANCE)
 ;+		(allowed-classes)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot earth_received_stop_time
-;+		(comment "The earth_received_stop_time attribute gives the ending time at which a signal (such a telemetry) was received on Earth")
+	(multislot classNameSpaceNC
+;+		(comment "The classNameSpaceNC attribute provides the class name space Id without a colon.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot has_Universal_Transverse_Mercator
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot value_syntax
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot space
+;+		(comment "space = \" \" (* space *) ; The character space is required to be bound to the “space” member of ISO/IEC 10646, but it only has meaning within character-literals and string-literals.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot associated_distributing_node
+;+		(comment "The associated_distributing_node association is a relationship to Nodes.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot release_date
+;+		(comment "The release_date attribute provides the date that the product was released.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot transfer_manifest_checksum
+;+		(comment "The transfer manifest checksum provides the checksum for the transfer manifest file.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot groups
+;+		(comment "The groups attribute provides a count of the total number of groups directly associated with a table record.  Groups within groups within the record are not included in this count.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(multislot has_document_file
+;+		(comment "The has_document_file association is a relationship to a document file.")
+		(type INSTANCE)
+;+		(allowed-classes Document_File)
+		(create-accessor read-write))
+	(single-slot easternmost_longitude
+;+		(comment "This attribute is used in the image map projection. Under review. xxx E. Rye xxx")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Spatial_Reference_Information
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(single-slot distribution_type
+;+		(comment "This attribute is used in by the data set release class. It is under review.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot document_reference
+;+		(comment "The document reference attribute provides either the logical_identifier or the logical_identifier plus the version_id for a registry object.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot service_type
+;+		(comment "The service type attribute identifies the class of system function provided.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot minimum_value_exclusive_flag
+;+		(comment "The minimum_value_exclusive_flag attribute indicates that the  minimum_value is exclusive, when true.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot objectives_summary
+;+		(comment "The objectives_summary attribute describes the scientific objectives of an investigation")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot target_logical_identifier
+;+		(comment "The target logical identifier is an object identifier without the version. It identifies the set of all versions of an object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot data_set_desc
+;+		(comment "The data_set_desc attribute describes the content and type of a data set and provides information required to use the data (such as binning information).")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot sampling_parameter_name
+;+		(comment "The sampling_parameter_name element provides the name of the parameter which determines the sampling interval of a particular instrument or dataset parameter. For example, magnetic field intensity is sampled in time increments, and a spectrum is sampled in wavelength or frequency.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot red_channel_band
+;+		(comment "The red_channel_band attribute identifies the number of the band, along the band axis, that should be loaded, by default, into the red channel of a display device. The first band along the band axis has band number 1.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot observed_event_start_time_utc
+;+		(comment "observed_event_start_time_utc indicates the UTC value for earliest time in the described data. It is part of a start/stop pair. If one of observed_event_start_time_utc and observed_event_stop_time_utc is used, both must be used.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot namespace_id
+;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_type_list_entry
+;+		(comment "The has_type_list_entry association is a relationship to Type_List_Entry")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot identifier_reference
+;+		(comment "The identifier_reference attribute provides the value of an identifier.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot collected_under
+;+		(comment "The collected_under association is a relationship to circumstances of observation.")
+		(type INSTANCE)
+;+		(allowed-classes Context_Area)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot lowest_detectable_opacity
+;+		(comment "lowest_detectable_opacity indicates the sensitivity of a ring occultation data set to nearly opaque rings. It specifies the rough value for the smallest normal ring opacity that can be detected in the data at the resolution provided, incorporating both statistical effects and calibration uncertainties. Strongly recommended in labels of ring occultation observations. Not intended as a value for a table field.")
+		(type FLOAT)
+		(create-accessor read-write))
+	(single-slot sort_name
+;+		(comment "The sort name attribute provides a string to be used in ordering. For people, the last name (surname) is typically first, followed by a comma and then other names.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Universal_Polar_Stereographic
+;+		(comment "The xxx association is a relationship to yyy.")
+		(type INSTANCE)
+;+		(allowed-classes)
+		(create-accessor read-write))
+	(multislot valid_maximum
+;+		(comment "The valid_maximum attribute specifies the maximum valid value in the field or digital object with which the Special_Constants class is associated. Values above the valid_maximum have a special meaning. Values of this attribute should be represented in the same data_type as the elements in the object or field described. (Note that PDS3 had no qube-related valid_maximum values because all special constants were set below the valid_minimum.)")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot scale_factor_at_projection_origin
+;+		(comment " The scale_factor_at_projection_origin attribute provides a multiplier for reducing a distance obtained from a map by computation or scaling to the actual distance at the projection origin. ")
+		(type FLOAT)
+		(create-accessor read-write))
+	(multislot dsn_station_number
+;+		(comment "dsn_station_number identifies the receiving DSN station. Required in labels for radio occultations; not used for stellar occultations. Nillable in which case the nil_reason should be 'inapplicable'.")
+		(type INTEGER)
+		(create-accessor read-write))
+	(single-slot checksum
+;+		(comment "The checksum attribute provides a computed value which depends on the contents of a block of data and is used to detect corruption of the data.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot date
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot conceptual_domain
+;+		(comment "The conceptual_domain attribute provides the domain to which the value has been assigned.")
+		(type STRING)
 		(create-accessor read-write)))
 
 (defclass Tagged_Digital_Object "The Tagged Digital Object class is an abstract class for the digital class hierarchy. A tagged object is an information object."
@@ -4656,13 +4661,13 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -4670,6 +4675,11 @@
 (defclass Table_Base "The Table Base class defines a heterogeneous repeating record of scalars. The Table Base class is the parent class for all heterogeneous repeating record of scalars."
 	(is-a Byte_Stream)
 	(role abstract)
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot offset
 ;+		(comment "The offset attribute provides the displacement of the object starting position from the beginning of the parent structure (file, record, etc.).  If there is no displacement, offset=0.")
 		(type INTEGER)
@@ -4679,11 +4689,6 @@
 ;+		(comment "The records attribute provides a count of records.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Table_Binary "The Table Binary class is an extension of table base and defines a simple binary table."
@@ -4736,11 +4741,6 @@
 (defclass Encoded_Byte_Stream "The Encoded Byte Stream class defines byte streams that must be decoded by software before use. These byte streams must only use standard encodings. The Encoded Byte Stream class is the parent class for all encoded byte streams."
 	(is-a Byte_Stream)
 	(role concrete)
-	(single-slot offset
-;+		(comment "The offset attribute provides the displacement of the object starting position from the beginning of the parent structure (file, record, etc.).  If there is no displacement, offset=0.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot encoding_standard_id
 ;+		(comment "The encoding_standard_id attribute provides the formal name of a standard used for the structure of an Encoded Byte Stream digital object.")
 		(type STRING)
@@ -4750,6 +4750,11 @@
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot offset
+;+		(comment "The offset attribute provides the displacement of the object starting position from the beginning of the parent structure (file, record, etc.).  If there is no displacement, offset=0.")
+		(type INTEGER)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot object_length
 ;+		(comment "The object_length attribute provides the length of the digital object in bytes.")
@@ -4834,11 +4839,6 @@
 (defclass Parsable_Byte_Stream "The Parsable Byte Stream class defines byte streams that have standard parsing rules. The Parsable Byte Stream class is the parent class for all parsable byte streams."
 	(is-a Byte_Stream)
 	(role concrete)
-	(single-slot offset
-;+		(comment "The offset attribute provides the displacement of the object starting position from the beginning of the parent structure (file, record, etc.).  If there is no displacement, offset=0.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot parsing_standard_id
 ;+		(comment "The parsing_standard_id attribute provides the formal name of a standard used for the structure of a Parsable Byte Stream digital object.")
 		(type STRING)
@@ -4849,6 +4849,11 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot offset
+;+		(comment "The offset attribute provides the displacement of the object starting position from the beginning of the parent structure (file, record, etc.).  If there is no displacement, offset=0.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot object_length
 ;+		(comment "The object_length attribute provides the length of the digital object in bytes.")
 		(type INTEGER)
@@ -4858,9 +4863,16 @@
 (defclass Table_Delimited "The Table_Delimited class defines a simple table (spreadsheet) with delimited fields and records."
 	(is-a Parsable_Byte_Stream)
 	(role concrete)
-	(single-slot records
-;+		(comment "The records attribute provides a count of records.")
-		(type INTEGER)
+	(single-slot parsing_standard_id
+;+		(comment "The parsing_standard_id attribute provides the formal name of a standard used for the structure of a Parsable Byte Stream digital object.")
+		(type STRING)
+;+		(value "PDS DSV 1")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot field_delimiter
+;+		(comment "The field_delimiter attribute provides the character that marks the boundary between two fields in a delimited table.")
+		(type STRING)
+;+		(value "Semicolon" "Comma" "Horizontal Tab" "Vertical Bar" "comma" "horizontal tab" "semicolon" "vertical bar")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot uniformly_sampled
@@ -4875,22 +4887,15 @@
 ;+		(allowed-classes Record_Delimited)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot records
+;+		(comment "The records attribute provides a count of records.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot record_delimiter
 ;+		(comment "The record_delimiter attribute provides the character or characters used to indicate the end of a record.")
 		(type STRING)
 ;+		(value "Carriage-Return Line-Feed" "carriage-return line-feed" "Line-Feed")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot parsing_standard_id
-;+		(comment "The parsing_standard_id attribute provides the formal name of a standard used for the structure of a Parsable Byte Stream digital object.")
-		(type STRING)
-;+		(value "PDS DSV 1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot field_delimiter
-;+		(comment "The field_delimiter attribute provides the character that marks the boundary between two fields in a delimited table.")
-		(type STRING)
-;+		(value "Semicolon" "Comma" "Horizontal Tab" "Vertical Bar" "comma" "horizontal tab" "semicolon" "vertical bar")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -4929,16 +4934,16 @@
 (defclass Stream_Text "The Stream text class defines a text object."
 	(is-a Parsable_Byte_Stream)
 	(role concrete)
-	(single-slot record_delimiter
-;+		(comment "The record_delimiter attribute provides the character or characters used to indicate the end of a record.")
-		(type STRING)
-;+		(value "Carriage-Return Line-Feed" "carriage-return line-feed" "Line-Feed")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot parsing_standard_id
 ;+		(comment "The parsing_standard_id attribute provides the formal name of a standard used for the structure of a Parsable Byte Stream digital object.")
 		(type STRING)
 ;+		(value "7-Bit ASCII Text" "UTF-8 Text" "PDS3")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot record_delimiter
+;+		(comment "The record_delimiter attribute provides the character or characters used to indicate the end of a record.")
+		(type STRING)
+;+		(value "Carriage-Return Line-Feed" "carriage-return line-feed" "Line-Feed")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -4985,16 +4990,16 @@
 (defclass SPICE_Kernel "The SPICE Kernel class describes a SPICE object."
 	(is-a Parsable_Byte_Stream)
 	(role concrete)
-	(single-slot encoding_type
-;+		(comment "The encoding_type attribute provides the storage format (binary or character).")
-		(type STRING)
-;+		(value "Binary" "Character")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot parsing_standard_id
 ;+		(comment "The parsing_standard_id attribute provides the formal name of a standard used for the structure of a Parsable Byte Stream digital object.")
 		(type STRING)
 ;+		(value "SPICE")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot encoding_type
+;+		(comment "The encoding_type attribute provides the storage format (binary or character).")
+		(type STRING)
+;+		(value "Binary" "Character")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot kernel_type
@@ -5007,16 +5012,16 @@
 (defclass Checksum_Manifest "The Checksum_Manifest class defines a two column table for file references and checksums."
 	(is-a Parsable_Byte_Stream)
 	(role concrete)
-	(single-slot record_delimiter
-;+		(comment "The record_delimiter attribute provides the character or characters used to indicate the end of a record.")
-		(type STRING)
-;+		(value "Carriage-Return Line-Feed" "carriage-return line-feed" "Line-Feed")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot parsing_standard_id
 ;+		(comment "The parsing_standard_id attribute provides the formal name of a standard used for the structure of a Parsable Byte Stream digital object.")
 		(type STRING)
 ;+		(value "MD5Deep 4.n")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot record_delimiter
+;+		(comment "The record_delimiter attribute provides the character or characters used to indicate the end of a record.")
+		(type STRING)
+;+		(value "Carriage-Return Line-Feed" "carriage-return line-feed" "Line-Feed")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -5033,43 +5038,20 @@
 (defclass Array "The Array class defines a homogeneous N-dimensional array of scalars. The Array class is the parent class for all n-dimensional arrays of scalars."
 	(is-a Byte_Stream)
 	(role concrete)
-	(single-slot offset
-;+		(comment "The offset attribute provides the displacement of the object starting position from the beginning of the parent structure (file, record, etc.).  If there is no displacement, offset=0.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot axes
 ;+		(comment "The axes attribute provides a count of the axes.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot associated_Statistics
-;+		(comment "The associated_Object_Statistics association is a relationship to object statistics.")
-		(type INSTANCE)
-;+		(allowed-classes Object_Statistics)
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot has_Element_Array
-;+		(comment "The has_Element_Array association is a relationship to Element_Array")
-		(type INSTANCE)
-;+		(allowed-classes Element_Array)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot local_internal_reference
-;+		(comment "The local_internal_reference association is a relationship to the class Local_Internal_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Local_Internal_Reference)
-;+		(cardinality 0 0)
 		(create-accessor read-write))
 	(single-slot associated_Special_Constants
 ;+		(comment "The associated_Special_Constants association is a relationship to special constants.")
 		(type INSTANCE)
 ;+		(allowed-classes Special_Constants)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot has_Axis_Array
@@ -5078,11 +5060,34 @@
 ;+		(allowed-classes Axis_Array)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
+	(single-slot offset
+;+		(comment "The offset attribute provides the displacement of the object starting position from the beginning of the parent structure (file, record, etc.).  If there is no displacement, offset=0.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot has_Element_Array
+;+		(comment "The has_Element_Array association is a relationship to Element_Array")
+		(type INSTANCE)
+;+		(allowed-classes Element_Array)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot associated_Statistics
+;+		(comment "The associated_Object_Statistics association is a relationship to object statistics.")
+		(type INSTANCE)
+;+		(allowed-classes Object_Statistics)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot axis_index_order
 ;+		(comment "The axis_index_order attribute provides the axis index that varies fastest with respect to storage order.")
 		(type STRING)
 ;+		(value "Last Index Fastest")
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot local_internal_reference
+;+		(comment "The local_internal_reference association is a relationship to the class Local_Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Local_Internal_Reference)
+;+		(cardinality 0 0)
 		(create-accessor read-write)))
 
 (defclass Array_2D "The Array 2D class is the parent class for all two dimensional array based classes."
@@ -5195,8 +5200,14 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot records
-;+		(comment "The records attribute provides a count of records.")
+	(single-slot file_name
+;+		(comment "The file_name attribute provides the name of a file.")
+		(type STRING)
+		(default "file_name-period-file_extension")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot file_size
+;+		(comment "The file_size attribute provides the size of the file.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -5206,28 +5217,22 @@
 		(default "file_name-sequence_number")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot file_size
-;+		(comment "The file_size attribute provides the size of the file.")
+	(single-slot records
+;+		(comment "The records attribute provides a count of records.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot file_name
-;+		(comment "The file_name attribute provides the name of a file.")
-		(type STRING)
-		(default "file_name-period-file_extension")
-;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot file_URL
 ;+		(comment "The file_URL holds a reference or link to a version of the data that can be downloaded, streamed, or even accessed/visualized via a Web service. URL stands for Uniform Resource Locator and is the address of a given unique resource on the Web, whether it is linked to an image, table, HTML page, or other Web resource.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot comment
-;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
+	(single-slot creation_date_time
+;+		(comment "The creation_date_time attribute provides a date and time when the object was created.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot creation_date_time
-;+		(comment "The creation_date_time attribute provides a date and time when the object was created.")
+	(single-slot comment
+;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -5251,24 +5256,14 @@
 (defclass Composite_Structure "The Composite Structure class provides a general framework for defining a structure that consists of two or more simpler structures"
 	(is-a Tagged_Digital_Object)
 	(role concrete)
-	(single-slot type_description
-;+		(comment "The type_description attribute provides a description of the object's type.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot has_Local_ID_Relation
 ;+		(comment "The has_Local_ID_Relation association is a relationship to Local_ID_Relation.")
 		(type INSTANCE)
 ;+		(allowed-classes Local_ID_Relation)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot title
-;+		(comment "The title attribute provides a short, descriptive text string suitable for use as a title or brief description in a display or listing of products.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -5278,8 +5273,18 @@
 ;+		(allowed-classes Local_ID_Reference)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot title
+;+		(comment "The title attribute provides a short, descriptive text string suitable for use as a title or brief description in a display or listing of products.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot type_description
+;+		(comment "The type_description attribute provides a description of the object's type.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -5291,11 +5296,6 @@
 (defclass Axis_Array "The Axis Array class is used as a component of the array class and defines an axis of the array."
 	(is-a Tagged_Digital_Child)
 	(role concrete)
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot elements
 ;+		(comment "The elements attribute provides the count of the number of elements along an array axis.")
 		(type INTEGER)
@@ -5306,15 +5306,20 @@
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot unit
-;+		(comment "The unit attribute provides the unit of measurement.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot axis_name
 ;+		(comment "The axis_name attribute provides a word or combination of words by which the axis is known.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot unit
+;+		(comment "The unit attribute provides the unit of measurement.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot has_Band_Bin_Set
 ;+		(comment "The has_Band_Bin_Set association is a relationship to Band_Bin_Set.")
@@ -5326,11 +5331,10 @@
 (defclass Element_Array "The Element Array class is used as a component of the array class and defines an element of the array."
 	(is-a Tagged_Digital_Child)
 	(role concrete)
-	(single-slot data_type
-;+		(comment "The data_type attribute provides the hardware representation used to store a value in Element_Array.")
-		(type STRING)
-;+		(value "IEEE754MSBDouble" "IEEE754MSBSingle" "UnsignedByte" "SignedMSB2" "SignedMSB4" "SignedLSB4" "SignedLSB2" "UnsignedLSB2" "UnsignedLSB4" "UnsignedMSB2" "UnsignedMSB4" "SignedMSB8" "UnsignedLSB8" "UnsignedMSB8" "SignedLSB8" "IEEE754LSBDouble" "IEEE754LSBSingle" "SignedByte" "SignedBitString" "UnsignedBitString" "ComplexLSB16" "ComplexLSB8" "ComplexMSB16" "ComplexMSB8")
-;+		(cardinality 1 1)
+	(single-slot value_offset
+;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
+		(type FLOAT)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot unit
 ;+		(comment "The unit attribute provides the unit of measurement.")
@@ -5342,32 +5346,28 @@
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot value_offset
-;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
-		(type FLOAT)
-;+		(cardinality 0 1)
+	(single-slot data_type
+;+		(comment "The data_type attribute provides the hardware representation used to store a value in Element_Array.")
+		(type STRING)
+;+		(value "IEEE754MSBDouble" "IEEE754MSBSingle" "UnsignedByte" "SignedMSB2" "SignedMSB4" "SignedLSB4" "SignedLSB2" "UnsignedLSB2" "UnsignedLSB4" "UnsignedMSB2" "UnsignedMSB4" "SignedMSB8" "UnsignedLSB8" "UnsignedMSB8" "SignedLSB8" "IEEE754LSBDouble" "IEEE754LSBSingle" "SignedByte" "SignedBitString" "UnsignedBitString" "ComplexLSB16" "ComplexLSB8" "ComplexMSB16" "ComplexMSB8")
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Special_Constants "The Special Constants class provides a set of values used to indicate special cases that occur in the data."
 	(is-a Tagged_Digital_Child)
 	(role concrete)
+	(single-slot unknown_constant
+;+		(comment "The unknown_constant attribute provides a value that indicates the original value was unknown.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot high_instrument_saturation
+;+		(comment "The high_instrument_saturation attribute specifies a special value whose presence indicates the measuring instrument was saturated at the high end. The value must be less than the value of the valid_minimum attribute or more than the value of the valid_maximum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot error_constant
 ;+		(comment "The error_constant attribute provides a value that indicates the original value was in error.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot missing_constant
-;+		(comment "The missing_constant attribute provides a value that indicates the original value was missing, such as due to a gap in coverage.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot valid_maximum
-;+		(comment "The valid_maximum attribute specifies the maximum valid value in the field or digital object with which the Special_Constants class is associated. Values above the valid_maximum have a special meaning. Values of this attribute should be represented in the same data_type as the elements in the object or field described. (Note that PDS3 had no qube-related valid_maximum values because all special constants were set below the valid_minimum.)")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot valid_minimum
-;+		(comment "The valid_minimum attribute specifies the minimum valid value in the field or digital object with which the Special_Constants class is associated. Values below the valid_minimum have a special meaning. Values of this attribute should be represented in the same data_type as the elements in the object or field described.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -5386,18 +5386,18 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot high_instrument_saturation
-;+		(comment "The high_instrument_saturation attribute specifies a special value whose presence indicates the measuring instrument was saturated at the high end. The value must be less than the value of the valid_minimum attribute or more than the value of the valid_maximum attribute. Values of this attribute should be represented in the same data_type as the elements in the object with which the Special_Constants class is associated.")
+	(single-slot not_applicable_constant
+;+		(comment "The not_applicable_constant attribute provides a value that indicates the parameter is not applicable.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot saturated_constant
-;+		(comment "The saturated_constant attribute provides a value that indicates the original value was invalid because of sensor saturation.")
+	(single-slot valid_maximum
+;+		(comment "The valid_maximum attribute specifies the maximum valid value in the field or digital object with which the Special_Constants class is associated. Values above the valid_maximum have a special meaning. Values of this attribute should be represented in the same data_type as the elements in the object or field described. (Note that PDS3 had no qube-related valid_maximum values because all special constants were set below the valid_minimum.)")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot unknown_constant
-;+		(comment "The unknown_constant attribute provides a value that indicates the original value was unknown.")
+	(single-slot missing_constant
+;+		(comment "The missing_constant attribute provides a value that indicates the original value was missing, such as due to a gap in coverage.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -5406,8 +5406,13 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot not_applicable_constant
-;+		(comment "The not_applicable_constant attribute provides a value that indicates the parameter is not applicable.")
+	(single-slot valid_minimum
+;+		(comment "The valid_minimum attribute specifies the minimum valid value in the field or digital object with which the Special_Constants class is associated. Values below the valid_minimum have a special meaning. Values of this attribute should be represented in the same data_type as the elements in the object or field described.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot saturated_constant
+;+		(comment "The saturated_constant attribute provides a value that indicates the original value was invalid because of sensor saturation.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -5415,10 +5420,10 @@
 (defclass Uniformly_Sampled "The Uniformly_Sampled class provides parameters for a uniformly sampled table."
 	(is-a Tagged_Digital_Child)
 	(role concrete)
-	(single-slot sampling_parameters
-;+		(comment "The sampling_parameters attribute provides the total number of sampling parameter values between first_sampling_parameter_value and last_sampling_parameter_value (inclusive).")
-		(type STRING)
-;+		(cardinality 0 1)
+	(single-slot last_sampling_parameter_value
+;+		(comment "The last_sampling_parameter_value element provides the last value in an ascending series and is therefore the maximum value at which a given data item was sampled.")
+		(type FLOAT)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot sampling_parameter_scale
 ;+		(comment "The sampling_parameter_scale element specifies whether the sampling interval is linear or something other such as logarithmic.")
@@ -5426,15 +5431,10 @@
 ;+		(value "Linear" "Logarithmic" "Exponential")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot sampling_parameter_base
-;+		(comment "The sampling_parameter_base attribute provides the base b by which exponentials are calculated in the definition of the attribute sampling_parameter_interval.")
+	(single-slot sampling_parameters
+;+		(comment "The sampling_parameters attribute provides the total number of sampling parameter values between first_sampling_parameter_value and last_sampling_parameter_value (inclusive).")
 		(type STRING)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot sampling_parameter_unit
-;+		(comment "The sampling_parameter_unit element specifies the unit of measure of associated data sampling parameters.")
-		(type STRING)
-;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot first_sampling_parameter_value
 ;+		(comment "The first_sampling_parameter_value element provides the first value in an ascending series and is therefore the minimum value at which a given data item was sampled.")
@@ -5446,10 +5446,15 @@
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot last_sampling_parameter_value
-;+		(comment "The last_sampling_parameter_value element provides the last value in an ascending series and is therefore the maximum value at which a given data item was sampled.")
-		(type FLOAT)
+	(single-slot sampling_parameter_unit
+;+		(comment "The sampling_parameter_unit element specifies the unit of measure of associated data sampling parameters.")
+		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot sampling_parameter_base
+;+		(comment "The sampling_parameter_base attribute provides the base b by which exponentials are calculated in the definition of the attribute sampling_parameter_interval.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot sampling_parameter_name
 ;+		(comment "The sampling_parameter_name element provides the name of the parameter which determines the sampling interval of a particular instrument or dataset parameter. For example, magnetic field intensity is sampled in time increments, and a spectrum is sampled in wavelength or frequency.")
@@ -5460,6 +5465,11 @@
 (defclass Packed_Data_Fields "The Packed_Data_Fields class contains field definitions for extracting packed data from the associated byte string field."
 	(is-a Tagged_Digital_Child)
 	(role concrete)
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot bit_fields
 ;+		(comment "The bit_fields attribute provides the number of defined bit fields (Field_Bit definitions) within the Packed_Data_Field.")
 		(type STRING)
@@ -5470,41 +5480,29 @@
 		(type INSTANCE)
 ;+		(allowed-classes Field_Bit)
 		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Field "The Field class defines a field of a record and is the parent class of all specific field classes.The Field class defines a field of a record or a field of a group and is the parent class of all specific field classes."
 	(is-a Tagged_Digital_Child)
 	(role abstract)
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot field_number
 ;+		(comment "The field_number attribute provides the position of a field, within a series of fields, counting from 1. If two fields within a record are physically separated by one or more groups, they have consecutive field numbers; the fields within the intervening group(s) are numbered separately.  Fields within a group separated by one or more (sub)groups, will also have consecutive field numbers.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Field_Binary "The Field_Binary class defines a field of a binary record or a field of a binary group."
 	(is-a Field)
 	(role concrete)
-	(single-slot associated_Statistics
-;+		(comment "The associated_Object_Statistics association is a relationship to object statistics.")
-		(type INSTANCE)
-;+		(allowed-classes Field_Statistics)
+	(single-slot value_offset
+;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
+		(type FLOAT)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot data_type
-;+		(comment "The data_type attribute provides the hardware representation used to store a value in Field_Binary (see PDS Standards Reference section \"Binary Data Types\").")
-		(type STRING)
-;+		(value "SignedLSB2" "SignedLSB4" "SignedLSB8" "SignedMSB2" "SignedMSB4" "SignedMSB8" "UnsignedByte" "UnsignedLSB2" "UnsignedLSB4" "UnsignedMSB2" "UnsignedMSB4" "IEEE754MSBDouble" "IEEE754MSBSingle" "ASCII_File_Name" "ASCII_Boolean" "ASCII_Date_YMD" "ASCII_Integer" "ASCII_Real" "ASCII_AnyURI" "ASCII_Date_DOY" "ASCII_Date_Time_DOY_UTC" "ASCII_Date_Time_YMD_UTC" "ASCII_LID" "ASCII_LIDVID" "ASCII_MD5_Checksum" "ASCII_Time" "ASCII_VID" "ASCII_DOI" "ASCII_Numeric_Base2" "ASCII_Numeric_Base16" "ASCII_NonNegative_Integer" "ASCII_File_Specification_Name" "UnsignedLSB8" "UnsignedMSB8" "IEEE754LSBDouble" "IEEE754LSBSingle" "SignedByte" "UTF8_String" "ASCII_String" "SignedBitString" "UnsignedBitString" "ComplexLSB16" "ComplexLSB8" "ComplexMSB16" "ASCII_Directory_Path_Name" "ASCII_LIDVID_LID" "ASCII_Numeric_Base8" "ComplexMSB8" "ASCII_Date_Time_DOY" "ASCII_Date_Time_YMD" "ASCII_BibCode")
-;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot has_Packed_Data_Fields
 ;+		(comment "The has_Packed_Data_Fields association is a relationship to  Packed_Data_Fields.")
@@ -5512,8 +5510,33 @@
 ;+		(allowed-classes Packed_Data_Fields)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot field_length
+;+		(comment "The field_length attribute provides the number of bytes in the field.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot field_format
 ;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot field_location
+;+		(comment "The field_location attribute provides the starting byte for a field within a record or group, counting from '1'.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot unit
+;+		(comment "The unit attribute provides the unit of measurement.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -5523,29 +5546,35 @@
 ;+		(allowed-classes Special_Constants)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot unit
-;+		(comment "The unit attribute provides the unit of measurement.")
-		(type STRING)
+	(single-slot associated_Statistics
+;+		(comment "The associated_Object_Statistics association is a relationship to object statistics.")
+		(type INSTANCE)
+;+		(allowed-classes Field_Statistics)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot field_location
-;+		(comment "The field_location attribute provides the starting byte for a field within a record or group, counting from '1'.")
-		(type INTEGER)
-;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot scaling_factor
 ;+		(comment "The scaling_factor attribute is the scaling factor to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 1.")
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot data_type
+;+		(comment "The data_type attribute provides the hardware representation used to store a value in Field_Binary (see PDS Standards Reference section \"Binary Data Types\").")
+		(type STRING)
+;+		(value "SignedLSB2" "SignedLSB4" "SignedLSB8" "SignedMSB2" "SignedMSB4" "SignedMSB8" "UnsignedByte" "UnsignedLSB2" "UnsignedLSB4" "UnsignedMSB2" "UnsignedMSB4" "IEEE754MSBDouble" "IEEE754MSBSingle" "ASCII_File_Name" "ASCII_Boolean" "ASCII_Date_YMD" "ASCII_Integer" "ASCII_Real" "ASCII_AnyURI" "ASCII_Date_DOY" "ASCII_Date_Time_DOY_UTC" "ASCII_Date_Time_YMD_UTC" "ASCII_LID" "ASCII_LIDVID" "ASCII_MD5_Checksum" "ASCII_Time" "ASCII_VID" "ASCII_DOI" "ASCII_Numeric_Base2" "ASCII_Numeric_Base16" "ASCII_NonNegative_Integer" "ASCII_File_Specification_Name" "UnsignedLSB8" "UnsignedMSB8" "IEEE754LSBDouble" "IEEE754LSBSingle" "SignedByte" "UTF8_String" "ASCII_String" "SignedBitString" "UnsignedBitString" "ComplexLSB16" "ComplexLSB8" "ComplexMSB16" "ASCII_Directory_Path_Name" "ASCII_LIDVID_LID" "ASCII_Numeric_Base8" "ComplexMSB8" "ASCII_Date_Time_DOY" "ASCII_Date_Time_YMD" "ASCII_BibCode")
+;+		(cardinality 1 1)
+		(create-accessor read-write)))
+
+(defclass Field_Character "The Field_Character class defines a field of a character record or a field of a character group."
+	(is-a Field)
+	(role concrete)
 	(single-slot value_offset
 ;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
 		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot validation_format
+;+		(comment "The validation_format attribute gives the magnitude and precision of the data value with the expectation that both will be validated exactly. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section \"Field Formats\" for details.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot description
@@ -5557,15 +5586,42 @@
 ;+		(comment "The field_length attribute provides the number of bytes in the field.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
-		(create-accessor read-write)))
-
-(defclass Field_Character "The Field_Character class defines a field of a character record or a field of a character group."
-	(is-a Field)
-	(role concrete)
+		(create-accessor read-write))
+	(single-slot field_format
+;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot field_location
+;+		(comment "The field_location attribute provides the starting byte for a field within a record or group, counting from '1'.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot unit
+;+		(comment "The unit attribute provides the unit of measurement.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot associated_Special_Constants
+;+		(comment "The associated_Special_Constants association is a relationship to special constants.")
+		(type INSTANCE)
+;+		(allowed-classes Special_Constants)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot associated_Statistics
 ;+		(comment "The associated_Object_Statistics association is a relationship to object statistics.")
 		(type INSTANCE)
 ;+		(allowed-classes Field_Statistics)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot scaling_factor
+;+		(comment "The scaling_factor attribute is the scaling factor to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 1.")
+		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot data_type
@@ -5573,43 +5629,11 @@
 		(type STRING)
 ;+		(value "ASCII_Boolean" "ASCII_Date_YMD" "ASCII_Integer" "ASCII_Real" "ASCII_AnyURI" "ASCII_Date_DOY" "ASCII_Date_Time_DOY_UTC" "ASCII_Date_Time_YMD_UTC" "ASCII_LID" "ASCII_LIDVID" "ASCII_MD5_Checksum" "ASCII_Time" "ASCII_VID" "ASCII_DOI" "ASCII_Numeric_Base2" "ASCII_Numeric_Base16" "ASCII_NonNegative_Integer" "ASCII_File_Specification_Name" "ASCII_File_Name" "UTF8_String" "ASCII_String" "ASCII_Directory_Path_Name" "ASCII_LIDVID_LID" "ASCII_Numeric_Base8" "ASCII_Date_Time_DOY" "ASCII_Date_Time_YMD" "ASCII_BibCode")
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot field_format
-;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot associated_Special_Constants
-;+		(comment "The associated_Special_Constants association is a relationship to special constants.")
-		(type INSTANCE)
-;+		(allowed-classes Special_Constants)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot unit
-;+		(comment "The unit attribute provides the unit of measurement.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot validation_format
-;+		(comment "The validation_format attribute gives the magnitude and precision of the data value with the expectation that both will be validated exactly. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section \"Field Formats\" for details.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot field_location
-;+		(comment "The field_location attribute provides the starting byte for a field within a record or group, counting from '1'.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot scaling_factor
-;+		(comment "The scaling_factor attribute is the scaling factor to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 1.")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
+		(create-accessor read-write)))
+
+(defclass Field_Delimited "The Field_Delimited class defines a field of a delimited record or a field of a delimited group."
+	(is-a Field)
+	(role concrete)
 	(single-slot value_offset
 ;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
 		(type FLOAT)
@@ -5620,15 +5644,27 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot field_length
-;+		(comment "The field_length attribute provides the number of bytes in the field.")
-		(type INTEGER)
+	(single-slot field_format
+;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write)))
-
-(defclass Field_Delimited "The Field_Delimited class defines a field of a delimited record or a field of a delimited group."
-	(is-a Field)
-	(role concrete)
+		(create-accessor read-write))
+	(single-slot unit
+;+		(comment "The unit attribute provides the unit of measurement.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot associated_Special_Constants
+;+		(comment "The associated_Special_Constants association is a relationship to special constants.")
+		(type INSTANCE)
+;+		(allowed-classes Special_Constants)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot associated_Statistics
 ;+		(comment "The associated_Object_Statistics association is a relationship to object statistics.")
 		(type INSTANCE)
@@ -5640,65 +5676,24 @@
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot data_type
-;+		(comment "The data_type attribute provides the hardware representation used to store a value in Field_Delimited (see PDS Standards Reference section \"Character Data Types\").")
-		(type STRING)
-;+		(value "ASCII_Boolean" "ASCII_Date_YMD" "ASCII_Integer" "ASCII_Real" "ASCII_AnyURI" "ASCII_Date_DOY" "ASCII_Date_Time_DOY_UTC" "ASCII_Date_Time_YMD_UTC" "ASCII_LID" "ASCII_LIDVID" "ASCII_MD5_Checksum" "ASCII_Time" "ASCII_VID" "ASCII_DOI" "ASCII_Numeric_Base2" "ASCII_Numeric_Base16" "ASCII_NonNegative_Integer" "ASCII_File_Specification_Name" "ASCII_File_Name" "UTF8_String" "ASCII_String" "ASCII_Directory_Path_Name" "ASCII_LIDVID_LID" "ASCII_Numeric_Base8" "ASCII_Date_Time_DOY" "ASCII_Date_Time_YMD" "ASCII_BibCode")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot field_format
-;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot associated_Special_Constants
-;+		(comment "The associated_Special_Constants association is a relationship to special constants.")
-		(type INSTANCE)
-;+		(allowed-classes Special_Constants)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot unit
-;+		(comment "The unit attribute provides the unit of measurement.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot scaling_factor
 ;+		(comment "The scaling_factor attribute is the scaling factor to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 1.")
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot value_offset
-;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot data_type
+;+		(comment "The data_type attribute provides the hardware representation used to store a value in Field_Delimited (see PDS Standards Reference section \"Character Data Types\").")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(value "ASCII_Boolean" "ASCII_Date_YMD" "ASCII_Integer" "ASCII_Real" "ASCII_AnyURI" "ASCII_Date_DOY" "ASCII_Date_Time_DOY_UTC" "ASCII_Date_Time_YMD_UTC" "ASCII_LID" "ASCII_LIDVID" "ASCII_MD5_Checksum" "ASCII_Time" "ASCII_VID" "ASCII_DOI" "ASCII_Numeric_Base2" "ASCII_Numeric_Base16" "ASCII_NonNegative_Integer" "ASCII_File_Specification_Name" "ASCII_File_Name" "UTF8_String" "ASCII_String" "ASCII_Directory_Path_Name" "ASCII_LIDVID_LID" "ASCII_Numeric_Base8" "ASCII_Date_Time_DOY" "ASCII_Date_Time_YMD" "ASCII_BibCode")
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Field_Bit "The Field_Bit class provides parameters for extracting one field out of a string of bytes which contains packed data (that is, data values either smaller than a single byte, or crossing byte boundaries, or both."
 	(is-a Field)
 	(role concrete)
-	(single-slot start_bit_location
-;+		(comment "The start_bit_location attribute provides the position of the first bit in a bit field relative to the first bit in the parent packed data field. Bytes are sequential and bits are numbered continuously across byte boundaries within a single bit field. The first bit position in the packed data field is \"1\".")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot stop_bit
 ;+		(comment "The stop-bit attribute provides the location of the last bit in this bit field relative to the first bit in the packed_data field.  Bits are numbered continuously across byte boundaries.  The first bit location in the packed data field is \"1\".")
 		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot stop_bit_location
-;+		(comment "The stop_bit_location attribute provides the position of the last bit in a bit field relative to the first bit in the parent packed data field. Bytes are sequential and bits are numbered continuously across byte boundaries within a single bit field. The first bit position in the packed data field is \"1\".")
-		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot start_bit
@@ -5706,14 +5701,33 @@
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot data_type
-;+		(comment "The data_type attribute provides the hardware representation used to store a value in Field_Bit (see PDS Standards Reference section \"Binary Data Types\").")
+	(single-slot value_offset
+;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot stop_bit_location
+;+		(comment "The stop_bit_location attribute provides the position of the last bit in a bit field relative to the first bit in the parent packed data field. Bytes are sequential and bits are numbered continuously across byte boundaries within a single bit field. The first bit position in the packed data field is \"1\".")
 		(type STRING)
-;+		(value "UnsignedBitString" "SignedBitString")
-;+		(cardinality 1 1)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot field_format
 ;+		(comment "The field_format attribute gives the magnitude and precision of the data value. This may specify the output format for a binary value, or give a general indication of the precision of a field, but is not used for validation. A subset of the standard POSIX string formats is allowed. See the PDS Standards Reference section “Field Formats” for details.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot unit
+;+		(comment "The unit attribute provides the unit of measurement.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -5723,42 +5737,33 @@
 ;+		(allowed-classes Special_Constants)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot unit
-;+		(comment "The unit attribute provides the unit of measurement.")
+	(single-slot start_bit_location
+;+		(comment "The start_bit_location attribute provides the position of the first bit in a bit field relative to the first bit in the parent packed data field. Bytes are sequential and bits are numbered continuously across byte boundaries within a single bit field. The first bit position in the packed data field is \"1\".")
 		(type STRING)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot scaling_factor
 ;+		(comment "The scaling_factor attribute is the scaling factor to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 1.")
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot value_offset
-;+		(comment "The value_offset attribute is the offset to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 0.")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot data_type
+;+		(comment "The data_type attribute provides the hardware representation used to store a value in Field_Bit (see PDS Standards Reference section \"Binary Data Types\").")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(value "UnsignedBitString" "SignedBitString")
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Record "The Record class defines a record of a file and is the parent class of all specific record classes."
 	(is-a Tagged_Digital_Child)
 	(role abstract)
-	(single-slot fields
-;+		(comment "The fields attribute provides a count of the total number of scalar fields directly associated with a table record.  Fields within groups within the record are not included in this count.")
+	(single-slot groups
+;+		(comment "The groups attribute provides a count of the total number of groups directly associated with a table record.  Groups within groups within the record are not included in this count.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot groups
-;+		(comment "The groups attribute provides a count of the total number of groups directly associated with a table record.  Groups within groups within the record are not included in this count.")
+	(single-slot fields
+;+		(comment "The fields attribute provides a count of the total number of scalar fields directly associated with a table record.  Fields within groups within the record are not included in this count.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -5766,56 +5771,51 @@
 (defclass Record_Binary "The Record_Binary class is a component of the table class and defines a record of the table."
 	(is-a Record)
 	(role concrete)
+	(single-slot record_length
+;+		(comment "The record_length attribute provides the length of a record, including a record delimiter, if present.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(multislot has_Table_Field
 ;+		(comment "The has_Table_Field association is a relationship to the field types.")
 		(type INSTANCE)
 ;+		(allowed-classes Group_Field_Binary Field_Binary XSChoice%23)
 		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot record_length
-;+		(comment "The record_length attribute provides the length of a record, including a record delimiter, if present.")
-		(type INTEGER)
-;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Record_Character "The Record_Character class is a component of the table class and defines a record of the table."
 	(is-a Record)
 	(role concrete)
-	(single-slot record_length
-;+		(comment "The record_length attribute provides the length of a record, including the record delimiter.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot has_Character_Field
 ;+		(comment "The has_Character_Field association is a relationship to the field types.")
 		(type INSTANCE)
 ;+		(allowed-classes Group_Field_Character Field_Character XSChoice%23)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot record_length
+;+		(comment "The record_length attribute provides the length of a record, including the record delimiter.")
+		(type INTEGER)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Record_Delimited "The Record_Delimited class is a component of the delimited table (spreadsheet) class and defines a record of the delimited table."
 	(is-a Record)
 	(role concrete)
-	(single-slot maximum_record_length
-;+		(comment "The maximum_record_length attribute provides the maximum length of a record, including the record delimiter.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot has_Delimited_Field
 ;+		(comment "The has_Delimited_Field association is a relationship to field.")
 		(type INSTANCE)
 ;+		(allowed-classes Field_Delimited Group_Field_Delimited XSChoice%23)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot maximum_record_length
+;+		(comment "The maximum_record_length attribute provides the maximum length of a record, including the record delimiter.")
+		(type INTEGER)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Group "The Group class defines a group of (repeating) fields and, possibly, (sub) groups; it is the parent class of all specific group classes."
 	(is-a Tagged_Digital_Child)
 	(role abstract)
-	(single-slot fields
-;+		(comment "The fields attribute provides a count of the total number of scalar fields directly associated with a group.  Fields within (sub) groups of the group are not included in this count.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot repetitions
 ;+		(comment "The repetitions attribute provides the number of times a set of repeating fields and, possibly, (sub)groups is replicated within a group.")
 		(type INTEGER)
@@ -5823,6 +5823,16 @@
 		(create-accessor read-write))
 	(single-slot groups
 ;+		(comment "The groups attribute provides a count of the number of (sub)groups within the repeating structure of a group.  (Subsub)groups within (sub)groups within the group are not included in this count.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot fields
+;+		(comment "The fields attribute provides a count of the total number of scalar fields directly associated with a group.  Fields within (sub) groups of the group are not included in this count.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -5835,22 +5845,11 @@
 ;+		(comment "The group_number attribute provides the position of a group, within a series of groups, counting from 1.  If two groups within a record are physically separated by one or more fields, they have consecutive group numbers; the intervening fields are numbered separately.  Groups within a parent group, but separated by one or more fields, will also have consecutive group numbers.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Group_Field_Binary "The Group_Field_Binary class allows a group of table fields."
 	(is-a Group)
 	(role concrete)
-	(multislot has_Group_Field_Binary
-;+		(comment "The has_Group_Field_Binary association is a relationship to the Group_Field_Binary.")
-		(type INSTANCE)
-;+		(allowed-classes XSChoice%23 Field_Binary Group_Field_Binary)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(single-slot group_length
 ;+		(comment "The group_length attribute provides the total length, in bytes, of a repeating field and/or group structure. It is the number of bytes in the repeating fields/groups plus any embedded unused bytes that are also repeated multiplied by the number of repetitions.")
 		(type INTEGER)
@@ -5860,6 +5859,12 @@
 ;+		(comment "The group_location attribute provides the starting position for a Group_Field_Binary within the containing Record_Binary or Group_Field_Binary class, in bytes. Location '1' denotes the first byte of the containing class.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Group_Field_Binary
+;+		(comment "The has_Group_Field_Binary association is a relationship to the Group_Field_Binary.")
+		(type INSTANCE)
+;+		(allowed-classes XSChoice%23 Field_Binary Group_Field_Binary)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
 (defclass Group_Field_Character "The Group_Field_Character class allows a group of table fields."
@@ -5900,16 +5905,16 @@
 		(type STRING)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot comment
-;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot id_reference_type
 ;+		(comment "The id_reference_type attribute provides the name of an association between two objects.")
 		(type STRING)
 ;+		(value "has_component" "has_primary_component")
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot comment
+;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Local_ID_Relation "The Local_ID_Relation class defines a one directional relationship between two description objects in the label."
@@ -5919,11 +5924,6 @@
 ;+		(comment "The id_reference_to provides the identifier of the ending object in a one  directional relationship.")
 		(type STRING)
 		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot comment
-;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot id_reference_from
 ;+		(comment "The id_reference_from provides the identifier of the starting object in a  one directional relationship.")
@@ -5935,6 +5935,11 @@
 		(type STRING)
 ;+		(value "has_backplane" "has_display_settings" "has_spectral_characteristics" "has_axis_values" "has_column_headers")
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot comment
+;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Tagged_NonDigital_Object "The Tagged NonDigital Object class is an abstract class for the physical and conceptual class hierarchy. A tagged object is an information object."
@@ -5954,15 +5959,15 @@
 ;+		(allowed-classes Conceptual_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot url
-;+		(comment "The url attribute provides a Uniform Resource Identifier (URI) that specifies where a resource is available and the mechanism for retrieving it.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot type
 ;+		(comment "The type attribute classifies the Resource according to its function.")
 		(type STRING)
 ;+		(value "Information.Agency" "Information.Instrument" "Information.Instrument_Host" "Information.Investigation" "Information.Node" "Information.Person" "Information.Resource" "Information.Target" "Information.Science_Portal" "System.Search" "System.Browse" "System.Registry_Query" "System.Transform" "System.Directory_Listing" "System.Transport")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot name_
@@ -5970,8 +5975,8 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot url
+;+		(comment "The url attribute provides a Uniform Resource Identifier (URI) that specifies where a resource is available and the mechanism for retrieving it.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -5985,8 +5990,8 @@
 ;+		(allowed-classes Conceptual_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot stop_date
-;+		(comment "The stop_date attribute provides the date when an activity ended.")
+	(single-slot start_date
+;+		(comment "The start_date attribute provides the date when an activity began.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -5996,18 +6001,18 @@
 ;+		(value "Individual Investigation" "Mission" "Observing Campaign" "Other Investigation" "Field Campaign")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot name_
 ;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot start_date
-;+		(comment "The start_date attribute provides the date when an activity began.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot stop_date
+;+		(comment "The stop_date attribute provides the date when an activity ended.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -6021,13 +6026,13 @@
 ;+		(allowed-classes Physical_Object Conceptual_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -6047,8 +6052,13 @@
 ;+		(allowed-classes Physical_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot instrument_host_version_id
-;+		(comment "The instrument_host_version_id attribute provides the version of the instrument host.")
+	(single-slot serial_number
+;+		(comment "The serial number attribute provides the manufacturer's serial number assigned to an instrument host.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot naif_host_id
+;+		(comment "The naif_host_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -6058,18 +6068,13 @@
 ;+		(value "Earth Based" "Rover" "Spacecraft" "Lander" "Earth-based" "Aircraft" "Balloon" "Suborbital Rocket")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot serial_number
-;+		(comment "The serial number attribute provides the manufacturer's serial number assigned to an instrument host.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot naif_host_id
-;+		(comment "The naif_host_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
+	(single-slot instrument_host_version_id
+;+		(comment "The instrument_host_version_id attribute provides the version of the instrument host.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -6078,20 +6083,15 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
-;+		(cardinality 1 1)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Instrument "The Instrument class provides a description of a physical object that collects data."
 	(is-a TNDO_Context)
 	(role concrete)
-	(single-slot naif_instrument_id
-;+		(comment "The naif_instrument_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
@@ -6103,23 +6103,23 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot subtype
-;+		(comment "The subtype attribute is a special type included within the general type. It provides more specific clarifying and/or supplemental information as to the nature of the type.")
+	(single-slot serial_number
+;+		(comment "The serial number element provides the assigned manufacturer's serial number.")
 		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot type
 ;+		(comment "The type attribute classifies the instrument according to its function.")
 		(type STRING)
 ;+		(value "Accelerometer" "Altimeter" "Camera" "Cosmic Ray Detector" "Dust Detector" "Imaging Spectrometer" "Magnetometer" "Photometer" "Plasma Analyzer" "Radio Science" "Radio Spectrometer" "Radio Telescope" "Radiometer" "Reflectometer" "Spectrometer" "Spectrograph Imager" "Alpha Particle Detector" "Biology Experiments" "Bolometer" "Imager" "Energetic Particle Detector" "Gamma Ray Detector" "Gas Analyzer" "Grinding Tool" "Inertial Measurement Unit	" "Infrared Spectrometer" "Laser Induced Breakdown Spectrometer" "Mass Spectrometer" "Microwave Spectrometer" "Naked Eye" "Neutral Particle Detector" "Neutron Detector" "Plasma Detector" "Plasma Wave Spectrometer" "Polarimeter" "Radar" "Thermal Imager" "Ultraviolet Spectrometer" "Wet Chemistry Laboratory" "X-ray Diffraction Spectrometer" "X-ray Detector" "Atomic Force Microscope" "Alpha Particle X-Ray Spectrometer" "Moessbauer Spectrometer" "Thermal Probe" "Electrical Probe" "X-ray Fluorescence Spectrometer" "Anemometer" "Barometer" "Thermometer" "Hygrometer" "Robotic Arm" "Drilling Tool" "Weather Station" "Atmospheric Sciences" "Dust" "Gravimeter" "Interferometer" "Microscope" "Particle Detector" "Radio-Radar" "Small Bodies Sciences" "Seismometer" "Regolith Properties" "Spectrograph")
 		(create-accessor read-write))
-	(single-slot has_type_list_area
-;+		(comment "The has_type_list_area association is a relationship to Type_List_Area.")
-		(type INSTANCE)
-;+		(allowed-classes Type_List_Area)
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot serial_number
-;+		(comment "The serial number element provides the assigned manufacturer's serial number.")
+	(single-slot naif_instrument_id
+;+		(comment "The naif_instrument_id element provides the numeric ID used within the SPICE system to identify the spacecraft, spacecraft structure or science instrument.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -6128,9 +6128,14 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(multislot subtype
+;+		(comment "The subtype attribute is a special type included within the general type. It provides more specific clarifying and/or supplemental information as to the nature of the type.")
 		(type STRING)
+		(create-accessor read-write))
+	(single-slot has_type_list_area
+;+		(comment "The has_type_list_area association is a relationship to Type_List_Area.")
+		(type INSTANCE)
+;+		(allowed-classes Type_List_Area)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -6148,15 +6153,15 @@
 		(type STRING)
 ;+		(value "Asteroid" "Comet" "Dust" "Galaxy" "Globular Cluster" "Meteorite" "Meteoroid" "Meteoroid Stream" "Nebula" "Open Cluster" "Planet" "Planetary Nebula" "Planetary System" "Plasma Cloud" "Ring" "Satellite" "Star" "Star Cluster" "Terrestrial Sample" "Trans-Neptunian Object" "Dwarf Planet" "Plasma Stream" "Equipment" "Calibration" "Lunar Sample" "Synthetic Sample" "Calibrator" "Exoplanet System" "Calibration Field" "Magnetic Field" "Centaur" "Laboratory Analog" "Sample" "Astrophysical" "Sky")
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot description
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Node "The Node class provides a description of an entity that provides local governance within the federated Planetary Data System."
@@ -6173,15 +6178,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot name_
 ;+		(comment "The name attribute provides a word or combination of words by which the Node is known.")
 		(type STRING)
 ;+		(value "Geosciences" "Cartography and Imaging Sciences Discipline" "Navigation and Ancillary Information Facility" "Planetary Atmospheres" "Planetary Plasma Interactions" "Ring-Moon Systems" "Radio Science" "Small Bodies" "Engineering" "Management" "Planetary Science Archive" "Imaging" "Planetary Rings")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -6199,22 +6204,22 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot electronic_mail_address
-;+		(comment "The electronic mail address attribute provides a multi-part email address: the first part (the user name), which identifies a unique user, is separated by an \"at sign\"  from the host name, which uniquely identifies the mail server.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot name_
 ;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot electronic_mail_address
+;+		(comment "The electronic mail address attribute provides a multi-part email address: the first part (the user name), which identifies a unique user, is separated by an \"at sign\"  from the host name, which uniquely identifies the mail server.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot registration_date
 ;+		(comment "The registration_date attribute provides the date of registration within the PDS system.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -6222,6 +6227,11 @@
 (defclass PDS_Affiliate "The PDS Affiliate class provides a description of a person who has an association with the planetary science community and has access to PDS resources not normally allowed to the general public."
 	(is-a TNDO_Context)
 	(role concrete)
+	(single-slot telephone_number
+;+		(comment "The telephone_number attribute provides a telephone number in  international notation in compliance with the E.164 telephone number format recommendation.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot alternate_telephone_number
 ;+		(comment "The telephone_number attribute provides a telephone number in  international notation in compliance with the E.164 telephone number format recommendation.")
 		(type STRING)
@@ -6232,23 +6242,19 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot electronic_mail_address
-;+		(comment "The electronic mail address attribute provides a multi-part email address: the first part (the user name), which identifies a unique user, is separated by an \"at sign\"  from the host name, which uniquely identifies the mail server.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot telephone_number
-;+		(comment "The telephone_number attribute provides a telephone number in  international notation in compliance with the E.164 telephone number format recommendation.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot name_
 ;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot postal_address_text
-;+		(comment "The postal address text attribute provides a mailing address.")
+	(multislot electronic_mail_address
+;+		(comment "The electronic mail address attribute provides a multi-part email address: the first part (the user name), which identifies a unique user, is separated by an \"at sign\"  from the host name, which uniquely identifies the mail server.")
 		(type STRING)
+		(create-accessor read-write))
+	(single-slot affiliation_type
+;+		(comment "The affiliation type attribute describes the type of relationship an individual has with the PDS.  Individuals with PDS affiliations are generally listed in the PDS Phone Book.")
+		(type STRING)
+;+		(value "Manager" "Technical Staff" "Affiliate" "Data Provider")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot data_object
@@ -6257,20 +6263,19 @@
 ;+		(allowed-classes Physical_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot postal_address_text
+;+		(comment "The postal address text attribute provides a mailing address.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot sort_name
 ;+		(comment "The sort name attribute provides a string to be used in ordering. For people, the last name (surname) is typically first, followed by a comma and then other names.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot phone_book_flag
-;+		(comment "The phone_book_flag attribute indicates whether or not this person should be included in the phone book.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot affiliation_type
-;+		(comment "The affiliation type attribute describes the type of relationship an individual has with the PDS.  Individuals with PDS affiliations are generally listed in the PDS Phone Book.")
-		(type STRING)
-;+		(value "Manager" "Technical Staff" "Affiliate" "Data Provider")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot team_name
@@ -6278,13 +6283,13 @@
 		(type STRING)
 ;+		(value "Engineering" "Geosciences" "Cartography and Imaging Sciences Discipline" "Navigation and Ancillary Information Facility" "Planetary Atmospheres" "Planetary Plasma Interactions" "Ring-Moon Systems" "Radio Science" "Small Bodies" "National Space Science Data Center" "Management" "Headquarters" "Planetary Rings" "Imaging")
 		(create-accessor read-write))
-	(single-slot registration_date
-;+		(comment "The registration_date attribute provides the date of registration within the PDS system.")
+	(single-slot phone_book_flag
+;+		(comment "The phone_book_flag attribute indicates whether or not this person should be included in the phone book.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot registration_date
+;+		(comment "The registration_date attribute provides the date of registration within the PDS system.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -6313,15 +6318,15 @@
 ;+		(allowed-classes Conceptual_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot name_
 ;+		(comment "The name attribute provides a word or combination of words by which the Agency is known.")
 		(type STRING)
 ;+		(value "National Aeronautics and Space Administration" "European Space Agency" "Japan Aerospace Exploration Agency" "Roscosmos State Corporation for Space Activities")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -6340,6 +6345,11 @@
 ;+		(value "Observatory" "Laboratory")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot name_
 ;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
@@ -6347,11 +6357,6 @@
 		(create-accessor read-write))
 	(single-slot country
 ;+		(comment "country")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -6364,30 +6369,15 @@
 (defclass Telescope "The Telescope class provides coordinates and parameters for terrestrial, ground-based telescopes."
 	(is-a TNDO_Context)
 	(role concrete)
-	(single-slot telescope_altitude
-;+		(comment "The telescope_altitude attribute provides the height of the telescope above a plane tangent to the reference figure (or datum) at the telescope location.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot coordinate_source
-;+		(comment "The coordinate_source attribute provides the reference figure or datum.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
 ;+		(allowed-classes Physical_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot aperture
-;+		(comment "The aperture attribute provides a measure of the effective collecting area of the telescope -- its diameter (if single and circular) or its equivalent diameter (if non-circular and/or an array).  For purposes of this definition, aperture efficiency is assumed to be 100 percent.")
-		(type FLOAT)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot telescope_latitude
-;+		(comment "The telescope_latitude attribute provides the angular distance of the telescope north (positive) from the equator, measured on the meridian of the telescope.")
-		(type FLOAT)
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot telescope_longitude
@@ -6395,9 +6385,24 @@
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot coordinate_source
+;+		(comment "The coordinate_source attribute provides the reference figure or datum.")
 		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot aperture
+;+		(comment "The aperture attribute provides a measure of the effective collecting area of the telescope -- its diameter (if single and circular) or its equivalent diameter (if non-circular and/or an array).  For purposes of this definition, aperture efficiency is assumed to be 100 percent.")
+		(type FLOAT)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot telescope_altitude
+;+		(comment "The telescope_altitude attribute provides the height of the telescope above a plane tangent to the reference figure (or datum) at the telescope location.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot telescope_latitude
+;+		(comment "The telescope_latitude attribute provides the angular distance of the telescope north (positive) from the equator, measured on the meridian of the telescope.")
+		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot altitude
@@ -6413,15 +6418,9 @@
 ;+		(comment "The software language attribute identifies the language used to write the software.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+	(single-slot abstract_desc
+;+		(comment "The abstract desc attribute provides a summary of a text, scientific article, or document.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot service_type
-;+		(comment "The service type attribute identifies the class of system function provided.")
-		(type STRING)
-;+		(value "Tool" "Service")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot release_date
@@ -6429,24 +6428,13 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot supported_operating_system_note
-;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
+	(single-slot version_id
+;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot data_object
-;+		(comment "The data_object association is a relationship to Data Object.")
-		(type INSTANCE)
-;+		(allowed-classes Conceptual_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot url
-;+		(comment "The url attribute provides a Uniform Resource Identifier (URI) that specifies where a resource is available and the mechanism for retrieving it.")
-		(type STRING)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot abstract_desc
-;+		(comment "The abstract desc attribute provides a summary of a text, scientific article, or document.")
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -6456,13 +6444,19 @@
 ;+		(value "Analysis" "Reader" "Design" "Dissemination" "Generation" "Planning" "Search" "Transformation" "Validation" "Visualization")
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot system_requirements_note
-;+		(comment "The system requirements note attribute identifies what is necessary to process the software.")
+	(single-slot data_object
+;+		(comment "The data_object association is a relationship to Data Object.")
+		(type INSTANCE)
+;+		(allowed-classes Conceptual_Object)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot version_id
-;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
+	(single-slot system_requirements_note
+;+		(comment "The system requirements note attribute identifies what is necessary to process the software.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -6471,8 +6465,19 @@
 		(type STRING)
 ;+		(value "API" "Command-Line" "GUI" "Service")
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot service_type
+;+		(comment "The service type attribute identifies the class of system function provided.")
+		(type STRING)
+;+		(value "Tool" "Service")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot url
+;+		(comment "The url attribute provides a Uniform Resource Identifier (URI) that specifies where a resource is available and the mechanism for retrieving it.")
+		(type STRING)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot supported_operating_system_note
+;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -6486,13 +6491,13 @@
 ;+		(value "Balloon" "Suborbital Rocket" "Aircraft")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -6504,8 +6509,8 @@
 (defclass Ingest_LDD_File_Desc "The Ingest_LDD_File_Desc class provides a description of the Ingest_LDD file."
 	(is-a TNDO_Context)
 	(role concrete)
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -6513,8 +6518,8 @@
 ;+		(comment "The ldd_version_id attribute provides the version of the Local Data Dictionary.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -6526,38 +6531,13 @@
 (defclass Data_Set_PDS3 "The Data Set PDS3 class is used to capture the data set information from the PDS3 Data Set Catalog."
 	(is-a TNDO_Context_PDS3)
 	(role concrete)
-	(single-slot stop_date_time
-;+		(comment "The stop_date_time attribute provides the date and time at the end of the data set.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot start_date_time
-;+		(comment "The start_date_time attribute provides the date and time at the beginning of the data set.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot start_time
-;+		(comment "The start_time attribute provides the date and time of the beginning of an event or observation (whether it be a spacecraft, ground-based, or system event) in UTC.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot nssdc
-;+		(comment "The nssdc association is a relationship to NSSDC.")
-		(type INSTANCE)
-;+		(allowed-classes NSSDC)
-		(create-accessor read-write))
-	(single-slot stop_time
-;+		(comment "The stop_time element provides the date and time of the end of an observation or event (whether it be a spacecraft, ground-based, or system event) in UTC.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot data_set_id
-;+		(comment "The data set id provides a formal name used to refer to a data set.")
+	(single-slot data_set_release_date
+;+		(comment "The data_set_release_date attribute provides the date when a data set is released by the data producer for archive or publication. In many systems this represents the end of a proprietary or validation period. Formation rule In AMMOS identify the date at which a product may be released to the general public from proprietary access. AMMOS-related systems should apply this attribute only to proprietary data.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot data_set_release_date
-;+		(comment "The data_set_release_date attribute provides the date when a data set is released by the data producer for archive or publication. In many systems this represents the end of a proprietary or validation period. Formation rule In AMMOS identify the date at which a product may be released to the general public from proprietary access. AMMOS-related systems should apply this attribute only to proprietary data.")
+	(single-slot abstract_desc
+;+		(comment "The abstract desc attribute provides a summary of a text, scientific article, or document.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -6567,15 +6547,25 @@
 ;+		(value "ARCHIVED" "IN_LIEN_RESOLUTION" "IN_PEER_REVIEW" "IN_QUEUE" "LOCALLY_ARCHIVED" "PRE_PEER_REVIEW" "SAFED" "SUPERSEDED" "IN_QUEUE_ACCUMULATING" "PRE_PEER_REVIEW_ACCUMULATING" "IN_PEER_REVIEW_ACCUMULATING" "IN_LIEN_RESOLUTION_ACCUMULATING" "LOCALLY_ARCHIVED_ACCUMULATING" "ARCHIVED_ACCUMULATING")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot data_set_terse_desc
-;+		(comment "A one line description of the data set")
+	(single-slot data_set_id
+;+		(comment "The data set id provides a formal name used to refer to a data set.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot producer_full_name
-;+		(comment "The producer_full_name attribute provides the full_name of the individual mainly responsible for the production of the data set. This individual does not have to be registered with the PDS.")
+	(single-slot stop_date_time
+;+		(comment "The stop_date_time attribute provides the date and time at the end of the data set.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot confidence_level_note
+;+		(comment "The confidence_level_note attribute is a text field which characterizes the reliability of data within a data set or the reliability of a particular programming algorithm or software component. Essentially, this note discusses the level of confidence in the accuracy of the data or in the ability of the software to produce accurate results.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot start_time
+;+		(comment "The start_time attribute provides the date and time of the beginning of an event or observation (whether it be a spacecraft, ground-based, or system event) in UTC.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
@@ -6583,28 +6573,43 @@
 ;+		(allowed-classes Conceptual_Object Physical_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot data_set_desc
-;+		(comment "The data_set_desc attribute describes the content and type of a data set and provides information required to use the data (such as binning information).")
+	(single-slot data_set_name
+;+		(comment "The data_set_name attribute provides the full name given to a data set or a data product. The data_set_name typically identifies the instrument that acquired the data of that instrument Example value data_set_id. Note This attribute is defined in the AMMOS Magellan catalog as an alias for file_name to provide backward compatibility")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot abstract_desc
-;+		(comment "The abstract desc attribute provides a summary of a text, scientific article, or document.")
+	(multislot nssdc
+;+		(comment "The nssdc association is a relationship to NSSDC.")
+		(type INSTANCE)
+;+		(allowed-classes NSSDC)
+		(create-accessor read-write))
+	(single-slot producer_full_name
+;+		(comment "The producer_full_name attribute provides the full_name of the individual mainly responsible for the production of the data set. This individual does not have to be registered with the PDS.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot confidence_level_note
-;+		(comment "The confidence_level_note attribute is a text field which characterizes the reliability of data within a data set or the reliability of a particular programming algorithm or software component. Essentially, this note discusses the level of confidence in the accuracy of the data or in the ability of the software to produce accurate results.")
+	(single-slot data_set_terse_desc
+;+		(comment "A one line description of the data set")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot start_date_time
+;+		(comment "The start_date_time attribute provides the date and time at the beginning of the data set.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot citation_text
 ;+		(comment "The citation_text attribute provides a character string containing a literature or other citation in sufficient detail that the material  could be located in PDS or elsewhere.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot data_set_name
-;+		(comment "The data_set_name attribute provides the full name given to a data set or a data product. The data_set_name typically identifies the instrument that acquired the data of that instrument Example value data_set_id. Note This attribute is defined in the AMMOS Magellan catalog as an alias for file_name to provide backward compatibility")
+	(single-slot stop_time
+;+		(comment "The stop_time element provides the date and time of the end of an observation or event (whether it be a spacecraft, ground-based, or system event) in UTC.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot data_set_desc
+;+		(comment "The data_set_desc attribute describes the content and type of a data set and provides information required to use the data (such as binning information).")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -6618,13 +6623,18 @@
 ;+		(allowed-classes Conceptual_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot mission_objectives_summary
-;+		(comment "The mission_objectives_summary attribute describes the major scientific objectives of a planetary mission or project.")
+	(single-slot mission_desc
+;+		(comment "The mission_desc attribute summarizes major aspects of a planetary mission or project, including the number and type of spacecraft, the target body or bodies and major accomplishments.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot mission_desc
-;+		(comment "The mission_desc attribute summarizes major aspects of a planetary mission or project, including the number and type of spacecraft, the target body or bodies and major accomplishments.")
+	(single-slot mission_stop_date
+;+		(comment "The mission_stop_date attribute provides the date of the end of a mission in UTC system format.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot mission_objectives_summary
+;+		(comment "The mission_objectives_summary attribute describes the major scientific objectives of a planetary mission or project.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -6637,18 +6647,29 @@
 ;+		(comment "The mission_start_date attribute provides the date of the beginning of a mission in UTC system format.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot mission_stop_date
-;+		(comment "The mission_stop_date attribute provides the date of the end of a mission in UTC system format.")
-		(type STRING)
-;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Instrument_PDS3 "The Instrument class provides a description of a phyiscal object that collects data. This class captures the PDS3 catalog Instrument information."
 	(is-a TNDO_Context_PDS3)
 	(role concrete)
-	(single-slot instrument_version_id
-;+		(comment "The Instrument_Version_Id element identifies the specific model of an instrument used to obtain data. For example, this keyword could be used to distinguish between an engineering model of a camera used to acquire test data, and a flight model of a camera used to acquire science data during a mission.")
+	(single-slot data_object
+;+		(comment "The data_object association is a relationship to Data Object.")
+		(type INSTANCE)
+;+		(allowed-classes Physical_Object)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot instrument_desc
+;+		(comment "The instrument_desc attribute describes a given instrument.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot instrument_id
+;+		(comment "The instrument id provides a formal name used to refer to an instrument.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot instrument_type
+;+		(comment "The instrument_type attribute identifies the type of an instrument. Example values: POLARIMETER SPECTROMETER")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -6657,29 +6678,13 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot data_object
-;+		(comment "The data_object association is a relationship to Data Object.")
-		(type INSTANCE)
-;+		(allowed-classes Physical_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot instrument_id
-;+		(comment "The instrument id provides a formal name used to refer to an instrument.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot instrument_desc
-;+		(comment "The instrument_desc attribute describes a given instrument.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot instrument_serial_number
 ;+		(comment "The instrument serial number element provides the manufacturer's serial number assigned to an instrument. This number may be used to uniquely identify a particular instrument for tracing its components or determining its calibration history, for example.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot instrument_type
-;+		(comment "The instrument_type attribute identifies the type of an instrument. Example values: POLARIMETER SPECTROMETER")
+	(single-slot instrument_version_id
+;+		(comment "The Instrument_Version_Id element identifies the specific model of an instrument used to obtain data. For example, this keyword could be used to distinguish between an engineering model of a camera used to acquire test data, and a flight model of a camera used to acquire science data during a mission.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -6687,11 +6692,6 @@
 (defclass Instrument_Host_PDS3 "The Instrument Host class provides a description of the phyiscal object upon which an instrument is mounted. This class captures the PDS3 catalog Instrument Host information."
 	(is-a TNDO_Context_PDS3)
 	(role concrete)
-	(single-slot instrument_host_type
-;+		(comment "The instrument_host_type attribute provides the type of host on which an instrument is based. For example instrument is located on a spacecraft instrument_host_type attribute would have the value SPACECRAFT.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
@@ -6700,6 +6700,11 @@
 		(create-accessor read-write))
 	(single-slot instrument_host_id
 ;+		(comment "The instrument_host_id attribute provides a unique identifier for the host on which an instrument is located. This host can be either a spacecraft or an earth base (e.g. earth).")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot instrument_host_type
+;+		(comment "The instrument_host_type attribute provides the type of host on which an instrument is based. For example instrument is located on a spacecraft instrument_host_type attribute would have the value SPACECRAFT.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -6717,10 +6722,25 @@
 (defclass Target_PDS3 "The Target class provides a description of a phyiscal object that is the object of data collection. This class captures the PDS3 catalog Target information."
 	(is-a TNDO_Context_PDS3)
 	(role concrete)
+	(single-slot data_object
+;+		(comment "The data_object association is a relationship to Data Object.")
+		(type INSTANCE)
+;+		(allowed-classes Physical_Object)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot target_desc
+;+		(comment "The target_desc attribute describes the characteristics of a particular target.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot target_type
 ;+		(comment "The target_type attribute identifies the type of a named target.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot orbit_direction
+;+		(comment "The orbit_direction element provides the direction of movement along the orbit about the primary as seen from the north pole of the 'invariable plane of the solar system', which is the plane passing through the center of mass of the solar system and perpendicular to the angular momentum vector of the solar system orbit motion. PROGRADE for positive rotation according to the right-hand rule, RETROGRADE for negative rotation.")
+		(type STRING)
 		(create-accessor read-write))
 	(single-slot rotation_direction
 ;+		(comment "The rotation_direction element provides the direction of rotation as viewed from the north pole of the 'invariable plane of the solar system', which is the plane passing through the center of mass of the solar system and perpendicular to the angular momentum vector of the solar system. The value for this element is PROGRADE for counter -clockwise rotation, RETROGRADE for clockwise rotation and SYNCHRONOUS for satellites which are tidally locked with the primary. Sidereal_rotation_period and rotation_direction_type are unknown for a number of satellites, and are not applicable (N/A) for satellites which are tumbling.")
@@ -6732,37 +6752,32 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot data_object
-;+		(comment "The data_object association is a relationship to Data Object.")
-		(type INSTANCE)
-;+		(allowed-classes Physical_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot primary_body_name
 ;+		(comment "The primary_body_name attribute identifies the primary body with which a given target body is associated as a secondary body.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot target_desc
-;+		(comment "The target_desc attribute describes the characteristics of a particular target.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot orbit_direction
-;+		(comment "The orbit_direction element provides the direction of movement along the orbit about the primary as seen from the north pole of the 'invariable plane of the solar system', which is the plane passing through the center of mass of the solar system and perpendicular to the angular momentum vector of the solar system orbit motion. PROGRADE for positive rotation according to the right-hand rule, RETROGRADE for negative rotation.")
-		(type STRING)
 		(create-accessor read-write)))
 
 (defclass Volume_PDS3 "The Volume_PDS3 class is used to capture the volume information from the PDS3 Data Set Catalog."
 	(is-a TNDO_Context_PDS3)
 	(role concrete)
-	(single-slot medium_type
-;+		(comment "The medium_type attribute identifies the physical storage medium for a data volume. Examples: CD-ROM, CARTRIDGE TAPE.")
+	(single-slot archive_status_note
+;+		(comment "The archive status note attribute provides a comment about the archive status.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot volume_set_id
 ;+		(comment "The volume_set_id attribute identifies a data volume or a set of volumes. Volume sets are normally considered as a single orderable entity. Examples: USA_NASA_PDS_MG_1001, USA_NASA_PDS_GR_0001_TO_GR_0009")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot volume_name
+;+		(comment "The volume_name attribute contains the name of a data volume.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot volume_de_fullname
+;+		(comment "The volume_de_fullname attribute provide the full name of the data engineer.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -6776,37 +6791,6 @@
 ;+		(comment "The curating_node_id attribute provides the id of the node currently maintaining the data set or volume and is responsible for maintaining catalog information.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot publication_date
-;+		(comment "The publication_date attribute provides the date on which an item was published.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot volume_version_id
-;+		(comment "The volume_version_id attribute identifies the version of a data volume. All original volumes should use a volume_version_id of 'Version 1'.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot archive_status_note
-;+		(comment "The archive status note attribute provides a comment about the archive status.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot data_object
-;+		(comment "The data_object association is a relationship to Data Object.")
-		(type INSTANCE)
-;+		(allowed-classes Conceptual_Object Physical_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot volume_id
-;+		(comment "The volume_id attribute provides a unique identifier for a data volume. Example: MG_1001.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot volume_de_fullname
-;+		(comment "The volume_de_fullname attribute provide the full name of the data engineer.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot volume_format
 ;+		(comment "The volume_format attribute identifies the logical format used in writing a data volume.")
 		(type STRING)
@@ -6817,23 +6801,9 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot volume_id
+;+		(comment "The volume_id attribute provides a unique identifier for a data volume. Example: MG_1001.")
 		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot volume_name
-;+		(comment "The volume_name attribute contains the name of a data volume.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write)))
-
-(defclass Volume_Set_PDS3 "The Volume_Set_PDS3 class is used to capture the volume set information from the PDS3 Data Set Catalog."
-	(is-a TNDO_Context_PDS3)
-	(role concrete)
-	(single-slot volumes
-;+		(comment "The volumes element provides the number of physical data volumes contained in a volume set.")
-		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot data_object
@@ -6842,18 +6812,13 @@
 ;+		(allowed-classes Conceptual_Object Physical_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot volume_series_name
-;+		(comment "The volume_series_name element provides a full, formal name that describes a broad categorization of data products or data sets related to a planetary body or a research campaign (e.g. International Halley Watch). A volume series consists of one or more volume sets that represent data from one or more missions or campaigns.")
+	(single-slot volume_version_id
+;+		(comment "The volume_version_id attribute identifies the version of a data volume. All original volumes should use a volume_version_id of 'Version 1'.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot volume_set_id
-;+		(comment "The volume_set_id attribute identifies a data volume or a set of volumes. Volume sets are normally considered as a single orderable entity. Examples: USA_NASA_PDS_MG_1001, USA_NASA_PDS_GR_0001_TO_GR_0009")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot volume_set_name
-;+		(comment "The volume_set_name element provides the full, formal name of one or more data volumes containing a single data set or a collection of related data sets. Volume sets are normally considered as a single orderable entity.")
+	(single-slot publication_date
+;+		(comment "The publication_date attribute provides the date on which an item was published.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -6861,6 +6826,46 @@
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot medium_type
+;+		(comment "The medium_type attribute identifies the physical storage medium for a data volume. Examples: CD-ROM, CARTRIDGE TAPE.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write)))
+
+(defclass Volume_Set_PDS3 "The Volume_Set_PDS3 class is used to capture the volume set information from the PDS3 Data Set Catalog."
+	(is-a TNDO_Context_PDS3)
+	(role concrete)
+	(single-slot data_object
+;+		(comment "The data_object association is a relationship to Data Object.")
+		(type INSTANCE)
+;+		(allowed-classes Conceptual_Object Physical_Object)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot volumes
+;+		(comment "The volumes element provides the number of physical data volumes contained in a volume set.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot volume_set_id
+;+		(comment "The volume_set_id attribute identifies a data volume or a set of volumes. Volume sets are normally considered as a single orderable entity. Examples: USA_NASA_PDS_MG_1001, USA_NASA_PDS_GR_0001_TO_GR_0009")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot volume_series_name
+;+		(comment "The volume_series_name element provides a full, formal name that describes a broad categorization of data products or data sets related to a planetary body or a research campaign (e.g. International Halley Watch). A volume series consists of one or more volume sets that represent data from one or more missions or campaigns.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot volume_set_name
+;+		(comment "The volume_set_name element provides the full, formal name of one or more data volumes containing a single data set or a collection of related data sets. Volume sets are normally considered as a single orderable entity.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Subscriber_PDS3 "The Subscriber PDS3 class provides the name of the subscriber and their subscription list."
@@ -6871,15 +6876,15 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot full_name
-;+		(comment "The full_name attribute provides the complete name for a person and includes titles and suffixes.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot subscription_id
 ;+		(comment "The subscriber_id provides the identification of a PDS subscription.")
 		(type STRING)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot full_name
+;+		(comment "The full_name attribute provides the complete name for a person and includes titles and suffixes.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass TNDO_Supplemental "The Tagged NonDigital Object (TNDO) Supplemental class is an abstract class for the supplemental class hierarchy."
@@ -6892,6 +6897,11 @@
 	(single-slot md5_checksum
 ;+		(comment "The md5_checksum attribute is the 32-character hexadecimal number computed using the MD5 algorithm for the contiguous bytes of single digital object (as stored) or for an entire file.")
 		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot maximum_scaled_value
+;+		(comment "The maximum_scaled_value attribute provides the maximum value after application of scaling_factor and value_offset (see their definitions; maximum_scaled_value is the maximum of Ov).")
+		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot local_identifier
@@ -6914,31 +6924,16 @@
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot mean
-;+		(comment "The mean attribute provides the sum of the stored array element values (after application of any bit mask) divided by the number of elements (Special_Constants values are excluded from both the sum and the count).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot maximum_scaled_value
-;+		(comment "The maximum_scaled_value attribute provides the maximum value after application of scaling_factor and value_offset (see their definitions; maximum_scaled_value is the maximum of Ov).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot minimum_scaled_value
-;+		(comment "The minimum_scaled_value attribute provides the minimum value after application of scaling_factor and value_offset (see their definitions; minimum_scaled_value is the minimum of Ov).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot standard_deviation
-;+		(comment "The standard_deviation attribute provides the standard deviation of the stored array element values after application of any bit mask (Special_Constants values are excluded from the computation).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
 ;+		(allowed-classes Conceptual_Object)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_scaled_value
+;+		(comment "The minimum_scaled_value attribute provides the minimum value after application of scaling_factor and value_offset (see their definitions; minimum_scaled_value is the minimum of Ov).")
+		(type FLOAT)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot maximum
 ;+		(comment "The maximum attribute provides the largest value which appears in the stored array after application of any bit mask (Special_Constants values are excluded).")
@@ -6949,31 +6944,21 @@
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot mean
+;+		(comment "The mean attribute provides the sum of the stored array element values (after application of any bit mask) divided by the number of elements (Special_Constants values are excluded from both the sum and the count).")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot standard_deviation
+;+		(comment "The standard_deviation attribute provides the standard deviation of the stored array element values after application of any bit mask (Special_Constants values are excluded from the computation).")
+		(type FLOAT)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Field_Statistics "The Field Statistics class provides a set of metrics for a column formed by a field in a repeating record."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot minimum
-;+		(comment "The minimum attribute provides the algebraically smallest stored value which appears in the field over all records (empty fields and Special_Constants values are excluded).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot mean
-;+		(comment "The mean attribute provides the sum of the stored field values divided by the number of values in all records (empty fields and Special_Constants values are excluded from both the sum and the count).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot standard_deviation
-;+		(comment "The standard_deviation attribute provides the standard deviation of the stored field  over all records (empty fields and Special_Constants values are excluded from the computation).")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
@@ -6990,8 +6975,28 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot median
 ;+		(comment "The median attribute provides the number separating the larger half of stored field values from the algebraically smaller half over all records (empty fields and Special_Constants values are excluded from the sort).")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot minimum
+;+		(comment "The minimum attribute provides the algebraically smallest stored value which appears in the field over all records (empty fields and Special_Constants values are excluded).")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot mean
+;+		(comment "The mean attribute provides the sum of the stored field values divided by the number of values in all records (empty fields and Special_Constants values are excluded from both the sum and the count).")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot standard_deviation
+;+		(comment "The standard_deviation attribute provides the standard deviation of the stored field  over all records (empty fields and Special_Constants values are excluded from the computation).")
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -6999,22 +7004,21 @@
 (defclass Update "The Update class consists of update information."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
 ;+		(allowed-classes Conceptual_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot update_purpose
-;+		(comment "The update purpose attribute indicates the intended objective of this update.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
-;+		(value "Update Label Metadata" "Update Supplemental Metadata")
-;+		(cardinality 1 1)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot update_entry
 ;+		(comment "The update_entry association is a relationship to Update_Entry.")
@@ -7022,29 +7026,20 @@
 ;+		(allowed-classes Update_Entry)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot update_purpose
+;+		(comment "The update purpose attribute indicates the intended objective of this update.")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(value "Update Label Metadata" "Update Supplemental Metadata")
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Vector "The Vector class provides the components of either a velocity or position vector."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
 ;+		(allowed-classes Conceptual_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot vector_components
-;+		(comment "The vector_components attribute provides a count of vector components.")
-		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot type
@@ -7053,21 +7048,15 @@
 ;+		(value "Position" "Velocity" "Acceleration" "Pointing")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot data_type
-;+		(comment "The data_type attribute provides the hardware representation used to store a value in Vector (see PDS Standards Reference section \"Attribute Data Types\").")
-		(type STRING)
-;+		(value "ASCII_Real")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot reference_frame_id
 ;+		(comment "The reference frame id attribute identifies a reference frame, an origin and set of axes, the physical realization of a reference system, i.e., the reference frame orientation and axes are established by the reported coordinates of datum points in the reference system.")
 		(type STRING)
 ;+		(value "ICRF" "MOON_ME_DE421")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot vector_component
@@ -7076,20 +7065,31 @@
 ;+		(allowed-classes Vector_Component)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot vector_components
+;+		(comment "The vector_components attribute provides a count of vector components.")
+		(type INTEGER)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot data_type
+;+		(comment "The data_type attribute provides the hardware representation used to store a value in Vector (see PDS Standards Reference section \"Attribute Data Types\").")
+		(type STRING)
+;+		(value "ASCII_Real")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Quaternion "The Quaternion class models a mathematical construct that consists of four individual numeric components.  Quaternions are a convenient mechanism for encapsulating orientation information since they require only four units of numeric storage, as opposed to the nine needed for a rotation matrix."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
@@ -7102,11 +7102,6 @@
 ;+		(value "SPICE" "Spacecraft Telemetry")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot quaternion_component
 ;+		(comment "The quaternion_component association is a relationship to Quaternion_Component.")
 		(type INSTANCE)
@@ -7117,27 +7112,40 @@
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass DD_Attribute_Full "The DD_Attribute_Full class provides a more complete definition of an attribute in the data dictionary."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(multislot terminological_entry
-;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
-		(type INSTANCE)
-;+		(allowed-classes Terminological_Entry)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot submitter_name
-;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
+	(single-slot namespace_id
+;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot value_domain_entry
-;+		(comment "The value_domain_entry association is a relationship to Value_Domain.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Value_Domain_Full)
-;+		(cardinality 0 1)
+	(single-slot version_id
+;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot nillable_flag
+;+		(comment "The nillable_flag attribute indicates whether an attribute is allowed to take on nil as a value.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot local_identifier
 ;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
@@ -7154,36 +7162,21 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot definition
-;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
+	(single-slot submitter_name
+;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot attribute_concept
-;+		(comment "The attribute_concept attribute provides the type of information (classification) conveyed by the attribute -- e.g., stop_date_time has  attribute_concept = date_time.")
-		(type STRING)
-;+		(value "Address" "Angle" "Attribute" "Bit" "Checksum" "Collection" "Constant" "Cosine" "Count" "Delimiter" "Description" "Deviation" "Direction" "Distance" "DOI" "Duration" "Factor" "Flag" "Format" "Group" "Home" "Latitude" "Length" "List" "Location" "Logical" "Longitude" "Mask" "Maximum" "Mean" "Median" "Minimum" "Name" "Note" "Number" "Offset" "Order" "Parallel" "Password" "Path" "Pattern" "Pixel" "Quaternion" "Radius" "Ratio" "Reference" "Resolution" "Role" "Rotation" "Scale" "Sequence" "Set" "Size" "Status" "Summary" "Syntax" "Temperature" "Text" "Title" "Type" "Unit" "Value" "Vector" "ID" "Unknown")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot nillable_flag
-;+		(comment "The nillable_flag attribute indicates whether an attribute is allowed to take on nil as a value.")
-		(type STRING)
-;+		(cardinality 1 1)
+	(multislot terminological_entry
+;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
+		(type INSTANCE)
+;+		(allowed-classes Terminological_Entry)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
 ;+		(allowed-classes Conceptual_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot namespace_id
-;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot type
@@ -7198,11 +7191,6 @@
 ;+		(value "0001_NASA_PDS_1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot version_id
-;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot steward_id
 ;+		(comment "The steward attribute indicates the person or organization that manages a set of registered attributes and classes.")
 		(type STRING)
@@ -7213,21 +7201,38 @@
 ;+		(comment "The class_name attribute provides the common name by which the class is identified, as well as the class within which the attribute is used.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot definition
+;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot value_domain_entry
+;+		(comment "The value_domain_entry association is a relationship to Value_Domain.")
+		(type INSTANCE)
+;+		(allowed-classes DD_Value_Domain_Full)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot attribute_concept
+;+		(comment "The attribute_concept attribute provides the type of information (classification) conveyed by the attribute -- e.g., stop_date_time has  attribute_concept = date_time.")
+		(type STRING)
+;+		(value "Address" "Angle" "Attribute" "Bit" "Checksum" "Collection" "Constant" "Cosine" "Count" "Delimiter" "Description" "Deviation" "Direction" "Distance" "DOI" "Duration" "Factor" "Flag" "Format" "Group" "Home" "Latitude" "Length" "List" "Location" "Logical" "Longitude" "Mask" "Maximum" "Mean" "Median" "Minimum" "Name" "Note" "Number" "Offset" "Order" "Parallel" "Password" "Path" "Pattern" "Pixel" "Quaternion" "Radius" "Ratio" "Reference" "Resolution" "Role" "Rotation" "Scale" "Sequence" "Set" "Size" "Status" "Summary" "Syntax" "Temperature" "Text" "Title" "Type" "Unit" "Value" "Vector" "ID" "Unknown")
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Display_2D_Image "The Display_2D_Image class provides attributes to enable the display of a 2 dimensional image."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot line_display_direction
-;+		(comment "The line_display_direction element is the preferred orientation of lines within an image for viewing on a display device. Note that if this keyword is present in a label, the sample_display_direction keyword must also be present and must contain a value orthogonal to the value selected for this keyword.")
-		(type STRING)
-;+		(value "Down" "Up")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot sample_display_direction
 ;+		(comment "The sample_display_direction attribute provides the preferred orientation of samples within a line for viewing on a display device. The attribute sample_display_direction must be used with line_display_direction.")
 		(type STRING)
 ;+		(value "Right")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot line_display_direction
+;+		(comment "The line_display_direction element is the preferred orientation of lines within an image for viewing on a display device. Note that if this keyword is present in a label, the sample_display_direction keyword must also be present and must contain a value orthogonal to the value selected for this keyword.")
+		(type STRING)
+;+		(value "Down" "Up")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -7249,12 +7254,6 @@
 (defclass Bundle "The Bundle class describes a collection of collections."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot bundle_type
-;+		(comment "The bundle_type attribute provides a classification for the bundle.")
-		(type STRING)
-;+		(value "Archive" "Supplemental" "External")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
@@ -7265,6 +7264,12 @@
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot bundle_type
+;+		(comment "The bundle_type attribute provides a classification for the bundle.")
+		(type STRING)
+;+		(value "Archive" "Supplemental" "External")
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Symbolic_Literals_PDS "The Symbolic_Literals_PDS class is used to collect orphan attributes for the pds namespace. These attributes are members by default of the USER class but not members of any domain class."
@@ -7280,8 +7285,8 @@
 (defclass Tracking "The Tracking class provides the status of products during the archive life cycle."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot identifier
-;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -7291,8 +7296,8 @@
 ;+		(allowed-classes Tracking_Detail)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot identifier
+;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -7300,21 +7305,6 @@
 (defclass Software "The Software class describes a software product"
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot software_id
-;+		(comment "The software id attribute provides a formal name used to refer to the software.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot software_type
-;+		(comment "The software type attribute identifies the class of which the software is a member.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot software_version_id
-;+		(comment "The software_version_id attribute provides the version of the software.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
@@ -7326,13 +7316,8 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot version_id
-;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
+	(single-slot author_list
+;+		(comment "The author_list attribute contains a semi-colon-separated list of names of people to be cited as authors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final author. All authors should be listed explicitly - do not elide the list using \"et al.\".")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7341,27 +7326,52 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot software_version_id
+;+		(comment "The software_version_id attribute provides the version of the software.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot version_id
+;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot software_type
+;+		(comment "The software type attribute identifies the class of which the software is a member.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot programmers_manual_id
 ;+		(comment "The programmers manual id attribute provides an identifier to a document giving instruction about the programming of the software.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot author_list
-;+		(comment "The author_list attribute contains a semi-colon-separated list of names of people to be cited as authors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final author. All authors should be listed explicitly - do not elide the list using \"et al.\".")
+	(single-slot software_id
+;+		(comment "The software id attribute provides a formal name used to refer to the software.")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Document "The Document class describes a document."
 	(is-a TNDO_Supplemental)
 	(role concrete)
+	(single-slot author_list
+;+		(comment "The author_list attribute contains a semi-colon-separated list of names of people to be cited as authors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final author. All authors should be listed explicitly - do not elide the list using \"et al.\".")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot acknowledgement_text
 ;+		(comment "The acknowledgement_text attribute is a character string which recognizes another's contribution, authority, or right.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot document_editions
-;+		(comment "The document_editions attribute provides a count of the total number of complete, distinct editions of the document.")
+	(single-slot document_name
+;+		(comment "The document_title attribute provides the full name of the published document. This optional attribute is used only if the title in the identification area of the document product is not sufficient.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7370,23 +7380,13 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot publication_date
-;+		(comment "The publication_date attribute provides the date on which an item was published.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot author_list
-;+		(comment "The author_list attribute contains a semi-colon-separated list of names of people to be cited as authors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final author. All authors should be listed explicitly - do not elide the list using \"et al.\".")
+	(single-slot revision_id
+;+		(comment "The revision_id attribute provides the revision level of a document, which may be set outside PDS and may be different from its version_id.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot editor_list
-;+		(comment "The editor_list attribute contains a semi-colon-separated list of names of people to be cited as editors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final editor. All editors should be listed explicitly - do not elide the list using \"et al.\".")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot document_name
-;+		(comment "The document_title attribute provides the full name of the published document. This optional attribute is used only if the title in the identification area of the document product is not sufficient.")
+	(single-slot document_editions
+;+		(comment "The document_editions attribute provides a count of the total number of complete, distinct editions of the document.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7396,19 +7396,24 @@
 ;+		(allowed-classes Digital_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot revision_id
-;+		(comment "The revision_id attribute provides the revision level of a document, which may be set outside PDS and may be different from its version_id.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot has_document_edition
 ;+		(comment "The has document edition association is a relationship to Document Edition.")
 		(type INSTANCE)
 ;+		(allowed-classes Document_Edition)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
+	(single-slot publication_date
+;+		(comment "The publication_date attribute provides the date on which an item was published.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot description
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot editor_list
+;+		(comment "The editor_list attribute contains a semi-colon-separated list of names of people to be cited as editors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final editor. All editors should be listed explicitly - do not elide the list using \"et al.\".")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7421,16 +7426,6 @@
 (defclass Software_Source "The Software Source class provides a description of a software code that is stored as source code."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot software_dialect
-;+		(comment "The software dialect attribute indicates the variety of a language used to write the software.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot supported_operating_system_note
-;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
-		(type STRING)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(single-slot software_language
 ;+		(comment "The software language attribute identifies the language used to write the software.")
 		(type STRING)
@@ -7442,13 +7437,28 @@
 ;+		(allowed-classes Digital_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot software_dialect
+;+		(comment "The software dialect attribute indicates the variety of a language used to write the software.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(multislot supported_architecture_note
 ;+		(comment "The supported architecture note attribute identifies  the hardware architecture that can process the software.")
 		(type STRING)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot compile_note
-;+		(comment "The compile note attribute provides a brief statement giving particulars about the compilation of the software source.")
+	(single-slot system_requirements_note
+;+		(comment "The system requirements note attribute identifies what is necessary to process the software.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot software_format_type
+;+		(comment "The software format type attribute classifies the format of the software.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot program_notes_id
+;+		(comment "The program notes id attribute provides an identifier to a brief statement giving particulars about a software program.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -7457,39 +7467,34 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot system_requirements_note
-;+		(comment "The system requirements note attribute identifies what is necessary to process the software.")
+	(single-slot compile_note
+;+		(comment "The compile note attribute provides a brief statement giving particulars about the compilation of the software source.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot software_format_type
-;+		(comment "The software format type attribute classifies the format of the software.")
+	(multislot supported_operating_system_note
+;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
 		(type STRING)
-;+		(cardinality 1 1)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
 	(single-slot files
 ;+		(comment "The files attribute provides the number of files.")
 		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot program_notes_id
-;+		(comment "The program notes id attribute provides an identifier to a brief statement giving particulars about a software program.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Software_Script "The Software Script class provides a description of a software code that is stored as a script."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot install_note
-;+		(comment "The install note attribute provides a brief statement giving particulars about the installation of the software.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
 ;+		(allowed-classes Digital_Object)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot supported_environment_note
+;+		(comment "The supported environment note attribute identifies  the environment  that can process the software.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot system_requirements_note
@@ -7497,25 +7502,20 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot install_note
+;+		(comment "The install note attribute provides a brief statement giving particulars about the installation of the software.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot files
 ;+		(comment "The files attribute provides the number of files.")
 		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot supported_environment_note
-;+		(comment "The supported environment note attribute identifies  the environment  that can process the software.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Software_Binary "The Software Binary class provides a description of a software code that is stored as a compiled binary file."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(multislot supported_operating_system_note
-;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
-		(type STRING)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
@@ -7527,11 +7527,6 @@
 		(type STRING)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(multislot os_version
-;+		(comment "The OS version attribute indicates the version of an operating system.")
-		(type STRING)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(single-slot system_requirements_note
 ;+		(comment "The system requirements note attribute identifies what is necessary to process the software.")
 		(type STRING)
@@ -7542,24 +7537,33 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot files
-;+		(comment "The files attribute provides the number of files.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot program_notes_id
 ;+		(comment "The program notes id attribute provides an identifier to a brief statement giving particulars about a software program.")
 		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot os_version
+;+		(comment "The OS version attribute indicates the version of an operating system.")
+		(type STRING)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(multislot supported_operating_system_note
+;+		(comment "The supported operating system note attribute identifies the Operating System that supports the software.")
+		(type STRING)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot files
+;+		(comment "The files attribute provides the number of files.")
+		(type INTEGER)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Information_Package_Component "The Information_Package_Component class associates a Bundle, Collections or Basic Products with Checksum and Storage Manifests."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot has_Transfer_Manifest
-;+		(comment "The has_Transfer_Manifest association is a relationship to Transfer_Manifest.")
-		(type INSTANCE)
-;+		(allowed-classes File_Area_Transfer_Manifest)
+	(single-slot transfer_manifest_checksum
+;+		(comment "The transfer manifest checksum provides the checksum for the transfer manifest file.")
+		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot has_Checksum_Manifest
@@ -7573,6 +7577,12 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot has_Transfer_Manifest
+;+		(comment "The has_Transfer_Manifest association is a relationship to Transfer_Manifest.")
+		(type INSTANCE)
+;+		(allowed-classes File_Area_Transfer_Manifest)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(multislot internal_reference
 ;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
 		(type INSTANCE)
@@ -7581,11 +7591,6 @@
 		(create-accessor read-write))
 	(single-slot checksum_manifest_checksum
 ;+		(comment "The checksum manifest checksum provides the checksum for the checksum manifest file.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot transfer_manifest_checksum
-;+		(comment "The transfer manifest checksum provides the checksum for the transfer manifest file.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -7628,33 +7633,13 @@
 (defclass DD_Class_Full "The DD_Class_Full class provides a more complete definition of a class for a data dictionary."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(multislot terminological_entry
-;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
-		(type INSTANCE)
-;+		(allowed-classes Terminological_Entry)
-		(create-accessor read-write))
-	(single-slot submitter_name
-;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
+	(single-slot namespace_id
+;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot registered_by
-;+		(comment "The registered_by attribute provides the name of the person or organization that registered the object.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot comment
-;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot definition
-;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
+	(single-slot version_id
+;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -7663,25 +7648,45 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot abstract_flag
+;+		(comment "The abstract flag attribute indicates whether or not the class can be instantiated. Abstract flag is only included if a value of 'true' is desired and indicates that the class is abstract and cannot be used in a label.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot registered_by
+;+		(comment "The registered_by attribute provides the name of the person or organization that registered the object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(multislot dd_association
 ;+		(comment "The local_association_attribute association provides a relationship to an attribute.")
 		(type INSTANCE)
 ;+		(allowed-classes DD_Association)
 		(create-accessor read-write))
-	(single-slot element_flag
-;+		(comment "The element flag attribute indicates whether or not the class is defined as a xs:element in XML Schema.")
+	(single-slot comment
+;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot submitter_name
+;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot terminological_entry
+;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
+		(type INSTANCE)
+;+		(allowed-classes Terminological_Entry)
 		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
 ;+		(allowed-classes Conceptual_Object)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot namespace_id
-;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot type
@@ -7695,21 +7700,21 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot version_id
-;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot abstract_flag
-;+		(comment "The abstract flag attribute indicates whether or not the class can be instantiated. Abstract flag is only included if a value of 'true' is desired and indicates that the class is abstract and cannot be used in a label.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot steward_id
 ;+		(comment "The steward_id attribute provides the abbreviation of the organization that manages the set of registered attributes and classes.")
 		(type STRING)
 ;+		(value "pds" "atm" "geo" "img" "naif" "ppi" "rings" "rs" "sbn" "ops")
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot definition
+;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot element_flag
+;+		(comment "The element flag attribute indicates whether or not the class is defined as a xs:element in XML Schema.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Zip "The Zip class describes a zip file."
@@ -7730,13 +7735,13 @@
 (defclass Vector_Cartesian_3 "The Vector_Cartesian_3_Base class is the parent class of 3 element Cartesian vectors."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot y
-;+		(comment "The y attribute provides the value of the y coordinate in a position vector.")
+	(single-slot x
+;+		(comment "The x attribute provides the value of the x coordinate in a position vector.")
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot x
-;+		(comment "The x attribute provides the value of the x coordinate in a position vector.")
+	(single-slot y
+;+		(comment "The y attribute provides the value of the y coordinate in a position vector.")
 		(type FLOAT)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -7771,15 +7776,31 @@
 (defclass Ingest_LDD "The Ingest_LDD class provides a form for collecting class and attribute definitions."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(multislot local_rule
-;+		(comment "The local_rule association is a relationship to DD_Rule")
-		(type INSTANCE)
-;+		(allowed-classes DD_Rule)
-		(create-accessor read-write))
-	(single-slot full_name
-;+		(comment "The full_name attribute provides the complete name for a person and includes titles and suffixes.")
+	(single-slot namespace_id
+;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot dictionary_type
+;+		(comment "The dictionary_type attribute provides the name of a dictionary category.")
+		(type STRING)
+;+		(value "Common" "Discipline" "Mission")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot local_class_extended
+;+		(comment "The local_class_extended association is a relationship to DD_Class_Extended.")
+		(type INSTANCE)
+;+		(allowed-classes DD_Class_Extended)
+		(create-accessor read-write))
+	(multislot local_attribute
+;+		(comment "The local_attribute association is a relationship to Local_Attribute.")
+		(type INSTANCE)
+;+		(allowed-classes DD_Attribute)
 		(create-accessor read-write))
 	(multislot external_property_maps_id
 ;+		(comment "The external_property_maps_id attribute provides the identifier of a property_maps instance external to this context.")
@@ -7790,20 +7811,20 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+	(single-slot full_name
+;+		(comment "The full_name attribute provides the complete name for a person and includes titles and suffixes.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot local_class
-;+		(comment "The local_class association is a relationship to Local_Class.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Class)
+	(single-slot last_modification_date_time
+;+		(comment "The last_modification_date_time attribute gives the most recent date and time that a change was made.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot local_class_extended
-;+		(comment "The local_class_extended association is a relationship to DD_Class_Extended.")
+	(multislot local_rule
+;+		(comment "The local_rule association is a relationship to DD_Rule")
 		(type INSTANCE)
-;+		(allowed-classes DD_Class_Extended)
+;+		(allowed-classes DD_Rule)
 		(create-accessor read-write))
 	(single-slot data_object
 ;+		(comment "The data_object association is a relationship to Data Object.")
@@ -7811,18 +7832,18 @@
 ;+		(allowed-classes Conceptual_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot namespace_id
-;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot local_attribute
-;+		(comment "The local_attribute association is a relationship to Local_Attribute.")
+	(multislot local_class
+;+		(comment "The local_class association is a relationship to Local_Class.")
 		(type INSTANCE)
-;+		(allowed-classes DD_Attribute)
+;+		(allowed-classes DD_Class)
 		(create-accessor read-write))
-	(single-slot last_modification_date_time
-;+		(comment "The last_modification_date_time attribute gives the most recent date and time that a change was made.")
+	(multislot local_attribute_extended
+;+		(comment "The local_attribute_extended association is a relationship to Local_Attribute_Extended.")
+		(type INSTANCE)
+;+		(allowed-classes DD_Attribute_Extended)
+		(create-accessor read-write))
+	(single-slot steward_id
+;+		(comment "The steward_id attribute provides the abbreviation of the organization that manages the set of registered attributes and classes.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -7831,45 +7852,44 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot steward_id
-;+		(comment "The steward_id attribute provides the abbreviation of the organization that manages the set of registered attributes and classes.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot has_Property_Maps
 ;+		(comment "The has_Property_Maps association is a relationship to a Property Maps class")
 		(type INSTANCE)
 ;+		(allowed-classes Property_Maps)
-		(create-accessor read-write))
-	(single-slot dictionary_type
-;+		(comment "The dictionary_type attribute provides the name of a dictionary category.")
-		(type STRING)
-;+		(value "Common" "Discipline" "Mission")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot local_attribute_extended
-;+		(comment "The local_attribute_extended association is a relationship to Local_Attribute_Extended.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Attribute_Extended)
 		(create-accessor read-write)))
 
 (defclass DD_Attribute "The DD_Attribute class defines an attribute for a data dictionary."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot submitter_name
-;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot terminological_entry
 ;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
 		(type INSTANCE)
 ;+		(allowed-classes Terminological_Entry)
 		(create-accessor read-write))
-	(single-slot value_domain_entry
-;+		(comment "The value_domain_entry association is a relationship to Value_Domain.")
+	(single-slot submitter_name
+;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot data_object
+;+		(comment "The data_object association is a relationship to Data Object.")
 		(type INSTANCE)
-;+		(allowed-classes DD_Value_Domain)
+;+		(allowed-classes Conceptual_Object)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot definition
+;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot version_id
+;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot nillable_flag
@@ -7877,58 +7897,38 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot internal_reference
+;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Internal_Reference)
+		(create-accessor read-write))
 	(single-slot local_identifier
 ;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot data_object
-;+		(comment "The data_object association is a relationship to Data Object.")
+	(single-slot value_domain_entry
+;+		(comment "The value_domain_entry association is a relationship to Value_Domain.")
 		(type INSTANCE)
-;+		(allowed-classes Conceptual_Object)
+;+		(allowed-classes DD_Value_Domain)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot internal_reference
-;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Internal_Reference)
 		(create-accessor read-write))
 	(single-slot comment
 ;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot definition
-;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot version_id
-;+		(comment "The version_id attribute provides the version of the product, expressed in the PDS [m.n] notation.")
-		(type STRING)
-;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass DD_Class "The DD_Class class defines a class for a data dictionary."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot submitter_name
-;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot terminological_entry
 ;+		(comment "The terminological_entry association is a relationship to Terminological_Entry.")
 		(type INSTANCE)
 ;+		(allowed-classes Terminological_Entry)
 		(create-accessor read-write))
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+	(single-slot submitter_name
+;+		(comment "The submitter_name attribute provides the name of the author, who submits the item to the steward.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -7938,18 +7938,8 @@
 ;+		(allowed-classes Conceptual_Object)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot internal_reference
-;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Internal_Reference)
-		(create-accessor read-write))
 	(single-slot definition
 ;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -7958,13 +7948,28 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot abstract_flag
-;+		(comment "The abstract flag attribute indicates whether or not the class can be instantiated. Abstract flag is only included if a value of 'true' is desired and indicates that the class is abstract and cannot be used in a label.")
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot element_flag
 ;+		(comment "The element flag attribute indicates whether or not the class is defined as a xs:element in XML Schema.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot internal_reference
+;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Internal_Reference)
+		(create-accessor read-write))
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot abstract_flag
+;+		(comment "The abstract flag attribute indicates whether or not the class can be instantiated. Abstract flag is only included if a value of 'true' is desired and indicates that the class is abstract and cannot be used in a label.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -7978,31 +7983,6 @@
 (defclass Band_Bin "The Band_Bin class specifies the characteristics of an individual spectral band in a spectral qube."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot filter_number
-;+		(comment "The filter_number attribute of a spectral qube describes the physical location of a band %28identified by the band_number%29 in a detector array. Filter 1 is on the leading edge of the array.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot standard_deviation
-;+		(comment "The standard_deviation attribute provides the standard deviation of values in the associated object; empty and Special_Constants values are excluded.")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot grating_position
-;+		(comment "The grating_position attribute of a spectral qube describes the grating position which corresponds to the band. Grating positions are usually assigned consecutively from 0, and increasing position causes increasing wavelength for each detector.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot detector_number
-;+		(comment "The detector_number attribute provides the spectrometer detector number corresponding to a band of a spectral qube. Detector numbers are usually assigned consecutively from 1, in order of increasing wavelength.")
-		(type INTEGER)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot scaling_factor
-;+		(comment "The scaling_factor attribute is the scaling factor to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 1.")
-		(type FLOAT)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot band_width
 ;+		(comment "The band_width attributes provides the width, at half height, of the band.")
 		(type FLOAT)
@@ -8013,8 +7993,18 @@
 		(type FLOAT)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot detector_number
+;+		(comment "The detector_number attribute provides the spectrometer detector number corresponding to a band of a spectral qube. Detector numbers are usually assigned consecutively from 1, in order of increasing wavelength.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot original_band
 ;+		(comment "The original_band attribute of a spectral qube provides the sequence of band numbers in the qube relative to some original qube. In the original qube, the values are just consecutive integers beginning with 1. In a qube which contains a subset of the bands in the original qube, the values are the original sequence numbers from that qube.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot filter_number
+;+		(comment "The filter_number attribute of a spectral qube describes the physical location of a band %28identified by the band_number%29 in a detector array. Filter 1 is on the leading edge of the array.")
 		(type INTEGER)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -8027,6 +8017,21 @@
 ;+		(comment "The center_wavelength attribute provides the wavelength or frequency describing the center of a bin along the band axis of a spectral qube. When describing data from a spectrometer, the value corresponds to the peak of the response function for a particular detector and%2For grating position.")
 		(type FLOAT)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot standard_deviation
+;+		(comment "The standard_deviation attribute provides the standard deviation of values in the associated object; empty and Special_Constants values are excluded.")
+		(type FLOAT)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot grating_position
+;+		(comment "The grating_position attribute of a spectral qube describes the grating position which corresponds to the band. Grating positions are usually assigned consecutively from 0, and increasing position causes increasing wavelength for each detector.")
+		(type INTEGER)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot scaling_factor
+;+		(comment "The scaling_factor attribute is the scaling factor to be applied to each stored value in order to recover an original  value. The observed value (Ov) is calculated from the stored value (Sv) thus: Ov = (Sv * scaling_factor) + value_offset. The default value is 1.")
+		(type FLOAT)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Band_Bin_Set "The Band_Bin_Set class contains the spectral characteristics for all the spectral bands in a qube."
@@ -8042,8 +8047,7 @@
 (defclass Schematron_Rule "The Schematron_Rule Class is used to capture schemtron rule statements."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot identifier
-;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
+	(single-slot xpath
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -8051,44 +8055,8 @@
 ;+		(comment "The schematronAssign attribute provides values for schemtron rule assignments at the rule level.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot classNameSpaceNC
-;+		(comment "The classNameSpaceNC attribute provides the class name space Id without a colon.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot alwaysInclude
-;+		(comment "The alwaysInclude attribute indicates whether a rule should always be included.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_Schematron_Assert
-		(type INSTANCE)
-;+		(allowed-classes Schematron_Assert)
-		(create-accessor read-write))
-	(single-slot attrTitle
-;+		(comment "The attrTitle attribute provides the name of the attribute to be used for display.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot schematronAssignPattern
-;+		(comment "The schematronAssignPattern attribute provides values for schemtron rule assignments at the pattern level.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot isMissionOnly
-;+		(comment "The isMissionOnly attribute indicates whether a rule is for mission level dictionaries only.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot %3ANAME
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot xpath
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot classSteward
-;+		(comment "The classSteward attribute provides the name of the steward for this rule.")
+	(single-slot attrNameSpaceNC
+;+		(comment "The attrNameSpaceNC attribute provides the attribute name space Id without a colon.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -8097,8 +8065,32 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot has_Schematron_Assert
+		(type INSTANCE)
+;+		(allowed-classes Schematron_Assert)
+		(create-accessor read-write))
 	(single-slot type
 ;+		(comment "The type attribute provides a classification for the resource.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot classNameSpaceNC
+;+		(comment "The classNameSpaceNC attribute provides the class name space Id without a colon.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot attrTitle
+;+		(comment "The attrTitle attribute provides the name of the attribute to be used for display.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot classSteward
+;+		(comment "The classSteward attribute provides the name of the steward for this rule.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot alwaysInclude
+;+		(comment "The alwaysInclude attribute indicates whether a rule should always be included.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -8107,8 +8099,21 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot attrNameSpaceNC
-;+		(comment "The attrNameSpaceNC attribute provides the attribute name space Id without a colon.")
+	(multislot schematronAssignPattern
+;+		(comment "The schematronAssignPattern attribute provides values for schemtron rule assignments at the pattern level.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot %3ANAME
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot identifier
+;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot isMissionOnly
+;+		(comment "The isMissionOnly attribute indicates whether a rule is for mission level dictionaries only.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -8116,24 +8121,11 @@
 (defclass Schematron_Assert "The Schematron_Assert Class is used to capture schemtron assert statements."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot identifier
-;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot assertMsg
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot assertStmt
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot specMesg
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot assertType
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -8146,17 +8138,41 @@
 ;+		(comment "The testValArr attribute provides the values for the assert statement.")
 		(type STRING)
 		(create-accessor read-write))
+	(single-slot assertStmt
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot %3ANAME
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot identifier
+;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot assertType
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass DD_Rule "The DD_Rule class defines a Schematron rule for a data dictionary."
 	(is-a TNDO_Supplemental)
 	(role concrete)
+	(single-slot dd_class_reference
+;+		(comment "The dd_class_reference association is a relationship to DD_Class_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes DD_Class_Reference)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(multislot rule_assign
 ;+		(comment "The rule_assign attribute provides an assignment statement for a schematron rule.")
 		(type STRING)
+		(create-accessor read-write))
+	(single-slot rule_context
+;+		(comment "The rule_context attribute provides the xpath for the rule.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot local_identifier
 ;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
@@ -8174,30 +8190,19 @@
 		(type INSTANCE)
 ;+		(allowed-classes DD_Attribute_Reference)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot dd_class_reference
-;+		(comment "The dd_class_reference association is a relationship to DD_Class_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Class_Reference)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot rule_context
-;+		(comment "The rule_context attribute provides the xpath for the rule.")
-		(type STRING)
-;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass DD_Rule_Statement "The DD_Rule_Statement class defines a Schematron rule statement."
 	(is-a TNDO_Supplemental)
 	(role concrete)
+	(multislot rule_value
+;+		(comment "The rule_value attribute provides values to be used to complete certain schematon statements.")
+		(type STRING)
+		(create-accessor read-write))
 	(single-slot rule_test
 ;+		(comment "The rule_test attribute provides the body of the statement to be executed by the schematron processor.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot rule_value
-;+		(comment "The rule_value attribute provides values to be used to complete certain schematon statements.")
-		(type STRING)
 		(create-accessor read-write))
 	(single-slot rule_description
 ;+		(comment "The rule_description attribute provides a description of the rule statement suitable for  user documentation.")
@@ -8219,9 +8224,20 @@
 (defclass Information_Package_Component_Deep_Archive "The Information Package Component Deep Archive class is an Information Package Component for the NASA planetary science deep archive."
 	(is-a TNDO_Supplemental)
 	(role concrete)
+	(single-slot aip_lidvid
+;+		(comment "The aip_lidvid attribute provides the logical_identifier plus version_id, which uniquely identifies a Archival Information Package.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot aip_label_checksum
 ;+		(comment "The aip_label_checksum attribute provides the checksum for the Archival Information Package label.")
 		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot has_manifest
+;+		(comment "The has_manifest association is a relationship to a manifest.")
+		(type INSTANCE)
+;+		(allowed-classes File_Area_SIP_Deep_Archive)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot checksum_type
@@ -8241,51 +8257,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot aip_lidvid
-;+		(comment "The aip_lidvid attribute provides the logical_identifier plus version_id, which uniquely identifies a Archival Information Package.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot manifest_url
 ;+		(comment "The manifest url provides the URL to the manifest file.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot has_manifest
-;+		(comment "The has_manifest association is a relationship to a manifest.")
-		(type INSTANCE)
-;+		(allowed-classes File_Area_SIP_Deep_Archive)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Property_Map "The Property Map class defines a table consisting of a set of data elements and their values. The data elements in this table are considered to be locally defined and not subject to standards except for nomenclature rules."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(multislot has_Property_Map_Entry
-;+		(comment "The has_Property_Map_Entry association is a relationship to property map entry.")
-		(type INSTANCE)
-;+		(allowed-classes Property_Map_Entry)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot identifier
-;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot title
-;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot model_object_type
-;+		(comment "The model_object_type attribute provides a classification for a modeled object.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot instance_id
-;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot model_object_id
 ;+		(comment "The model_object_id attribute provides the unique identifier of a class, attribute, or value that is defined in the information model.")
 		(type STRING)
@@ -8299,66 +8279,75 @@
 	(multislot external_namespace_id
 ;+		(comment "The external_namespace_id attribute provides a namespace_id external to this context.")
 		(type STRING)
-		(create-accessor read-write)))
-
-(defclass Property_Map_Entry "The property map entry consists of a property name and one or more values."
-	(is-a TNDO_Supplemental)
-	(role concrete)
-	(multislot property_value
-;+		(comment "The property value attribute provides the value assigned to a property.")
-		(type STRING)
-		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot property_name
-;+		(comment "The property name attribute provides a word or a combination of words by which a property is known.")
+	(single-slot model_object_type
+;+		(comment "The model_object_type attribute provides a classification for a modeled object.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot property_map_subtype
-;+		(comment "The property_map_subtype attribute indicates the subcategory of the property map.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot property_map_type
-;+		(comment "The property_map_type attribute indicates the category of the property map.")
-		(type STRING)
-;+		(value "Nuance" "Query Model" "Rationale" "Synonym" "Velocity Variable")
-;+		(cardinality 0 1)
-		(create-accessor read-write)))
-
-(defclass Property_Map_External "The Property Map External class references one or more Property Maps not defined within this namespace."
-	(is-a TNDO_Supplemental)
-	(role concrete)
-	(multislot property_map_id
-;+		(comment "The identifier attribute provides the formal name used to refer to a property map.")
-		(type STRING)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write)))
-
-(defclass Property_Maps "The Property Maps class defines a collection of one or more related Property Maps."
-	(is-a TNDO_Supplemental)
-	(role concrete)
-	(single-slot identifier
-;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_property_map
-;+		(comment "The has_property_map association is a relationship to Property_Map.")
-		(type INSTANCE)
-;+		(allowed-classes Property_Map)
-		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
 	(single-slot title
 ;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(multislot instance_id
+;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot identifier
+;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_Property_Map_Entry
+;+		(comment "The has_Property_Map_Entry association is a relationship to property map entry.")
+		(type INSTANCE)
+;+		(allowed-classes Property_Map_Entry)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write)))
+
+(defclass Property_Map_Entry "The property map entry consists of a property name and one or more values."
+	(is-a TNDO_Supplemental)
+	(role concrete)
+	(single-slot property_name
+;+		(comment "The property name attribute provides a word or a combination of words by which a property is known.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot property_map_type
+;+		(comment "The property_map_type attribute indicates the category of the property map.")
+		(type STRING)
+;+		(value "Nuance" "Query Model" "Rationale" "Synonym" "Velocity Variable")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot property_map_subtype
+;+		(comment "The property_map_subtype attribute indicates the subcategory of the property map.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot property_value
+;+		(comment "The property value attribute provides the value assigned to a property.")
+		(type STRING)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write)))
+
+(defclass Property_Map_External "The Property Map External class references one or more Property Maps not defined within this namespace."
+	(is-a TNDO_Supplemental)
+	(role concrete)
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot property_map_id
+;+		(comment "The identifier attribute provides the formal name used to refer to a property map.")
+		(type STRING)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write)))
+
+(defclass Property_Maps "The Property Maps class defines a collection of one or more related Property Maps."
+	(is-a TNDO_Supplemental)
+	(role concrete)
 	(single-slot namespace_id
 ;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
 		(type STRING)
@@ -8372,37 +8361,32 @@
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_property_map
+;+		(comment "The has_property_map association is a relationship to Property_Map.")
+		(type INSTANCE)
+;+		(allowed-classes Property_Map)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot title
+;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot identifier
+;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Entity "The Entity class is a physical, digital, conceptual, or other kind of thing with some fixed aspects; entities may be real or imaginary."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot title
-;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot external_reference_extended
 ;+		(comment "The external_reference_extended association is a relationship to external_reference_extended.")
 		(type INSTANCE)
 ;+		(allowed-classes External_Reference_Extended)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot internal_reference
-;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Internal_Reference)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot local_internal_reference
-;+		(comment "The local_internal_reference association is a relationship to the class Local_Internal_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Local_Internal_Reference)
-		(create-accessor read-write))
-	(multislot was_derived_from
-;+		(comment "The was_derived_from association is a recursive relationship on entity.")
-		(type INSTANCE)
-;+		(allowed-classes Entity)
 		(create-accessor read-write))
 	(single-slot description
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
@@ -8413,6 +8397,27 @@
 ;+		(comment "The entity_type attribute provides a classification for the entity.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot title
+;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot internal_reference
+;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Internal_Reference)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot was_derived_from
+;+		(comment "The was_derived_from association is a recursive relationship on entity.")
+		(type INSTANCE)
+;+		(allowed-classes Entity)
+		(create-accessor read-write))
+	(multislot local_internal_reference
+;+		(comment "The local_internal_reference association is a relationship to the class Local_Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Local_Internal_Reference)
 		(create-accessor read-write)))
 
 (defclass Output_Data "The Output_Data Class is used to"
@@ -8439,10 +8444,10 @@
 (defclass Agent "The Agent class is something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot title
-;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
-		(type STRING)
-;+		(cardinality 1 1)
+	(multislot acted_on_behalf_of
+;+		(comment "The acted_on_behalf_of association is a recursive relationship on agent.")
+		(type INSTANCE)
+;+		(allowed-classes Agent)
 		(create-accessor read-write))
 	(single-slot external_reference_extended
 ;+		(comment "The external_reference_extended association is a relationship to external_reference_extended.")
@@ -8450,31 +8455,31 @@
 ;+		(allowed-classes External_Reference_Extended)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot title
+;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot internal_reference
 ;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
 		(type INSTANCE)
 ;+		(allowed-classes Internal_Reference)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot local_internal_reference
-;+		(comment "The local_internal_reference association is a relationship to the class Local_Internal_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Local_Internal_Reference)
-		(create-accessor read-write))
-	(multislot acted_on_behalf_of
-;+		(comment "The acted_on_behalf_of association is a recursive relationship on agent.")
-		(type INSTANCE)
-;+		(allowed-classes Agent)
-		(create-accessor read-write))
 	(single-slot agent_type
 ;+		(comment "The agent_type attribute provides a classification for the agent.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
-;+		(cardinality 1 1)
+	(multislot local_internal_reference
+;+		(comment "The local_internal_reference association is a relationship to the class Local_Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Local_Internal_Reference)
 		(create-accessor read-write)))
 
 (defclass Activity "The Activity class is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities."
@@ -8485,27 +8490,27 @@
 ;+		(allowed-classes Methods Config Input_Data)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot title
-;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot external_reference_extended
 ;+		(comment "The external_reference_extended association is a relationship to external_reference_extended.")
 		(type INSTANCE)
 ;+		(allowed-classes External_Reference_Extended)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot title
+;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot internal_reference
 ;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
 		(type INSTANCE)
 ;+		(allowed-classes Internal_Reference)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot local_internal_reference
-;+		(comment "The local_internal_reference association is a relationship to the class Local_Internal_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Local_Internal_Reference)
 		(create-accessor read-write))
 	(single-slot was_associated_with
 		(type INSTANCE)
@@ -8517,10 +8522,10 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
-;+		(cardinality 1 1)
+	(multislot local_internal_reference
+;+		(comment "The local_internal_reference association is a relationship to the class Local_Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Local_Internal_Reference)
 		(create-accessor read-write)))
 
 (defclass Term_Map_SKOS "TheTerm_Map_SKOS class is used to collect a set of terms and definitions for a SKOS ontology."
@@ -8536,21 +8541,6 @@
 (defclass Virtual_Structure "The Virtual Structure class provides a general framework for defining a structure that relates existing products and/or product components."
 	(is-a TNDO_Supplemental)
 	(role concrete)
-	(single-slot type_description
-;+		(comment "The type_description attribute provides a description of the object's type.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot title
-;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot virtual_reference
-;+		(comment "The virtual_reference association is a relationship to Virtual_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Virtual_Reference)
-		(create-accessor read-write))
 	(multislot virtual_relation
 ;+		(comment "The virtual_relation association is a relationship to Virtual_Relation.")
 		(type INSTANCE)
@@ -8560,6 +8550,21 @@
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot title
+;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot type_description
+;+		(comment "The type_description attribute provides a description of the object's type.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot virtual_reference
+;+		(comment "The virtual_reference association is a relationship to Virtual_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Virtual_Reference)
 		(create-accessor read-write)))
 
 (defclass Virtual_Relation "The Virtual_Relation class defines a one directional relationship between two extisting products and/or product components."
@@ -8567,6 +8572,10 @@
 	(role concrete)
 	(multislot id_reference_to
 ;+		(comment "The id_reference_to provides the identifier of the ending object in a one  directional relationship.")
+		(type STRING)
+		(create-accessor read-write))
+	(multislot id_reference_from
+;+		(comment "The id_reference_from provides the identifier of the starting object in a  one directional relationship.")
 		(type STRING)
 		(create-accessor read-write))
 	(multislot lid_reference_to
@@ -8579,29 +8588,25 @@
 		(type INSTANCE)
 ;+		(allowed-classes LID_ID_Reference_From)
 		(create-accessor read-write))
-	(single-slot comment
-;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot id_reference_from
-;+		(comment "The id_reference_from provides the identifier of the starting object in a  one directional relationship.")
-		(type STRING)
-		(create-accessor read-write))
-	(multislot lidvid_reference_from
-;+		(comment "The lid_reference_from provides the identifier of the starting object in a one  directional relationship.")
-		(type INSTANCE)
-;+		(allowed-classes LIDVID_ID_Reference_From)
-		(create-accessor read-write))
 	(single-slot virtual_reference_type
 ;+		(comment "The virtual_reference_type attribute provides the name of an association between two objects.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot comment
+;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(multislot lidvid_refernce_to
 ;+		(comment "The lidvid_refernce_to provides the identifier of the ending object in a  one directional relationship.")
 		(type INSTANCE)
 ;+		(allowed-classes LIDVID_ID_Reference_To)
+		(create-accessor read-write))
+	(multislot lidvid_reference_from
+;+		(comment "The lid_reference_from provides the identifier of the starting object in a one  directional relationship.")
+		(type INSTANCE)
+;+		(allowed-classes LIDVID_ID_Reference_From)
 		(create-accessor read-write)))
 
 (defclass Virtual_Reference "The Virtual_Reference class defines a one directional relationship by referencing an existing product or product component."
@@ -8616,15 +8621,15 @@
 		(type INSTANCE)
 ;+		(allowed-classes LID_ID_Reference_To)
 		(create-accessor read-write))
-	(single-slot comment
-;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot virtual_reference_type
 ;+		(comment "The virtual_reference_type attribute provides the name of an association between two objects.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot comment
+;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot lidvid_refernce_to
 ;+		(comment "The lidvid_refernce_to provides the identifier of the ending object in a  one directional relationship.")
@@ -8682,28 +8687,28 @@
 		(type INSTANCE)
 ;+		(allowed-classes Terminological_Entry)
 		(create-accessor read-write))
-	(multislot value_domain_entry
-;+		(comment "The value_domain_entry association is a relationship to Value_Domain.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Value_Domain)
+	(single-slot definition
+;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot local_identifier
 ;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot comment
-;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
+	(multislot value_domain_entry
+;+		(comment "The value_domain_entry association is a relationship to Value_Domain.")
+		(type INSTANCE)
+;+		(allowed-classes DD_Value_Domain)
 		(create-accessor read-write))
 	(single-slot instance_id
 ;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot definition
-;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
+	(single-slot comment
+;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -8716,23 +8721,23 @@
 		(type INSTANCE)
 ;+		(allowed-classes Terminological_Entry)
 		(create-accessor read-write))
+	(single-slot definition
+;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot local_identifier
 ;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot comment
-;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot instance_id
 ;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot definition
-;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
+	(single-slot comment
+;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -8756,11 +8761,10 @@
 ;+		(allowed-classes Reference_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot file_area
-;+		(comment "The file_area association is a relationship to File Area")
+	(multislot file_area_supplemental
+;+		(comment "The file_area_supplemental association is a relationship to File Area Supplemental.")
 		(type INSTANCE)
-;+		(allowed-classes File_Area_Observational)
-		(cardinality 1 ?VARIABLE)
+;+		(allowed-classes File_Area_Observational_Supplemental)
 		(create-accessor read-write))
 	(single-slot observation_area
 ;+		(comment "The observation_area association is a relationship to Observation_Area.")
@@ -8768,21 +8772,16 @@
 ;+		(allowed-classes Observation_Area)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(multislot file_area_supplemental
-;+		(comment "The file_area_supplemental association is a relationship to File Area Supplemental.")
+	(multislot file_area
+;+		(comment "The file_area association is a relationship to File Area")
 		(type INSTANCE)
-;+		(allowed-classes File_Area_Observational_Supplemental)
+;+		(allowed-classes File_Area_Observational)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
 (defclass Product_Browse "The Product Browse class defines a product consisting of one  encoded byte stream digital object."
 	(is-a Product)
 	(role concrete)
-	(single-slot context_area
-;+		(comment "The context_area association is a relationship to Context_Area.")
-		(type INSTANCE)
-;+		(allowed-classes Context_Area)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot reference_list
 ;+		(comment "The reference_list association is a relationship to Reference_List.")
 		(type INSTANCE)
@@ -8794,17 +8793,17 @@
 		(type INSTANCE)
 ;+		(allowed-classes File_Area_Browse)
 		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write)))
-
-(defclass Product_Document "A Product Document is a product consisting of a single logical document that may comprise one or more document editions."
-	(is-a Product)
-	(role concrete)
+		(create-accessor read-write))
 	(single-slot context_area
 ;+		(comment "The context_area association is a relationship to Context_Area.")
 		(type INSTANCE)
 ;+		(allowed-classes Context_Area)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
+		(create-accessor read-write)))
+
+(defclass Product_Document "A Product Document is a product consisting of a single logical document that may comprise one or more document editions."
+	(is-a Product)
+	(role concrete)
 	(single-slot reference_list
 ;+		(comment "The reference_list association is a relationship to Reference_List.")
 		(type INSTANCE)
@@ -8816,6 +8815,12 @@
 		(type INSTANCE)
 ;+		(allowed-classes Document)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot context_area
+;+		(comment "The context_area association is a relationship to Context_Area.")
+		(type INSTANCE)
+;+		(allowed-classes Context_Area)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Product_File_Text "The Product File Text consists of a single text file with ASCII character encoding."
@@ -8837,12 +8842,6 @@
 (defclass Product_SPICE_Kernel "The Product SPICE Kernel class defines a SPICE kernel product."
 	(is-a Product)
 	(role concrete)
-	(single-slot context_area
-;+		(comment "The context_area association is a relationship to Context_Area.")
-		(type INSTANCE)
-;+		(allowed-classes Context_Area)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot reference_list
 ;+		(comment "The reference_list association is a relationship to Reference_List.")
 		(type INSTANCE)
@@ -8853,6 +8852,12 @@
 ;+		(comment "The file_area association is a relationship to File Area")
 		(type INSTANCE)
 ;+		(allowed-classes File_Area_SPICE_Kernel)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot context_area
+;+		(comment "The context_area association is a relationship to Context_Area.")
+		(type INSTANCE)
+;+		(allowed-classes Context_Area)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -8881,28 +8886,22 @@
 ;+		(allowed-classes Reference_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot file_area
-;+		(comment "The file_area association is a relationship to File Area")
-		(type INSTANCE)
-;+		(allowed-classes File_Area_Update)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot product_data_object
 ;+		(comment "The product_data_object association is a relationship to a data object.")
 		(type INSTANCE)
 ;+		(allowed-classes Update)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot file_area
+;+		(comment "The file_area association is a relationship to File Area")
+		(type INSTANCE)
+;+		(allowed-classes File_Area_Update)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Product_XML_Schema "The Product_XML_Schema  describes a resource used for the PDS4 implementation into XML."
 	(is-a Product)
 	(role concrete)
-	(single-slot context_area
-;+		(comment "The context_area association is a relationship to Context_Area.")
-		(type INSTANCE)
-;+		(allowed-classes Context_Area)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot reference_list
 ;+		(comment "The reference_list association is a relationship to Reference_List.")
 		(type INSTANCE)
@@ -8914,22 +8913,28 @@
 		(type INSTANCE)
 ;+		(allowed-classes File_Area_XML_Schema)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot context_area
+;+		(comment "The context_area association is a relationship to Context_Area.")
+		(type INSTANCE)
+;+		(allowed-classes Context_Area)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Product_Zipped "The Product_Zipped  is a product with references to other products. The referenced products and all associated products and files are packaged into a single ZIP file."
 	(is-a Product)
 	(role concrete)
-	(single-slot file
-;+		(comment "The file association is a relationship to File.")
-		(type INSTANCE)
-;+		(allowed-classes File)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot internal_reference
 ;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
 		(type INSTANCE)
 ;+		(allowed-classes Internal_Reference)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot file
+;+		(comment "The file association is a relationship to File.")
+		(type INSTANCE)
+;+		(allowed-classes File)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot has_zip
 ;+		(comment "The has_ZIP association is a relationship to ZIP")
@@ -8995,27 +9000,21 @@
 ;+		(allowed-classes Reference_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot file_area
-;+		(comment "The file_area association is a relationship to File Area")
-		(type INSTANCE)
-;+		(allowed-classes File_Area_Service_Description)
-		(create-accessor read-write))
 	(single-slot product_data_object
 ;+		(comment "The product_data_object association is a relationship to a data object.")
 		(type INSTANCE)
 ;+		(allowed-classes Service)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot file_area
+;+		(comment "The file_area association is a relationship to File Area")
+		(type INSTANCE)
+;+		(allowed-classes File_Area_Service_Description)
 		(create-accessor read-write)))
 
 (defclass Product_Software "Product Software is a product consisting of a set of one or more software formats."
 	(is-a Product)
 	(role concrete)
-	(single-slot product_description
-;+		(comment "Description at the identifiable layer.")
-		(type INSTANCE)
-;+		(allowed-classes Software)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot reference_list
 ;+		(comment "The reference_list association is a relationship to Reference_List.")
 		(type INSTANCE)
@@ -9026,15 +9025,21 @@
 ;+		(comment "The software_format_set association is a relationship to a set of one or more software formats.")
 		(type INSTANCE)
 ;+		(allowed-classes Software_Binary Software_Source Software_Script)
+		(create-accessor read-write))
+	(single-slot product_description
+;+		(comment "Description at the identifiable layer.")
+		(type INSTANCE)
+;+		(allowed-classes Software)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Product_Bundle "A Product_Bundle is an aggregate product and has a table of references to one or more collections."
 	(is-a Product)
 	(role concrete)
-	(single-slot context_area
-;+		(comment "The context_area association is a relationship to Context_Area.")
+	(single-slot reference_list
+;+		(comment "The reference_list association is a relationship to Reference_List.")
 		(type INSTANCE)
-;+		(allowed-classes Context_Area)
+;+		(allowed-classes Reference_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(multislot member_entry
@@ -9043,11 +9048,11 @@
 ;+		(allowed-classes Bundle_Member_Entry)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot reference_list
-;+		(comment "The reference_list association is a relationship to Reference_List.")
+	(single-slot product_data_object
+;+		(comment "The product_data_object association is a relationship to a data object.")
 		(type INSTANCE)
-;+		(allowed-classes Reference_List)
-;+		(cardinality 0 1)
+;+		(allowed-classes Bundle)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot file_area
 ;+		(comment "The file_area association is a relationship to File Area")
@@ -9055,22 +9060,16 @@
 ;+		(allowed-classes File_Area_Text)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot product_data_object
-;+		(comment "The product_data_object association is a relationship to a data object.")
-		(type INSTANCE)
-;+		(allowed-classes Bundle)
-;+		(cardinality 1 1)
-		(create-accessor read-write)))
-
-(defclass Product_Collection "A Product_Collection has a table of references to one or more basic products. The references are stored in a table called the inventory."
-	(is-a Product)
-	(role concrete)
 	(single-slot context_area
 ;+		(comment "The context_area association is a relationship to Context_Area.")
 		(type INSTANCE)
 ;+		(allowed-classes Context_Area)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
+		(create-accessor read-write)))
+
+(defclass Product_Collection "A Product_Collection has a table of references to one or more basic products. The references are stored in a table called the inventory."
+	(is-a Product)
+	(role concrete)
 	(single-slot reference_list
 ;+		(comment "The reference_list association is a relationship to Reference_List.")
 		(type INSTANCE)
@@ -9088,6 +9087,12 @@
 		(type INSTANCE)
 ;+		(allowed-classes File_Area_Inventory)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot context_area
+;+		(comment "The context_area association is a relationship to Context_Area.")
+		(type INSTANCE)
+;+		(allowed-classes Context_Area)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Product_Volume_PDS3 "A Product Volume PDS3 product captures the PDS3 volume information."
@@ -9211,17 +9216,17 @@
 ;+		(allowed-classes Reference_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot product_data_object
-;+		(comment "The product_data_object association is a relationship to a data object.")
-		(type INSTANCE)
-;+		(allowed-classes Investigation Instrument_Host Instrument Target Resource PDS_Guest PDS_Affiliate Node Other Agency Facility Telescope XSChoice%23 Airborne)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot has_discipline_area
 ;+		(comment "The has_discipline_area association is a relationship to Discipline Area.")
 		(type INSTANCE)
 ;+		(allowed-classes Discipline_Area)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot product_data_object
+;+		(comment "The product_data_object association is a relationship to a data object.")
+		(type INSTANCE)
+;+		(allowed-classes Investigation Instrument_Host Instrument Target Resource PDS_Guest PDS_Affiliate Node Other Agency Facility Telescope XSChoice%23 Airborne)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Product_Subscription_PDS3 "The Product_Subscription_PDS3 class provides the list of subscriptions for a PDS3 subscriber."
@@ -9265,17 +9270,17 @@
 ;+		(allowed-classes Reference_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Information_Package_Component
-;+		(comment "The has_Information_Package_Component association is a relationship to a Information_Package_Component.")
-		(type INSTANCE)
-;+		(allowed-classes Information_Package_Component)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(single-slot product_data_object
 ;+		(comment "The product_data_object association is a relationship to a data object.")
 		(type INSTANCE)
 ;+		(allowed-classes Archival_Information_Package)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Information_Package_Component
+;+		(comment "The has_Information_Package_Component association is a relationship to a Information_Package_Component.")
+		(type INSTANCE)
+;+		(allowed-classes Information_Package_Component)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
 (defclass Product_DIP "The Product DIP class defines a product for the Dissemination Information Package."
@@ -9287,17 +9292,17 @@
 ;+		(allowed-classes Reference_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Information_Package_Component
-;+		(comment "The has_Information_Package_Component association is a relationship to a Information_Package_Component.")
-		(type INSTANCE)
-;+		(allowed-classes Information_Package_Component)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(single-slot product_data_object
 ;+		(comment "The product_data_object association is a relationship to a data object.")
 		(type INSTANCE)
 ;+		(allowed-classes Dissemination_Information_Package)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Information_Package_Component
+;+		(comment "The has_Information_Package_Component association is a relationship to a Information_Package_Component.")
+		(type INSTANCE)
+;+		(allowed-classes Information_Package_Component)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
 (defclass Product_DIP_Deep_Archive "The Product DIP_Deep_Archive class defines a product for the Dissemination Information Package for the deep archive."
@@ -9309,17 +9314,17 @@
 ;+		(allowed-classes Reference_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Information_Package_Component
-;+		(comment "The has_Information_Package_Component association is a relationship to a Information_Package_Component.")
-		(type INSTANCE)
-;+		(allowed-classes Information_Package_Component)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(single-slot product_data_object
 ;+		(comment "The product_data_object association is a relationship to a data object.")
 		(type INSTANCE)
 ;+		(allowed-classes DIP_Deep_Archive)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Information_Package_Component
+;+		(comment "The has_Information_Package_Component association is a relationship to a Information_Package_Component.")
+		(type INSTANCE)
+;+		(allowed-classes Information_Package_Component)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
 (defclass Product_SIP "The Product SIP class defines a product for the Submission Information Package."
@@ -9331,28 +9336,22 @@
 ;+		(allowed-classes Reference_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot has_Information_Package_Component
-;+		(comment "The has_Information_Package_Component association is a relationship to a Information_Package_Component.")
-		(type INSTANCE)
-;+		(allowed-classes Information_Package_Component)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(single-slot product_data_object
 ;+		(comment "The product_data_object association is a relationship to a data object.")
 		(type INSTANCE)
 ;+		(allowed-classes Submission_Information_Package)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot has_Information_Package_Component
+;+		(comment "The has_Information_Package_Component association is a relationship to a Information_Package_Component.")
+		(type INSTANCE)
+;+		(allowed-classes Information_Package_Component)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
 (defclass Product_Native "Product_Native is used to describe digital objects in the original format returned by the spacecraft or experimental system when that format  cannot be described using one of the PDS4 formats specified for observational data (tables or arrays,  excluding Array_1D)."
 	(is-a Product)
 	(role concrete)
-	(single-slot context_area
-;+		(comment "The context_area association is a relationship to Context_Area.")
-		(type INSTANCE)
-;+		(allowed-classes Context_Area)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot reference_list
 ;+		(comment "The reference_list association is a relationship to Reference_List.")
 		(type INSTANCE)
@@ -9364,17 +9363,17 @@
 		(type INSTANCE)
 ;+		(allowed-classes File_Area_Native)
 		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write)))
-
-(defclass Product_Telemetry "Prototype - Product_Telemetry is used to describe digital objects in telemetry format."
-	(is-a Product)
-	(role concrete)
+		(create-accessor read-write))
 	(single-slot context_area
 ;+		(comment "The context_area association is a relationship to Context_Area.")
 		(type INSTANCE)
 ;+		(allowed-classes Context_Area)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
+		(create-accessor read-write)))
+
+(defclass Product_Telemetry "Prototype - Product_Telemetry is used to describe digital objects in telemetry format."
+	(is-a Product)
+	(role concrete)
 	(single-slot reference_list
 ;+		(comment "The reference_list association is a relationship to Reference_List.")
 		(type INSTANCE)
@@ -9386,6 +9385,12 @@
 		(type INSTANCE)
 ;+		(allowed-classes File_Area_Telemetry)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot context_area
+;+		(comment "The context_area association is a relationship to Context_Area.")
+		(type INSTANCE)
+;+		(allowed-classes Context_Area)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Product_SIP_Deep_Archive "The Product SIP Deep Archive class defines a Submission Information Package (SIP) for the NASA planetary science deep archive."
@@ -9397,28 +9402,22 @@
 ;+		(allowed-classes Reference_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot has_Information_Package_Component
-;+		(comment "The has_Information_Package_Component association is a relationship to a Information_Package_Component.")
-		(type INSTANCE)
-;+		(allowed-classes Information_Package_Component_Deep_Archive)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot product_data_object
 ;+		(comment "The product_data_object association is a relationship to a data object.")
 		(type INSTANCE)
 ;+		(allowed-classes SIP_Deep_Archive)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot has_Information_Package_Component
+;+		(comment "The has_Information_Package_Component association is a relationship to a Information_Package_Component.")
+		(type INSTANCE)
+;+		(allowed-classes Information_Package_Component_Deep_Archive)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Product_Ancillary "The Product_Ancillary class defines a product that contains data that are supplementary to observational data and cannot reasonably be associated with any other non-observational data class. Use of Product_Ancillary must be approved by the curating node."
 	(is-a Product)
 	(role concrete)
-	(single-slot context_area
-;+		(comment "The context_area association is a relationship to Context_Area.")
-		(type INSTANCE)
-;+		(allowed-classes Context_Area)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot reference_list
 ;+		(comment "The reference_list association is a relationship to Reference_List.")
 		(type INSTANCE)
@@ -9430,6 +9429,12 @@
 		(type INSTANCE)
 ;+		(allowed-classes File_Area_Ancillary)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot context_area
+;+		(comment "The context_area association is a relationship to Context_Area.")
+		(type INSTANCE)
+;+		(allowed-classes Context_Area)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Product_Metadata_Supplemental "The Product_Metadata_Supplemental class is used to provide new, and/or improved, metadata for some or all of the basic products in a single collection. More than one Product_Metadata_Supplemental may apply to any given collection."
@@ -9451,43 +9456,37 @@
 (defclass Product_Ingest_LDD "The Product_Ingest_LDD describes the components of a dictionary product which includes the Ingest_LDD file."
 	(is-a Product)
 	(role concrete)
-	(single-slot file_area
-;+		(comment "The file_area association is a relationship to File Area")
-		(type INSTANCE)
-;+		(allowed-classes File_Area_Ingest_LDD)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot product_data_object
 ;+		(comment "The product_data_object association is a relationship to a data object.")
 		(type INSTANCE)
 ;+		(allowed-classes Ingest_LDD_File_Desc)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot file_area
+;+		(comment "The file_area association is a relationship to File Area")
+		(type INSTANCE)
+;+		(allowed-classes File_Area_Ingest_LDD)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Product_Virtual "The Product Virtual class describes a composite product comprised of references to existing products and/or product components."
 	(is-a Product)
 	(role concrete)
+	(multislot file_area
+;+		(comment "The file_area association is a relationship to File Area")
+		(type INSTANCE)
+;+		(allowed-classes File_Area_Observational)
+		(create-accessor read-write))
 	(single-slot virtual_area
 ;+		(comment "The virtual_area association is a relationship to Virtual Area")
 		(type INSTANCE)
 ;+		(allowed-classes Virtual_Area)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot file_area
-;+		(comment "The file_area association is a relationship to File Area")
-		(type INSTANCE)
-;+		(allowed-classes File_Area_Observational)
 		(create-accessor read-write)))
 
 (defclass Product_External "The Product External class defines a product that does not reside within the PDS archives."
 	(is-a Product)
 	(role concrete)
-	(single-slot context_area
-;+		(comment "The context_area association is a relationship to Context_Area.")
-		(type INSTANCE)
-;+		(allowed-classes Context_Area)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot reference_list
 ;+		(comment "The reference_list association is a relationship to Reference_List.")
 		(type INSTANCE)
@@ -9499,6 +9498,12 @@
 		(type INSTANCE)
 ;+		(allowed-classes File_Area_External)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot context_area
+;+		(comment "The context_area association is a relationship to Context_Area.")
+		(type INSTANCE)
+;+		(allowed-classes Context_Area)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Product_Components "The Product Component class is an abstract class for the components of the Product class."
@@ -9508,27 +9513,16 @@
 (defclass Identification_Area "The identification area consists of attributes that identify and name an object."
 	(is-a Product_Components)
 	(role concrete)
-	(single-slot modification_history
-;+		(comment "The modification_history association is a relationship to Modification_History, a history of changes made to the product.")
-		(type INSTANCE)
-;+		(allowed-classes Modification_History)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot title
-;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot alias_list
 ;+		(comment "The alias_list association is a relationship to Alias_List, a list of alternate names and identifications.")
 		(type INSTANCE)
 ;+		(allowed-classes Alias_List)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot logical_identifier
-;+		(comment "A logical identifier identifies the set of all versions of an object. It is an object identifier without a version.")
+	(single-slot information_model_version
+;+		(comment "The information_model_version attribute provides the  version identification of the PDS Information Model on which the label and schema are based.")
 		(type STRING)
-		(default "URN:NASA:PDS:identifier")
+;+		(value "1.4.0.0" "1.0.0.0" "1.1.0.0" "1.2.0.0" "1.2.0.1" "1.3.0.0" "1.3.0.1" "1.5.0.0" "1.6.0.0" "1.7.0.0" "1.8.0.0" "1.9.0.0" "1.9.1.0" "1.10.0.0" "1.10.1.0" "1.11.0.0" "1.12.0.0" "1.13.0.0" "1.14.0.0" "1.15.0.0" "1.16.0.0" "1.17.0.0" "1.18.0.0" "1.19.0.0" "1.20.0.0" "1.21.0.0")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot version_id
@@ -9537,6 +9531,17 @@
 		(default "major.minor")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot title
+;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot license_information
+;+		(comment "The license_information is a relationship to License_Information.")
+		(type INSTANCE)
+;+		(allowed-classes License_Information)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot product_class
 ;+		(comment "The product_class attribute provides the name of the product class.")
 		(type STRING)
@@ -9544,10 +9549,10 @@
 ;+		(value "Product_Attribute_Definition" "Product_Browse" "Product_Bundle" "Product_Context" "Product_Collection" "Product_Document" "Product_File_Repository" "Product_File_Text" "Product_Observational" "Product_Service" "Product_Software" "Product_SPICE_Kernel" "Product_Thumbnail" "Product_Update" "Product_XML_Schema" "Product_Zipped" "Product_Data_Set_PDS3" "Product_Instrument_Host_PDS3" "Product_Instrument_PDS3" "Product_Mission_PDS3" "Product_Proxy_PDS3" "Product_Subscription_PDS3" "Product_Target_PDS3" "Product_Volume_PDS3" "Product_Volume_Set_PDS3" "Product_AIP" "Product_DIP" "Product_DIP_Deep_Archive" "Product_SIP" "Product_Class_Definition" "Product_Native" "Product_SIP_Deep_Archive" "Product_Ancillary" "Product_Metadata_Supplemental" "Product_External")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot information_model_version
-;+		(comment "The information_model_version attribute provides the  version identification of the PDS Information Model on which the label and schema are based.")
+	(single-slot logical_identifier
+;+		(comment "A logical identifier identifies the set of all versions of an object. It is an object identifier without a version.")
 		(type STRING)
-;+		(value "1.4.0.0" "1.0.0.0" "1.1.0.0" "1.2.0.0" "1.2.0.1" "1.3.0.0" "1.3.0.1" "1.5.0.0" "1.6.0.0" "1.7.0.0" "1.8.0.0" "1.9.0.0" "1.9.1.0" "1.10.0.0" "1.10.1.0" "1.11.0.0" "1.12.0.0" "1.13.0.0" "1.14.0.0" "1.15.0.0" "1.16.0.0" "1.17.0.0" "1.18.0.0" "1.19.0.0" "1.20.0.0" "1.21.0.0")
+		(default "URN:NASA:PDS:identifier")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot citation_information
@@ -9555,15 +9560,43 @@
 		(type INSTANCE)
 ;+		(allowed-classes Citation_Information)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot modification_history
+;+		(comment "The modification_history association is a relationship to Modification_History, a history of changes made to the product.")
+		(type INSTANCE)
+;+		(allowed-classes Modification_History)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Context_Area "The Context Area provides context information for a product."
 	(is-a Product_Components)
 	(role concrete)
+	(single-slot has_mission_area
+;+		(comment "The has_mission_area association is a relationship to Mission Area.")
+		(type INSTANCE)
+;+		(allowed-classes Mission_Area)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot has_discipline_area
+;+		(comment "The has_discipline_area association is a relationship to Discipline Area.")
+		(type INSTANCE)
+;+		(allowed-classes Discipline_Area)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(multislot has_investigation_area
 ;+		(comment "The hsa_investigation_area association is a relationship to Investigation_Area.")
 		(type INSTANCE)
 ;+		(allowed-classes Investigation_Area)
+		(create-accessor read-write))
+	(multislot has_observing_system
+;+		(comment "The has_observing_system association is a relationship to Observing_System.")
+		(type INSTANCE)
+;+		(allowed-classes Observing_System)
+		(create-accessor read-write))
+	(multislot has_target_identification
+;+		(comment "The has_target_identification association is a relationship to Target_Identification.")
+		(type INSTANCE)
+;+		(allowed-classes Target_Identification)
 		(create-accessor read-write))
 	(single-slot has_primary_result_description
 ;+		(comment "The has_primary_result_description association is a relationship to Primary_Result_Description.")
@@ -9576,33 +9609,11 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot has_mission_area
-;+		(comment "The has_mission_area association is a relationship to Mission Area.")
-		(type INSTANCE)
-;+		(allowed-classes Mission_Area)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_observing_system
-;+		(comment "The has_observing_system association is a relationship to Observing_System.")
-		(type INSTANCE)
-;+		(allowed-classes Observing_System)
-		(create-accessor read-write))
 	(single-slot has_time_coordinates
 ;+		(comment "The has_time_coordinates association is a relationship to Time_Coordinates.")
 		(type INSTANCE)
 ;+		(allowed-classes Time_Coordinates)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot has_discipline_area
-;+		(comment "The has_discipline_area association is a relationship to Discipline Area.")
-		(type INSTANCE)
-;+		(allowed-classes Discipline_Area)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot has_target_identification
-;+		(comment "The has_target_identification association is a relationship to Target_Identification.")
-		(type INSTANCE)
-;+		(allowed-classes Target_Identification)
 		(create-accessor read-write)))
 
 (defclass Observation_Area "The observation area consists of attributes that provide information about the circumstances under which the data were collected."
@@ -9620,17 +9631,17 @@
 ;+		(allowed-classes Observing_System)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(single-slot has_time_coordinates
-;+		(comment "The has_time_coordinates association is a relationship to Time_Coordinates.")
-		(type INSTANCE)
-;+		(allowed-classes Time_Coordinates)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(multislot has_target_identification
 ;+		(comment "The has_target_identification association is a relationship to Target_Identification.")
 		(type INSTANCE)
 ;+		(allowed-classes Target_Identification)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot has_time_coordinates
+;+		(comment "The has_time_coordinates association is a relationship to Time_Coordinates.")
+		(type INSTANCE)
+;+		(allowed-classes Time_Coordinates)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Discipline_Area "The Discipline area allows the insertion of discipline specific metadata."
@@ -9644,8 +9655,13 @@
 (defclass Update_Entry "The Update Entry class provides the date and description of an update."
 	(is-a Product_Components)
 	(role concrete)
-	(single-slot full_name
-;+		(comment "The full_name attribute provides the complete name for a person and includes titles and suffixes.")
+	(single-slot date_time
+;+		(comment "The date_time attribute provides the date and time of an event.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -9655,13 +9671,8 @@
 ;+		(allowed-classes Internal_Reference)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot date_time
-;+		(comment "The date_time attribute provides the date and time of an event.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot full_name
+;+		(comment "The full_name attribute provides the complete name for a person and includes titles and suffixes.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -9673,26 +9684,26 @@
 ;+		(comment "The alternate_designation attribute provides aliases.")
 		(type STRING)
 		(create-accessor read-write))
-	(single-slot internal_reference
-;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Internal_Reference)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot type
 ;+		(comment "The type attribute classifies a target according to its size and properties so that correct nomenclature can be applied.")
 		(type STRING)
 ;+		(value "Asteroid" "Comet" "Dust" "Galaxy" "Globular Cluster" "Meteorite" "Meteoroid" "Meteoroid Stream" "Nebula" "Open Cluster" "Planet" "Planetary Nebula" "Planetary System" "Plasma Cloud" "Ring" "Satellite" "Star" "Star Cluster" "Terrestrial Sample" "Trans-Neptunian Object" "Dwarf Planet" "Calibration" "Plasma Stream" "Equipment" "Lunar Sample" "Synthetic Sample" "Calibrator" "Exoplanet System" "Calibration Field" "Magnetic Field" "Centaur" "Laboratory Analog" "Sample" "Astrophysical" "Sky")
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides additional information or clarification, as needed.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot name_
 ;+		(comment "The name attribute provides a human-readable primary name/identification in the standard format for the target type.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides additional information or clarification, as needed.")
-		(type STRING)
+	(single-slot internal_reference
+;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Internal_Reference)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
@@ -9714,13 +9725,13 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot comment
-;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
+	(single-slot alternate_id
+;+		(comment "The alternate_id attribute provides an additional identifier supplied by the data provider.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot alternate_id
-;+		(comment "The alternate_id attribute provides an additional identifier supplied by the data provider.")
+	(single-slot comment
+;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -9728,6 +9739,16 @@
 (defclass Citation_Information "The Citation_Information class provides specific fields often used in citing the product in journal articles, abstract services, and other reference contexts."
 	(is-a Product_Components)
 	(role concrete)
+	(single-slot author_list
+;+		(comment "The author_list attribute contains a semi-colon-separated list of names of people to be cited as authors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final author. All authors should be listed explicitly - do not elide the list using \"et al.\".")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a short (5KB or less) description of the product as a whole.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot editor_list
 ;+		(comment "The editor_list attribute contains a semi-colon-separated list of names of people to be cited as editors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final editor. All editors should be listed explicitly - do not elide the list using \"et al.\".")
 		(type STRING)
@@ -9736,11 +9757,6 @@
 	(multislot keyword
 ;+		(comment "The keyword attribute provides one or more words to be used for  keyword search.")
 		(type STRING)
-		(create-accessor read-write))
-	(multislot has_Funding_Acknowledgement
-;+		(comment "The has_Funding_Acknowledgement association is a relationship to Funding_Acknowledgement.")
-		(type INSTANCE)
-;+		(allowed-classes Funding_Acknowledgement)
 		(create-accessor read-write))
 	(single-slot publication_year
 ;+		(comment "The publication_year attribute provides the year in which the product should be considered as published. Generally, this will be the year the data were declared \"Certified\" or \"Archived\".")
@@ -9752,15 +9768,10 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a short (5KB or less) description of the product as a whole.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot author_list
-;+		(comment "The author_list attribute contains a semi-colon-separated list of names of people to be cited as authors of the associated product. The general format for individual names is: SURNAME, GIVEN NAME(s). Initials may be used in lieu of given name(s). If the name contains a suffix (\"Jr.\", \"Sr.\", \"III\", etc.) it should be placed before the comma (,). Do not include the word \"and\" before the final author. All authors should be listed explicitly - do not elide the list using \"et al.\".")
-		(type STRING)
-;+		(cardinality 0 1)
+	(multislot has_Funding_Acknowledgement
+;+		(comment "The has_Funding_Acknowledgement association is a relationship to Funding_Acknowledgement.")
+		(type INSTANCE)
+;+		(allowed-classes Funding_Acknowledgement)
 		(create-accessor read-write)))
 
 (defclass Modification_History "The Modification_History class tracks the history of changes made to the product once it enters the registry system."
@@ -9776,8 +9787,8 @@
 (defclass Modification_Detail "The Modification_Detail class provides the details of one round of modification for the product.  The first, required, instance of this class documents the date the product was first registered."
 	(is-a Product_Components)
 	(role concrete)
-	(single-slot modification_date
-;+		(comment "The modification_date attribute provides date the modifications were completed")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -9786,8 +9797,8 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot modification_date
+;+		(comment "The modification_date attribute provides date the modifications were completed")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -9795,25 +9806,25 @@
 (defclass Time_Coordinates "The Time_Coordinates class provides a list of time coordinates."
 	(is-a Product_Components)
 	(role concrete)
-	(single-slot start_date_time
-;+		(comment "The start_date_time attribute provides the date and time appropriate to the beginning of the product being labeled.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot stop_date_time
-;+		(comment "The stop_date_time attribute provides the date and time appropriate to the end of the product being labeled.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot solar_longitude
 ;+		(comment "The solar_longitude attribute provides the angle between the body-Sun line at the time of interest and the body-Sun line at its vernal equinox.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot start_date_time
+;+		(comment "The start_date_time attribute provides the date and time appropriate to the beginning of the product being labeled.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot local_mean_solar_time
 ;+		(comment "The local_mean_solar_time attribute provides the hour angle of the fictitious mean Sun at a fixed point on a rotating solar system body.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot stop_date_time
+;+		(comment "The stop_date_time attribute provides the date and time appropriate to the end of the product being labeled.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot local_true_solar_time
 ;+		(comment "The local_true_solar_time (LTST) attribute provides the local time on a rotating solar system body where LTST is 12 h at the sub-solar point (SSP) and increases 1 h for each 15 degree increase in east longitude away from the SSP for prograde rotation.")
@@ -9824,10 +9835,10 @@
 (defclass Primary_Result_Summary "The Primary_Result_Summary class provides a high-level description of the types of products included in the collection or bundle"
 	(is-a Product_Components)
 	(role concrete)
-	(multislot data_regime
-;+		(comment "The data_regime attribute provides the wavelength (or an analogous concept for things like particle detectors) of the observations, stated as a category.")
-		(type STRING)
-;+		(value "Gamma Ray" "X-Ray" "Ultraviolet" "Visible" "Infrared" "Near Infrared" "Far Infrared" "Microwave" "Sub-Millimeter" "Millimeter" "Radio" "Magnetic Field" "Electric Field" "Ions" "Electrons" "Particles" "Dust" "Temperature" "Pressure")
+	(multislot has_Science_Facet
+;+		(comment "The has_Science_Facet association is a relationship Science_Facet.")
+		(type INSTANCE)
+;+		(allowed-classes Science_Facets)
 		(create-accessor read-write))
 	(single-slot type
 ;+		(comment "The type attribute provides a classification for the resource.")
@@ -9835,22 +9846,16 @@
 ;+		(value "Astrometry" "E/B-Field Vectors" "Count" "Gravity Model" "Image" "Map" "Null Result" "Photometry" "Polarimetry" "Radiometry" "Shape Model" "Spectrum" "Altimetry" "Occultation" "Physical Parameters" "Lightcurves" "Reference" "Meteorology")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(multislot processing_level
-;+		(comment "The processing_level attribute provides a broad classification of data processing level.")
-		(type STRING)
-;+		(value "Raw" "Calibrated" "Partially Processed" "Derived" "Telemetry")
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(multislot purpose
 ;+		(comment "The purpose attribute provides an indication of the primary purpose of the observations included.")
 		(type STRING)
 ;+		(value "Science" "Navigation" "Calibration" "Checkout" "Engineering" "Observation Geometry" "Supporting Observation")
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
-	(multislot has_Science_Facet
-;+		(comment "The has_Science_Facet association is a relationship Science_Facet.")
-		(type INSTANCE)
-;+		(allowed-classes Science_Facets)
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot processing_level_id
 ;+		(comment "The processing_level_id attribute provides a broad indication of data processing level.")
@@ -9858,21 +9863,21 @@
 ;+		(value "Raw" "Calibrated" "Partially Processed" "Derived" "Telemetry")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(multislot data_regime
+;+		(comment "The data_regime attribute provides the wavelength (or an analogous concept for things like particle detectors) of the observations, stated as a category.")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(value "Gamma Ray" "X-Ray" "Ultraviolet" "Visible" "Infrared" "Near Infrared" "Far Infrared" "Microwave" "Sub-Millimeter" "Millimeter" "Radio" "Magnetic Field" "Electric Field" "Ions" "Electrons" "Particles" "Dust" "Temperature" "Pressure")
+		(create-accessor read-write))
+	(multislot processing_level
+;+		(comment "The processing_level attribute provides a broad classification of data processing level.")
+		(type STRING)
+;+		(value "Raw" "Calibrated" "Partially Processed" "Derived" "Telemetry")
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
 (defclass Investigation_Area "The Investigation_Area class provides information about an investigation (mission, observing campaign or other coordinated, large-scale data collection effort)."
 	(is-a Product_Components)
 	(role concrete)
-	(multislot internal_reference
-;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes Internal_Reference)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
 	(single-slot type
 ;+		(comment "The type attribute classifies Investigation_Area according to the scope of the investigation..")
 		(type STRING)
@@ -9883,16 +9888,17 @@
 ;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(multislot internal_reference
+;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Internal_Reference)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
 (defclass Reference_List "The Reference_List class provides general references, cross-references, and source products for the product. References cited elsewhere in the label need not be repeated here."
 	(is-a Product_Components)
 	(role concrete)
-	(multislot external_reference
-;+		(comment "The external_reference association is a relationship to External_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes External_Reference)
-		(create-accessor read-write))
 	(multislot source_product_external
 ;+		(comment "The source_product_external association is a relationship to Source Product External.")
 		(type INSTANCE)
@@ -9907,6 +9913,11 @@
 ;+		(comment "The source_product_internal association is a relationship to Source_Product_Internal.")
 		(type INSTANCE)
 ;+		(allowed-classes Source_Product_Internal)
+		(create-accessor read-write))
+	(multislot external_reference
+;+		(comment "The external_reference association is a relationship to External_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes External_Reference)
 		(create-accessor read-write)))
 
 (defclass Internal_Reference "The Internal_Reference class is used to cross-reference other products in PDS4-compliant registries of PDS and its recognized international partners."
@@ -9918,10 +9929,9 @@
 		(default "XSChoice#1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot lidvid_reference
-;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
+	(single-slot reference_type
+;+		(comment "The reference_type attribute provides the name of the association.")
 		(type STRING)
-		(default "XSChoice#1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot comment
@@ -9929,22 +9939,23 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot reference_type
-;+		(comment "The reference_type attribute provides the name of the association.")
+	(single-slot lidvid_reference
+;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
 		(type STRING)
+		(default "XSChoice#1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass External_Reference "The External_Reference class is used to reference a source outside the PDS registry system."
 	(is-a Product_Components)
 	(role concrete)
-	(single-slot doi
-;+		(comment "The doi attribute provides the Digital Object Identifier for an object, assigned by the appropriate DOI System Registration Agency.")
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot doi
+;+		(comment "The doi attribute provides the Digital Object Identifier for an object, assigned by the appropriate DOI System Registration Agency.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -9957,13 +9968,13 @@
 (defclass External_Reference_Extended "The External_Reference_Extended class is used to reference a source outside the PDS registry system. This extension is used in the local data dictionary."
 	(is-a External_Reference)
 	(role concrete)
-	(single-slot url
-;+		(comment "The url attribute provides a Uniform Resource Identifier (URI) that specifies where a resource is available and the mechanism for retrieving it.")
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+	(single-slot url
+;+		(comment "The url attribute provides a Uniform Resource Identifier (URI) that specifies where a resource is available and the mechanism for retrieving it.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -9971,14 +9982,14 @@
 (defclass Bundle_Member_Entry "The Bundle Member Entry class provides a member reference to a collection."
 	(is-a Product_Components)
 	(role concrete)
-	(single-slot lid_reference
-;+		(comment "The lid_reference attribute provides the logical_identifier for a  product.")
+	(single-slot member_status
+;+		(comment "The member_status attribute indicates whether the collection is primary and whether the file_specification_name has been provided for the product_collection label.")
 		(type STRING)
-		(default "XSChoice#1")
+;+		(value "Primary" "Secondary")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot lidvid_reference
-;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
+	(single-slot lid_reference
+;+		(comment "The lid_reference attribute provides the logical_identifier for a  product.")
 		(type STRING)
 		(default "XSChoice#1")
 ;+		(cardinality 1 1)
@@ -9989,10 +10000,10 @@
 ;+		(value "bundle_has_browse_collection" "bundle_has_calibration_collection" "bundle_has_data_collection" "bundle_has_document_collection" "bundle_has_geometry_collection" "bundle_has_spice_kernel_collection" "bundle_has_schema_collection" "bundle_has_member_collection" "bundle_has_context_collection" "bundle_has_miscellaneous_collection")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot member_status
-;+		(comment "The member_status attribute indicates whether the collection is primary and whether the file_specification_name has been provided for the product_collection label.")
+	(single-slot lidvid_reference
+;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
 		(type STRING)
-;+		(value "Primary" "Secondary")
+		(default "XSChoice#1")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -10238,17 +10249,17 @@
 (defclass File_Area_Update "The File Area Update class is a File Area that describes a file that contains one or  more digital objects used to provide additional metadata for registered products."
 	(is-a File_Area)
 	(role concrete)
-	(single-slot has_tagged_data_object2
-;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
-		(type INSTANCE)
-;+		(allowed-classes Header)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot has_tagged_data_object
 ;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
 		(type INSTANCE)
 ;+		(allowed-classes XSChoice%23 Table_Character Table_Delimited)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot has_tagged_data_object2
+;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
+		(type INSTANCE)
+;+		(allowed-classes Header)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot has_File
 ;+		(comment "The has_File association is a relationship to File.")
@@ -10292,17 +10303,17 @@
 (defclass File_Area_Metadata "The File Area Metadata class describes a table which provides new, and/or improved, metadata. All field names provided must be attributes defined in PDS4, either in the common dictionary, or in a PDS4 discipline or mission dictionary."
 	(is-a File_Area)
 	(role concrete)
-	(single-slot has_tagged_data_object2
-;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
-		(type INSTANCE)
-;+		(allowed-classes Header)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot has_tagged_data_object
 ;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
 		(type INSTANCE)
 ;+		(allowed-classes Table_Character Table_Delimited XSChoice%23)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot has_tagged_data_object2
+;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
+		(type INSTANCE)
+;+		(allowed-classes Header)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot has_File
 ;+		(comment "The has_File association is a relationship to File.")
@@ -10345,57 +10356,52 @@
 (defclass Science_Facets "The Science_Facets class contains the science-related search facets.  It is optional and may be repeated if an product has facets related to, for example, two different disciplines (as defined by the discipline_name facet). Note that Science_Facets was modeled with Discipline_Facets as a component and Discipline_Facets was modeled with Group_Facet1 and Group_Facet2 as components. This dependency hierarchy was flattened and only Science_Facets exists in the schema."
 	(is-a Product_Components)
 	(role concrete)
-	(multislot domain
-;+		(comment "The radial %42zone%42 or %42shell%42 of the target for which the observations were collected or which are represented in the product(s).  The value may depend on wavelength_range and size of the target.")
-		(type STRING)
-;+		(value "Interior" "Surface" "Atmosphere" "Ionosphere" "Magnetosphere" "Heliosphere" "Interstellar" "Rings" "Dynamics" "Heliosheath")
+	(single-slot has_Discipline_Facets
+;+		(comment "The has_Discipline_Facets association is a relationship to Discipline_Facets.")
+		(type INSTANCE)
+;+		(allowed-classes Discipline_Facets)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot wavelength_range
 ;+		(comment "The wavelength range attribute specifies the wavelength range over which the data were collected or which otherwise characterizes the observation(s). Boundaries are vague, and there is overlap.")
 		(type STRING)
 ;+		(value "Radio" "Microwave" "Millimeter" "Submillimeter" "Far Infrared" "Infrared" "Near Infrared" "Visible" "Ultraviolet" "X-ray" "Gamma Ray")
 		(create-accessor read-write))
-	(single-slot has_Discipline_Facets
-;+		(comment "The has_Discipline_Facets association is a relationship to Discipline_Facets.")
-		(type INSTANCE)
-;+		(allowed-classes Discipline_Facets)
-;+		(cardinality 1 1)
+	(multislot domain
+;+		(comment "The radial %42zone%42 or %42shell%42 of the target for which the observations were collected or which are represented in the product(s).  The value may depend on wavelength_range and size of the target.")
+		(type STRING)
+;+		(value "Interior" "Surface" "Atmosphere" "Ionosphere" "Magnetosphere" "Heliosphere" "Interstellar" "Rings" "Dynamics" "Heliosheath")
 		(create-accessor read-write)))
 
 (defclass Group_Facet1 "The Group_Facet1 class contains a single facet restricted according to the value of discipline_name. It also contains zero or more subfacets restricted according to the value of the facet. Note that Science_Facets was modeled with Discipline_Facets as a component and Discipline_Facets was modeled with Group_Facet1 and Group_Facet2 as components. This dependency hierarchy was flattened and only Science_Facets exists in the schema."
 	(is-a Product_Components)
 	(role concrete)
-	(multislot subfacet1
-;+		(comment "The subfacet1 attribute provides a sub-categorization under the facet1 value.  The allowed values are restricted according to the value of facet1.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot facet1
 ;+		(comment "The facet1 attribute provides a sub-categorization under the discipline_name.  The values are restricted according to the value of discipline_name.")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot subfacet1
+;+		(comment "The subfacet1 attribute provides a sub-categorization under the facet1 value.  The allowed values are restricted according to the value of facet1.")
+		(type STRING)
 		(create-accessor read-write)))
 
 (defclass Group_Facet2 "The Group_Facet2 class contains a single facet restricted according to the value of discipline_name. It also contains zero or more subfacets restricted according to the value of the facet. Note that Science_Facets was modeled with Discipline_Facets as a component and Discipline_Facets was modeled with Group_Facet1 and Group_Facet2 as components. This dependency hierarchy was flattened and only Science_Facets exists in the schema."
 	(is-a Product_Components)
 	(role concrete)
-	(multislot subfacet2
-;+		(comment "The subfacet2 attribute provides a sub-categorization under the facet2 value.  The allowed values are restricted according to the value of facet2.")
-		(type STRING)
-		(create-accessor read-write))
 	(single-slot facet2
 ;+		(comment "The facet2 attribute provides a sub-categorization (under the discipline_name) of the type of data being described by Primary_Result_Summary.  The  facet1  and  factet2  values are intended to provide independent sub-categorizations. The values are restricted according to the value of discipline_name. Type: ASCII_Short_String_Collapsed")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot subfacet2
+;+		(comment "The subfacet2 attribute provides a sub-categorization under the facet2 value.  The allowed values are restricted according to the value of facet2.")
+		(type STRING)
 		(create-accessor read-write)))
 
 (defclass Local_Internal_Reference "The Local Internal_Reference class is used to cross-reference other Description Objects in a PDS4 label."
 	(is-a Product_Components)
 	(role concrete)
-	(single-slot comment
-;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(multislot local_identifier_reference
 ;+		(comment "The local_identifier_reference attribute provides the value of the local_identifier of the entity described by the referencing class. Note that a local_identifier attribute, with the same value as this local_identifier_reference, must be present within the label.")
 		(type STRING)
@@ -10405,20 +10411,25 @@
 ;+		(comment "The local_reference_type attribute provides the name of an association between an entity identified by a local_identifier_reference and another corresponding entity identified by a local_identifier. The values for the local_reference_type are expected to be enumerated for appropriate contexts in the Schematron files of local (i.e., discipline and mission) data dictionaries.")
 		(type STRING)
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot comment
+;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write)))
 
 (defclass Discipline_Facets "The Discipline_Facets class contains the discipline-related search facets.  It is required and may not be repeated. Note that Science_Facets was modeled with Discipline_Facets as a component and Discipline_Facets was modeled with Group_Facet1 and Group_Facet2 as components. This dependency hierarchy was flattened and only Science_Facets exists in the schema."
 	(is-a Product_Components)
 	(role concrete)
-	(multislot has_Group_Facet2
-;+		(comment "The has_Group_Facet2 association is a relationship to Group_Facet2.")
-		(type INSTANCE)
-;+		(allowed-classes Group_Facet2)
-		(create-accessor read-write))
 	(multislot has_Group_Facet1
 ;+		(comment "The has_Group_Facet1 association is a relationship to Group_Facet1.")
 		(type INSTANCE)
 ;+		(allowed-classes Group_Facet1)
+		(create-accessor read-write))
+	(multislot has_Group_Facet2
+;+		(comment "The has_Group_Facet2 association is a relationship to Group_Facet2.")
+		(type INSTANCE)
+;+		(allowed-classes Group_Facet2)
 		(create-accessor read-write))
 	(single-slot discipline_name
 ;+		(comment "The discipline_name attribute describes the observing discipline (as opposed to a PDS Discipline Node Name, though the concepts and values are similar). Some of these values are, with respect to the PDS Nodes, inter-disciplinary and should be used when they are applicable in perference to the more restrictive values.")
@@ -10429,17 +10440,17 @@
 (defclass Virtual_Area "The Virtual Area provides the metadata and references necessary to describe a composite of existing products and/or their components."
 	(is-a Product_Components)
 	(role concrete)
-	(single-slot virtual_structure
-;+		(comment "The virtual_structure association is a relationship to Virtual Structure")
-		(type INSTANCE)
-;+		(allowed-classes Virtual_Structure)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot has_discipline_area
 ;+		(comment "The has_discipline_area association is a relationship to Discipline Area.")
 		(type INSTANCE)
 ;+		(allowed-classes Discipline_Area)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot virtual_structure
+;+		(comment "The virtual_structure association is a relationship to Virtual Structure")
+		(type INSTANCE)
+;+		(allowed-classes Virtual_Structure)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Tagged_NonDigital_Child "The Tagged NonDigital Child class is an abstract class for the components  of classes in the tagged nondigital object class hierarchy."
@@ -10449,10 +10460,21 @@
 (defclass Observing_System_Component "The Observing System Component class describes one or more subsystems used to collect data."
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
-	(multislot external_reference
-;+		(comment "The external_reference association is a relationship to External_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes External_Reference)
+	(single-slot type
+;+		(comment "The type attribute classifies the observing system component according to its function.")
+		(type STRING)
+;+		(value "Naked Eye" "Laboratory" "Observatory" "Telescope" "Instrument" "Literature Search" "Spacecraft" "Artificial Illumination" "Facility" "Balloon" "Airborne" "Aircraft" "Suborbital Rocket" "Computer" "Host")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot internal_reference
 ;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
@@ -10460,53 +10482,15 @@
 ;+		(allowed-classes Internal_Reference)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot type
-;+		(comment "The type attribute classifies the observing system component according to its function.")
-		(type STRING)
-;+		(value "Naked Eye" "Laboratory" "Observatory" "Telescope" "Instrument" "Literature Search" "Spacecraft" "Artificial Illumination" "Facility" "Balloon" "Airborne" "Aircraft" "Suborbital Rocket" "Computer" "Host")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
-;+		(cardinality 0 1)
+	(multislot external_reference
+;+		(comment "The external_reference association is a relationship to External_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes External_Reference)
 		(create-accessor read-write)))
 
 (defclass Terminological_Entry "The terminological_entry class provides the name (designation) and definition of the attribute in a specified natural language."
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
-	(single-slot skos_relation_name
-;+		(comment "The attribute skos_relation_name provides a meaning of the relationship between two associated terms.")
-		(type STRING)
-;+		(value "exactMatch" "closeMatch" "broadMatch" "narrowMatch" "relatedMatch")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot instance_id
-;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot mapping_type
-;+		(comment "The mapping type attribute indicates how two terms are related to each other.")
-		(type STRING)
-;+		(value "pds4_attribute_replaces_pds3_attribute" "pds4_attribute_replaces_pds4_attribute" "pds4_attribute_replaces_column" "pds4_attribute_replacedby_term")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot definition
-;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot name_
-;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot language
 ;+		(comment "The language attribute provides the language used for definition and designation of the term.")
 		(type STRING)
@@ -10518,33 +10502,59 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot definition
+;+		(comment "The definition attribute provides a statement, picture in words, or account that defines the term.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(multislot source
 ;+		(comment "The bibliographic_reference association is a relationship to bibliographic reference.")
 		(type INSTANCE)
 ;+		(allowed-classes External_Reference_Extended)
-		(create-accessor read-write)))
-
-(defclass Terminological_Entry_SKOS "The terminological_entry_SKOS class provides terms and definitions for a SKOS ontology."
-	(is-a Tagged_NonDigital_Child)
-	(role concrete)
-	(single-slot identifier
-;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot title
-;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
+	(single-slot instance_id
+;+		(comment "The instance_id attribute provides an identifier for the single occurrence of an object, for example an XPath.")
 		(type STRING)
-;+		(cardinality 1 1)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot skos_relation_name
 ;+		(comment "The attribute skos_relation_name provides a meaning of the relationship between two associated terms.")
 		(type STRING)
 ;+		(value "exactMatch" "closeMatch" "broadMatch" "narrowMatch" "relatedMatch")
-;+		(cardinality 1 1)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot mapping_type
+;+		(comment "The mapping type attribute indicates how two terms are related to each other.")
+		(type STRING)
+;+		(value "pds4_attribute_replaces_pds3_attribute" "pds4_attribute_replaces_pds4_attribute" "pds4_attribute_replaces_column" "pds4_attribute_replacedby_term")
+;+		(cardinality 0 1)
+		(create-accessor read-write)))
+
+(defclass Terminological_Entry_SKOS "The terminological_entry_SKOS class provides terms and definitions for a SKOS ontology."
+	(is-a Tagged_NonDigital_Child)
+	(role concrete)
+	(single-slot model_object_id
+;+		(comment "The model_object_id attribute provides the unique identifier of a class, attribute, or value that is defined in the information model.")
+		(type STRING)
+;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot namespace_id
 ;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot steward_id
+;+		(comment "The steward_id attribute provides the abbreviation of the organization that manages the set of registered attributes and classes.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -10552,6 +10562,11 @@
 ;+		(comment "The model_object_type attribute provides a classification for a modeled object.")
 		(type STRING)
 ;+		(value "Attribute" "Class" "Nuance" "Keyword" "Value")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot title
+;+		(comment "The title attribute provides a short, descriptive text string suitable use as a title or brief description in display or listing of products.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot instance_id
@@ -10564,25 +10579,21 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot identifier
+;+		(comment "The identifier attribute provides the formal name used to refer to an object.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot registration_authority
 ;+		(comment "The registration_authority attribute provides the name of the group  responsible for the terminological entry.")
 		(type STRING)
 ;+		(value "PDS4" "PDS3" "VICAR")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot model_object_id
-;+		(comment "The model_object_id attribute provides the unique identifier of a class, attribute, or value that is defined in the information model.")
+	(single-slot skos_relation_name
+;+		(comment "The attribute skos_relation_name provides a meaning of the relationship between two associated terms.")
 		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot steward_id
-;+		(comment "The steward_id attribute provides the abbreviation of the organization that manages the set of registered attributes and classes.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
-		(type STRING)
+;+		(value "exactMatch" "closeMatch" "broadMatch" "narrowMatch" "relatedMatch")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -10599,6 +10610,11 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot value_end_date
+;+		(comment "The value_end_date attribute provides the last date on which the permissible value is in effect.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot value_begin_date
 ;+		(comment "The value_begin_date attribute provides the first date on which the permissible value is in effect.")
 		(type STRING)
@@ -10606,11 +10622,6 @@
 		(create-accessor read-write))
 	(single-slot value
 ;+		(comment "The value attribute provides a single, allowed numerical or character string value.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot value_end_date
-;+		(comment "The value_end_date attribute provides the last date on which the permissible value is in effect.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -10632,26 +10643,6 @@
 (defclass DD_Association "The DD_Association class defines the association between two classes or a class and an attribute in a data dictionary."
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
-	(multislot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
-		(type STRING)
-		(create-accessor read-write))
-	(single-slot minimum_occurrences
-;+		(comment "The minimum occurrences attribute indicates the number of times something may occur. It is also called the minimum cardinality.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot constant_value
-;+		(comment "The constant value attribute provides the value to be used if an attribute is static.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot dd_attribute_reference
-;+		(comment "The dd_attribute_reference association is a relationship to DD_Attribute_Reference.")
-		(type INSTANCE)
-;+		(allowed-classes DD_Attribute_Reference)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot dd_class_reference
 ;+		(comment "The dd_class_reference association is a relationship to DD_Class_Reference.")
 		(type INSTANCE)
@@ -10663,6 +10654,15 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(multislot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+		(type STRING)
+		(create-accessor read-write))
+	(single-slot constant_value
+;+		(comment "The constant value attribute provides the value to be used if an attribute is static.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot reference_type
 ;+		(comment "The reference_type attribute provides the name of the association.")
 		(type STRING)
@@ -10673,20 +10673,31 @@
 ;+		(comment "The identifier_reference attribute provides the value of an identifier.")
 		(type STRING)
 		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot dd_attribute_reference
+;+		(comment "The dd_attribute_reference association is a relationship to DD_Attribute_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes DD_Attribute_Reference)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot minimum_occurrences
+;+		(comment "The minimum occurrences attribute indicates the number of times something may occur. It is also called the minimum cardinality.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Vector_Component "The Vector_Component class provides a component of a vector."
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot sequence_number
 ;+		(comment "The sequence_number attribute provides a number that is used to order axes in an array.")
 		(type INTEGER)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot unit
-;+		(comment "The unit attribute provides the unit of measurement.")
-		(type STRING)
-;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot name_
 ;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
@@ -10698,8 +10709,8 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot unit
+;+		(comment "The unit attribute provides the unit of measurement.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write)))
@@ -10707,15 +10718,14 @@
 (defclass Quaternion_Component "The Quaternion_Component class provides a component of a quaternion."
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot sequence_number
 ;+		(comment "The sequence_number attribute provides a number that is used to order axes in an array.")
 		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot data_type
-;+		(comment "The data_type attribute provides the hardware representation used to store a value in Quaternion_Component (see PDS Standards Reference section \"Attribute Data Types\").")
-		(type STRING)
-;+		(value "ASCII_Real")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot name_
@@ -10728,10 +10738,11 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(single-slot data_type
+;+		(comment "The data_type attribute provides the hardware representation used to store a value in Quaternion_Component (see PDS Standards Reference section \"Attribute Data Types\").")
 		(type STRING)
-;+		(cardinality 0 1)
+;+		(value "ASCII_Real")
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Tracking_Detail "The Tracking Detail class is a single status record."
@@ -10742,9 +10753,10 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot modification_date
-;+		(comment "The modification_date attribute provides date the modifications were completed")
+	(single-slot archive_status
+;+		(comment "The ARCHIVE_STATUS attribute indicates the stage to which a data set has progressed in the archiving process, from IN QUEUE through ARCHIVED. It can also take on the values SUPERSEDED or SAFED, which indicate that the data set is not part of the active archive. ACCUMULATING can be appended to some values to indicate that the data set is incomplete and/or that not all components have reached the stage given by the root value; ACCUMULATING would be used, for example, when the archive is being delivered incrementally, as from a mission that lasts many months or years.")
 		(type STRING)
+;+		(value "ARCHIVED" "IN_LIEN_RESOLUTION" "IN_PEER_REVIEW" "IN_QUEUE" "LOCALLY_ARCHIVED" "PRE_PEER_REVIEW" "SAFED" "SUPERSEDED" "IN_QUEUE_ACCUMULATING" "PRE_PEER_REVIEW_ACCUMULATING" "IN_PEER_REVIEW_ACCUMULATING" "IN_LIEN_RESOLUTION_ACCUMULATING" "LOCALLY_ARCHIVED_ACCUMULATING" "ARCHIVED_ACCUMULATING")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot certified_flag
@@ -10752,10 +10764,9 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot archive_status
-;+		(comment "The ARCHIVE_STATUS attribute indicates the stage to which a data set has progressed in the archiving process, from IN QUEUE through ARCHIVED. It can also take on the values SUPERSEDED or SAFED, which indicate that the data set is not part of the active archive. ACCUMULATING can be appended to some values to indicate that the data set is incomplete and/or that not all components have reached the stage given by the root value; ACCUMULATING would be used, for example, when the archive is being delivered incrementally, as from a mission that lasts many months or years.")
+	(single-slot modification_date
+;+		(comment "The modification_date attribute provides date the modifications were completed")
 		(type STRING)
-;+		(value "ARCHIVED" "IN_LIEN_RESOLUTION" "IN_PEER_REVIEW" "IN_QUEUE" "LOCALLY_ARCHIVED" "PRE_PEER_REVIEW" "SAFED" "SUPERSEDED" "IN_QUEUE_ACCUMULATING" "PRE_PEER_REVIEW_ACCUMULATING" "IN_PEER_REVIEW_ACCUMULATING" "IN_LIEN_RESOLUTION_ACCUMULATING" "LOCALLY_ARCHIVED_ACCUMULATING" "ARCHIVED_ACCUMULATING")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -10786,19 +10797,39 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot formation_rule
+;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot unit_of_measure_type
 ;+		(comment "The unit_of_measure_type attribute identifies the class from which the attribute being defined in this data dictionary draws its possible expressions for units.")
 		(type STRING)
 ;+		(value "Units_of_Amount_Of_Substance" "Units_of_Angle" "Units_of_Angular_Velocity" "Units_of_Area" "Units_of_Frequency" "Units_of_Length" "Units_of_Mass" "Units_of_Misc" "Units_of_None" "Units_of_Optical_Path_Length" "Units_of_Pressure" "Units_of_Radiance" "Units_of_Rates" "Units_of_Map_Scale" "Units_of_Solid_Angle" "Units_of_Storage" "Units_of_Temperature" "Units_of_Time" "Units_of_Velocity" "Units_of_Voltage" "Units_of_Volume" "Units_of_Acceleration" "Units_of_Frame_Rate" "Units_of_Spectral_Irradiance" "Units_of_Spectral_Radiance" "Units_of_Wavenumber" "Units_of_Current" "Units_of_Pixel_Scale_Linear" "Units_of_Pixel_Scale_Angular" "Units_of_Pixel_Resolution_Linear" "Units_of_Pixel_Resolution_Angular" "Units_of_Pixel_Resolution_Map" "Units_of_Pixel_Scale_Map" "Units_of_Energy" "Units_of_Force" "Units_of_Gmass" "Units_of_Power" "Units_of_Mass_Density")
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot formation_rule
-;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
 ;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot specified_unit_id
+;+		(comment "The specified_unit_id attribute provides the unit chosen for maximum_value, minimum_value, and permissible_value.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -10808,28 +10839,8 @@
 ;+		(value "ASCII_Boolean" "ASCII_Date_YMD" "ASCII_Integer" "ASCII_Real" "ASCII_AnyURI" "ASCII_Date_DOY" "ASCII_Date_Time_DOY_UTC" "ASCII_Date_Time_YMD_UTC" "ASCII_LID" "ASCII_LIDVID" "ASCII_MD5_Checksum" "ASCII_Short_String_Collapsed" "ASCII_Text_Preserved" "ASCII_Short_String_Preserved" "ASCII_Time" "ASCII_VID" "ASCII_DOI" "ASCII_Numeric_Base2" "ASCII_Numeric_Base16" "ASCII_NonNegative_Integer" "ASCII_File_Specification_Name" "ASCII_Directory_Path_Name" "ASCII_LIDVID_LID" "ASCII_File_Name" "ASCII_Numeric_Base8" "ASCII_Text_Collapsed" "UTF8_Short_String_Collapsed" "UTF8_Short_String_Preserved" "UTF8_Text_Preserved" "Vector_Cartesian_3" "Vector_Cartesian_3_Acceleration" "Vector_Cartesian_3_Position" "Vector_Cartesian_3_Velocity" "Vector_Cartesian_3_Pointing" "ASCII_Date_Time_DOY" "ASCII_Date_Time_YMD" "ASCII_BibCode" "UTF8_Text_Collapsed")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot specified_unit_id
-;+		(comment "The specified_unit_id attribute provides the unit chosen for maximum_value, minimum_value, and permissible_value.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -10842,11 +10853,6 @@
 (defclass DD_Association_External "The DD_Association_External class defines the association between classes and attributes within the local data dictionary and those external to the local data dictionary."
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
-	(single-slot minimum_occurrences
-;+		(comment "The minimum occurrences attribute indicates the number of times something may occur. It is also called the minimum cardinality.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot namespace_id
 ;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
 		(type STRING)
@@ -10867,6 +10873,11 @@
 		(type STRING)
 ;+		(value "subclass_of" "attribute_of" "component_of" "restriction_of" "extension_of" "parent_of")
 ;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot minimum_occurrences
+;+		(comment "The minimum occurrences attribute indicates the number of times something may occur. It is also called the minimum cardinality.")
+		(type STRING)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass DD_Value_Domain_Full "The DD_Value_Domain_Full class provides a more complete definition of a attribute's value domain."
@@ -10877,30 +10888,13 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot unit_of_measure_type
-;+		(comment "The unit_of_measure_type attribute identifies the class from which the attribute being defined in this data dictionary draws its possible expressions for units.")
-		(type STRING)
-;+		(value "Units_of_Amount_Of_Substance" "Units_of_Angle" "Units_of_Angular_Velocity" "Units_of_Area" "Units_of_Frequency" "Units_of_Length" "Units_of_Mass" "Units_of_Misc" "Units_of_None" "Units_of_Optical_Path_Length" "Units_of_Pressure" "Units_of_Radiance" "Units_of_Rates" "Units_of_Map_Scale" "Units_of_Solid_Angle" "Units_of_Storage" "Units_of_Temperature" "Units_of_Time" "Units_of_Velocity" "Units_of_Voltage" "Units_of_Volume" "Units_of_Frame_Rate" "Units_of_Wavenumber" "Units_of_Spectral_Radiance" "Units_of_Spectral_Irradiance" "Units_of_Current" "Units_of_Pixel_Scale_Linear" "Units_of_Pixel_Scale_Angular" "Units_of_Pixel_Resolution_Linear" "Units_of_Pixel_Resolution_Angular" "Units_of_Acceleration" "Units_of_Pixel_Resolution_Map" "Units_of_Pixel_Scale_Map" "Units_of_Energy" "Units_of_Force" "Units_of_Gmass" "Units_of_Power" "Units_of_Mass_Density")
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot value_data_type
-;+		(comment "The value_data_type attribute is used in a data dictionary to specify the data type of an attribute's value.")
-		(type STRING)
-;+		(value "ASCII_Boolean" "ASCII_Date_YMD" "ASCII_Integer" "ASCII_Real" "ASCII_AnyURI" "ASCII_Date_DOY" "ASCII_Date_Time_DOY_UTC" "ASCII_Date_Time_YMD_UTC" "ASCII_LID" "ASCII_LIDVID" "ASCII_MD5_Checksum" "ASCII_Short_String_Collapsed" "ASCII_Text_Preserved" "ASCII_Short_String_Preserved" "ASCII_Time" "ASCII_VID" "ASCII_DOI" "ASCII_Numeric_Base2" "ASCII_Numeric_Base16" "ASCII_NonNegative_Integer" "ASCII_File_Specification_Name" "ASCII_Directory_Path_Name" "ASCII_LIDVID_LID" "ASCII_File_Name" "ASCII_Numeric_Base8" "ASCII_Text_Collapsed" "UTF8_Short_String_Collapsed" "UTF8_Short_String_Preserved" "UTF8_Text_Preserved" "ASCII_Date_Time_DOY" "ASCII_Date_Time_YMD" "ASCII_BibCode" "UTF8_Text_Collapsed")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot minimum_value
-;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot formation_rule
 ;+		(comment "The formation_rule attribute provides a 'user friendly' instruction for forming values.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -10914,13 +10908,24 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
+	(single-slot minimum_value
+;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot maximum_characters
 ;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
+	(single-slot unit_of_measure_type
+;+		(comment "The unit_of_measure_type attribute identifies the class from which the attribute being defined in this data dictionary draws its possible expressions for units.")
+		(type STRING)
+;+		(value "Units_of_Amount_Of_Substance" "Units_of_Angle" "Units_of_Angular_Velocity" "Units_of_Area" "Units_of_Frequency" "Units_of_Length" "Units_of_Mass" "Units_of_Misc" "Units_of_None" "Units_of_Optical_Path_Length" "Units_of_Pressure" "Units_of_Radiance" "Units_of_Rates" "Units_of_Map_Scale" "Units_of_Solid_Angle" "Units_of_Storage" "Units_of_Temperature" "Units_of_Time" "Units_of_Velocity" "Units_of_Voltage" "Units_of_Volume" "Units_of_Frame_Rate" "Units_of_Wavenumber" "Units_of_Spectral_Radiance" "Units_of_Spectral_Irradiance" "Units_of_Current" "Units_of_Pixel_Scale_Linear" "Units_of_Pixel_Scale_Angular" "Units_of_Pixel_Resolution_Linear" "Units_of_Pixel_Resolution_Angular" "Units_of_Acceleration" "Units_of_Pixel_Resolution_Map" "Units_of_Pixel_Scale_Map" "Units_of_Energy" "Units_of_Force" "Units_of_Gmass" "Units_of_Power" "Units_of_Mass_Density")
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
@@ -10928,6 +10933,12 @@
 ;+		(comment "The conceptual_domain attribute provides the domain to which the value has been assigned.")
 		(type STRING)
 ;+		(value "Short_String" "Integer" "Text" "Time" "Real" "Boolean" "Type" "Name" "Numeric" "Unknown")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot value_data_type
+;+		(comment "The value_data_type attribute is used in a data dictionary to specify the data type of an attribute's value.")
+		(type STRING)
+;+		(value "ASCII_Boolean" "ASCII_Date_YMD" "ASCII_Integer" "ASCII_Real" "ASCII_AnyURI" "ASCII_Date_DOY" "ASCII_Date_Time_DOY_UTC" "ASCII_Date_Time_YMD_UTC" "ASCII_LID" "ASCII_LIDVID" "ASCII_MD5_Checksum" "ASCII_Short_String_Collapsed" "ASCII_Text_Preserved" "ASCII_Short_String_Preserved" "ASCII_Time" "ASCII_VID" "ASCII_DOI" "ASCII_Numeric_Base2" "ASCII_Numeric_Base16" "ASCII_NonNegative_Integer" "ASCII_File_Specification_Name" "ASCII_Directory_Path_Name" "ASCII_LIDVID_LID" "ASCII_File_Name" "ASCII_Numeric_Base8" "ASCII_Text_Collapsed" "UTF8_Short_String_Collapsed" "UTF8_Short_String_Preserved" "UTF8_Text_Preserved" "ASCII_Date_Time_DOY" "ASCII_Date_Time_YMD" "ASCII_BibCode" "UTF8_Text_Collapsed")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(multislot permissible_value
@@ -10939,13 +10950,13 @@
 (defclass DD_Static_Permissible_Value "The DD_Static_Permissible_Value Class is used to"
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
-	(single-slot local_identifier
-;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
+	(single-slot value
+;+		(comment "The value attribute provides a single, allowed numerical or character string value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot value
-;+		(comment "The value attribute provides a single, allowed numerical or character string value.")
+	(single-slot local_identifier
+;+		(comment "The local_identifier attribute provides a character string which uniquely identifies the containing object within the label.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -10981,27 +10992,6 @@
 (defclass Document_Edition "A Document Edition is one complete version of the document in a set of files that is distinguished by language, a unique assemblage of file formats, or some other criteria."
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
-	(single-slot edition_name
-;+		(comment "The edition name attribute provides a name by which the edition is known.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(multislot has_document_file
-;+		(comment "The has_document_file association is a relationship to a document file.")
-		(type INSTANCE)
-;+		(allowed-classes Document_File)
-		(cardinality 1 ?VARIABLE)
-		(create-accessor read-write))
-	(single-slot starting_point_identifier
-;+		(comment "The starting_point attribute provides the local_identifier of the object to be accessed first.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(single-slot files
-;+		(comment "The files attribute provides the number of files in the edition.")
-		(type INTEGER)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot language
 ;+		(comment "The language attribute provides the language used for definition and designation of the term.")
 		(type STRING)
@@ -11012,41 +11002,62 @@
 ;+		(comment "The description attribute provides a statement, picture in words, or account that describes the edition, including how it is distinguished from other editions (if any).")
 		(type STRING)
 ;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(multislot has_document_file
+;+		(comment "The has_document_file association is a relationship to a document file.")
+		(type INSTANCE)
+;+		(allowed-classes Document_File)
+		(cardinality 1 ?VARIABLE)
+		(create-accessor read-write))
+	(single-slot edition_name
+;+		(comment "The edition name attribute provides a name by which the edition is known.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot starting_point_identifier
+;+		(comment "The starting_point attribute provides the local_identifier of the object to be accessed first.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot files
+;+		(comment "The files attribute provides the number of files in the edition.")
+		(type INTEGER)
+;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass Source_Product_Internal "The Source_Product _Internal class is used to reference one or more source products in the PDS4 registry system. A source product contains input data for the creation of this product."
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
-	(multislot lidvid_reference
-;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
+	(single-slot reference_type
+;+		(comment "The reference_type attribute provides the name of the association.")
 		(type STRING)
-		(default "logical_identifier::version_id")
-		(cardinality 1 ?VARIABLE)
+;+		(value "data_to_telemetry_source_product" "data_to_raw_source_product" "data_to_partially_processed_source_product" "data_to_calibrated_source_product" "data_to_derived_source_product")
+;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot comment
 ;+		(comment "The comment attribute is a character string expressing one or more remarks or thoughts relevant to the object.")
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot reference_type
-;+		(comment "The reference_type attribute provides the name of the association.")
+	(multislot lidvid_reference
+;+		(comment "The lidvid_reference attribute provides the logical_identifier plus version_id, which uniquely identifies a product.")
 		(type STRING)
-;+		(value "data_to_telemetry_source_product" "data_to_raw_source_product" "data_to_partially_processed_source_product" "data_to_calibrated_source_product" "data_to_derived_source_product")
-;+		(cardinality 1 1)
+		(default "logical_identifier::version_id")
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
 (defclass Source_Product_External "The Source_Product_External class is used to reference one or more source products (a product containing input data for the creation of this product) outside the PDS4 Registry that have a common reference_type, doi, curating facility, and/or description. At least one of doi or curating facility must be provided. All source products listed within a single Source_Product_External class must correspond to the same doi and/or curating facility."
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
 	(single-slot curating_facility
 ;+		(comment "The curating_facility attribute provides a unique name or identifier for the curating facility maintaining the source product.")
 		(type STRING)
 ;+		(cardinality 0 1)
-		(create-accessor read-write))
-	(multislot external_source_product_identifier
-;+		(comment "The external_source_product_identifier provides unique identifiers for one or more source products that are not in the PDS4 Registry. For guidelines on the construction of this identifier, refer to section E.2.6.1.2 of the Data Provider's Handbook.")
-		(type STRING)
-		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
 	(single-slot reference_type
 ;+		(comment "The reference_type attribute provides the name of the association.")
@@ -11059,10 +11070,10 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot description
-;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+	(multislot external_source_product_identifier
+;+		(comment "The external_source_product_identifier provides unique identifiers for one or more source products that are not in the PDS4 Registry. For guidelines on the construction of this identifier, refer to section E.2.6.1.2 of the Data Provider's Handbook.")
 		(type STRING)
-;+		(cardinality 0 1)
+		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write)))
 
 (defclass DD_Associate_External_Class "The DD_Associate_External_Class class allows the definition of permissible values in Ingest_LDD for attributes defined in external namespaces."
@@ -11074,13 +11085,13 @@
 ;+		(allowed-classes DD_Context_Value_List)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_occurrences
-;+		(comment "The minimum occurrences attribute indicates the number of times something may occur. It is also called the minimum cardinality.")
+	(single-slot namespace_id
+;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot namespace_id
-;+		(comment "The namespace_id attribute provides the abbreviation of the XML schema namespace container for this  logical grouping of classes and attributes.  It is assigned by the steward.")
+	(single-slot class_name
+;+		(comment "The class_name attribute provides the common name by which the class is identified, as well as the class within which the attribute is used.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -11089,8 +11100,8 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot class_name
-;+		(comment "The class_name attribute provides the common name by which the class is identified, as well as the class within which the attribute is used.")
+	(single-slot minimum_occurrences
+;+		(comment "The minimum occurrences attribute indicates the number of times something may occur. It is also called the minimum cardinality.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -11098,13 +11109,13 @@
 (defclass DD_Context_Value_List "The DD_Context_Value_List class identifies an attribute and its relative xpath for the definition of permissible values and their meanings."
 	(is-a Tagged_NonDigital_Child)
 	(role concrete)
-	(single-slot attribute_name
-;+		(comment "The attribute_name attribute provides the common name by which an attribute is known.")
+	(single-slot attribute_relative_xpath
+;+		(comment "The attribute_relative_xpath attribute provides a location path for an attribute within a tree representation of an XML document. The location path includes the attribute name.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot attribute_relative_xpath
-;+		(comment "The attribute_relative_xpath attribute provides a location path for an attribute within a tree representation of an XML document. The location path includes the attribute name.")
+	(single-slot attribute_name
+;+		(comment "The attribute_name attribute provides the common name by which an attribute is known.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -11123,11 +11134,6 @@
 		(type STRING)
 ;+		(cardinality 0 1)
 		(create-accessor read-write))
-	(single-slot funding_year
-;+		(comment "The funding_year attribute provides the year that funding was awarded.")
-		(type STRING)
-;+		(cardinality 0 1)
-		(create-accessor read-write))
 	(single-slot funding_source
 ;+		(comment "The funding_source attribute provides the identifier for an agency or other entity that provided financial assistance in the poroduction of the archival data.")
 		(type STRING)
@@ -11137,6 +11143,31 @@
 	(single-slot funding_acknowledgement_text
 ;+		(comment "The funding_acknowledgement_text attribute provides a text description of the relationship between the funding source and the archival data.")
 		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot funding_year
+;+		(comment "The funding_year attribute provides the year that funding was awarded.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write)))
+
+(defclass License_Information "The license information are describes the license, terms, or other usage information that this product accompanies."
+	(is-a Tagged_NonDigital_Child)
+	(role concrete)
+	(single-slot description
+;+		(comment "The description attribute provides a statement, picture in words, or account that describes or is otherwise relevant to the object.")
+		(type STRING)
+;+		(cardinality 0 1)
+		(create-accessor read-write))
+	(single-slot name_
+;+		(comment "The name attribute provides a word or combination of words by which the object is known.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot internal_reference
+;+		(comment "The internal_reference association is a relationship to Internal_Reference.")
+		(type INSTANCE)
+;+		(allowed-classes Internal_Reference)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12076,8 +12107,18 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12091,8 +12132,8 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12102,18 +12143,8 @@
 ;+		(value "UTF-8")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -12121,10 +12152,9 @@
 (defclass ASCII_AnyURI "The ASCII AnyURI class indicates a URI or its subclasses URN and URL."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:anyURI")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12138,15 +12168,16 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+		(type STRING)
+;+		(value "xsd:anyURI")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
 	(single-slot character_encoding
 ;+		(comment "The character_encoding attribute identifies the standard that maps a set of allowed characters to their machine readable code.")
 		(type STRING)
 ;+		(value "UTF-8")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12169,10 +12200,15 @@
 ;+		(value "YYYY-MM-DD/YYYY-DOY")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "(-)?[0-9]{4}" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12186,15 +12222,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "(-)?[0-9]{4}" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12207,10 +12238,15 @@
 ;+		(value "YYYY-DOY")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "(-)?[0-9]{4}(Z?)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(Z?)")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12224,15 +12260,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "(-)?[0-9]{4}(Z?)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(Z?)")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12245,10 +12276,20 @@
 ;+		(value "YYYY-MM-DDTHH:MM:SS.SSS(Z)/YYYY-DOYTHH:MM:SS.SSS(Z)")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "(-)?[0-9]{4}" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)?" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:(([0-5][0-9])|60)(\\.([0-9]{1,4}))?(Z)?" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)(([0-1][0-9])|(2[0-4]))(Z)?" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)24:00((:00((\\.0+)?))?)(Z)?" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)?" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:(([0-5][0-9])|60)(\\.([0-9]{1,4}))?(Z)?" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)(([0-1][0-9])|(2[0-4]))(Z)?" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)24:00((:00((\\.0+)?))?)(Z)?")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12262,25 +12303,15 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "(-)?[0-9]{4}" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)?" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:(([0-5][0-9])|60)(\\.([0-9]{1,4}))?(Z)?" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)(([0-1][0-9])|(2[0-4]))(Z)?" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)24:00((:00((\\.0+)?))?)(Z)?" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)?" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:(([0-5][0-9])|60)(\\.([0-9]{1,4}))?(Z)?" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)(([0-1][0-9])|(2[0-4]))(Z)?" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)24:00((:00((\\.0+)?))?)(Z)?")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12293,10 +12324,20 @@
 ;+		(value "YYYY-DOYTHH:MM:SS.SSSSSS(Z)")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "(-)?[0-9]{4}(Z?)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(Z?)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(1981|1982|1983|1985|1993|1994|1997|2015)-181T23:59:60(\\.[0-9]+)?(Z?)" "(1972|1992|2012)-182T23:59:60(\\.[0-9]+)?(Z?)" "(1971|1973|1974|1975|1977|1978|1979|1987|1989|1990|1995|1998|2005)-365T23:59:60(\\.[0-9]+)?(Z?)" "(1972|1976|2008|2016)-366T23:59:60(\\.[0-9]+)?(Z?)")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12310,25 +12351,15 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "(-)?[0-9]{4}(Z?)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(Z?)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(1981|1982|1983|1985|1993|1994|1997|2015)-181T23:59:60(\\.[0-9]+)?(Z?)" "(1972|1992|2012)-182T23:59:60(\\.[0-9]+)?(Z?)" "(1971|1973|1974|1975|1977|1978|1979|1987|1989|1990|1995|1998|2005)-365T23:59:60(\\.[0-9]+)?(Z?)" "(1972|1976|2008|2016)-366T23:59:60(\\.[0-9]+)?(Z?)")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12341,10 +12372,20 @@
 ;+		(value "YYYY-MM-DDTHH:MM:SS.SSSSSS(Z)")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "(-)?[0-9]{4}(Z?)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))(Z?)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(Z?)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(Z?)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(Z?)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "((1971|1972|1973|1974|1975|1976|1977|1978|1979|1987|1989|1990|1995|1998|2005|2008|2016)-12-31T23:59:60(\\.[0-9]+)?(Z?)|(1972|1981|1982|1983|1985|1992|1993|1994|1997|2012|2015)-06-30T23:59:60(\\.[0-9]+)?(Z?))")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12358,25 +12399,15 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "(-)?[0-9]{4}(Z?)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))(Z?)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(Z?)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(Z?)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(Z?)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(T)(([0-1][0-9])|(2[0-3]))(Z?)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "((1971|1972|1973|1974|1975|1976|1977|1978|1979|1987|1989|1990|1995|1998|2005|2008|2016)-12-31T23:59:60(\\.[0-9]+)?(Z?)|(1972|1981|1982|1983|1985|1992|1993|1994|1997|2012|2015)-06-30T23:59:60(\\.[0-9]+)?(Z?))")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12389,10 +12420,20 @@
 ;+		(value "YYYY-MM-DDTHH:MM:SS.SSSZ/YYYY-DOYTHH:MM:SS.SSSZ")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "(-)?[0-9]{4}(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:(([0-5][0-9])|60)(\\.([0-9]{1,4}))?(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)(([0-1][0-9])|(2[0-4]))(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)24:00((:00((\\.0+)?))?)(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))(Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:(([0-5][0-9])|60)(\\.([0-9]{1,4}))?(Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)(([0-1][0-9])|(2[0-4]))(Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)24:00((:00((\\.0+)?))?)(Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(Z)")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12406,25 +12447,15 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "(-)?[0-9]{4}(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:(([0-5][0-9])|60)(\\.([0-9]{1,4}))?(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)(([0-1][0-9])|(2[0-4]))(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(T)24:00((:00((\\.0+)?))?)(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-6]))))(Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))(Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:(([0-5][0-9])|60)(\\.([0-9]{1,4}))?(Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)(([0-1][0-9])|(2[0-4]))(Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(T)24:00((:00((\\.0+)?))?)(Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))-((0[1-9])|([1-2][0-9])|(3[0-1]))(Z)")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12437,10 +12468,15 @@
 ;+		(value "YYYY-MM-DD")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "(-)?[0-9]{4}(Z?)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))(Z?)" "((-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))|(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))|(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31))))(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(Z?)")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12454,15 +12490,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "(-)?[0-9]{4}(Z?)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))(Z?)" "((-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))|(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))|(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31))))(Z?)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(Z?)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(Z?)")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12475,10 +12506,10 @@
 ;+		(value "dir1/dir2/")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:token")
+;+		(value "255")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12493,10 +12524,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "255")
+;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12509,10 +12540,10 @@
 ;+		(value "file_name.file_extension")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:token")
+;+		(value "255")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12527,10 +12558,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "255")
+;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12543,10 +12574,15 @@
 ;+		(value "10.ssss/sss")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "10\\.\\S+/\\S+")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12560,15 +12596,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "10\\.\\S+/\\S+")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -12581,10 +12612,10 @@
 ;+		(value "dir1/dir2/file_name.file_extension")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:token")
+;+		(value "255")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12599,20 +12630,25 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "255")
+;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass ASCII_Integer "The ASCII_Integer class indicates an integer."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:long")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
+;+		(value "9223372036854775807")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12625,15 +12661,10 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "9223372036854775807")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
+;+		(value "xsd:long")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
@@ -12652,10 +12683,16 @@
 ;+		(value "0123456789abcdef")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "[0-9a-fA-F]{32}")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "32")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12670,35 +12707,24 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "32")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "[0-9a-fA-F]{32}")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass ASCII_NonNegative_Integer "The ASCII_NonNegative_Integer class indicates a non-negative  integer."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:unsignedLong")
+;+		(value "[0-9]+")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot character_constraint
-;+		(comment "The character_constraint attribute limits the characters allowed.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12708,9 +12734,20 @@
 ;+		(value "18446744073709551615")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot character_constraint
+;+		(comment "The character_constraint attribute limits the characters allowed.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+		(type STRING)
+;+		(value "xsd:unsignedLong")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
@@ -12718,21 +12755,25 @@
 		(type STRING)
 ;+		(value "0")
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "[0-9]+")
-;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass ASCII_Numeric_Base16 "The ASCII Numeric Base16 class indicates an ASCII character representation of a non-negative unsigned integer in base 16. Must consist of the characters 0 through 9, and A through F or a through f. May not be preceded by any sign (+/-) notation."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:hexBinary")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "255")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12746,24 +12787,14 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "255")
+;+		(value "xsd:hexBinary")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
@@ -12771,22 +12802,16 @@
 (defclass ASCII_Numeric_Base2 "The ASCII Numeric Base2 class indicates an ASCII character representation of a non-negative unsigned integer in base 2. Must consist of the characters 0 and 1. May not be preceded by any sign (+/-) notation."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "[0-1]{1,255}")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot character_constraint
-;+		(comment "The character_constraint attribute limits the characters allowed.")
-		(type STRING)
-;+		(value "ASCII")
+;+		(value "255")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_value
@@ -12794,31 +12819,43 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "255")
+;+		(value "1")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot character_constraint
+;+		(comment "The character_constraint attribute limits the characters allowed.")
+		(type STRING)
+;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+		(type STRING)
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "[0-1]{1,255}")
-;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass ASCII_Numeric_Base8 "The ASCII Numeric Base8 class indicates an ASCII character representation of a non-negative unsigned integer in base 8. Must consist of the characters 0 through 7. May not be preceded by any sign (+/-) notation."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "[0-7]{1,255}")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "255")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12833,35 +12870,24 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "255")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "[0-7]{1,255}")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass ASCII_Real "The ASCII_Real class indicates a real."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:double")
+;+		(value "(\\+|-)?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)([Ee](\\+|-)?[0-9]+)?" "[^aFIN,]* ")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot character_constraint
-;+		(comment "The character_constraint attribute limits the characters allowed.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
@@ -12871,9 +12897,20 @@
 ;+		(value "1.7976931348623157e308")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot character_constraint
+;+		(comment "The character_constraint attribute limits the characters allowed.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+		(type STRING)
+;+		(value "xsd:double")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
@@ -12881,21 +12918,20 @@
 		(type STRING)
 ;+		(value "-1.7976931348623157e308")
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "(\\+|-)?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)([Ee](\\+|-)?[0-9]+)?" "[^aFIN,]* ")
-;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass ASCII_Short_String_Collapsed "The ASCII_Short_String_Collapsed class indicates a limited length, whitespace-collapsed string."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:token")
+;+		(value "255")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12910,15 +12946,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "255")
+;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
@@ -12930,10 +12961,15 @@
 (defclass ASCII_Short_String_Preserved "The ASCII_Short_String_Preserved class indicates a limited length, whitespace-preserved string."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "255")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12948,15 +12984,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "255")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
@@ -12968,10 +12999,9 @@
 (defclass ASCII_Text_Collapsed "The ASCII_Text_Collapsed class indicates an unlimited length, whitespace-collapsed text string."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -12986,31 +13016,19 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
+;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass ASCII_Text_Preserved "The ASCII_Text_Preserved class indicates an unlimited length, whitespace-preserved text string."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:string")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot minimum_characters
-;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "1")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot character_constraint
-;+		(comment "The character_constraint attribute limits the characters allowed.")
-		(type STRING)
-;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot maximum_value
@@ -13018,9 +13036,22 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot minimum_characters
+;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
+;+		(value "1")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot character_constraint
+;+		(comment "The character_constraint attribute limits the characters allowed.")
+		(type STRING)
+;+		(value "ASCII")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+		(type STRING)
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
@@ -13038,10 +13069,20 @@
 ;+		(value "HH:MM:SS.SSS")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "(([0-1][0-9])|(2[0-3]))(Z?)" "(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(23):[0-5][0-9]:(([0-5][0-9])|60)((\\.[0-9]+))?(Z?)")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -13055,25 +13096,15 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "(([0-1][0-9])|(2[0-3]))(Z?)" "(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z?)" "(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z?)" "(23):[0-5][0-9]:(([0-5][0-9])|60)((\\.[0-9]+))?(Z?)")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -13086,10 +13117,21 @@
 ;+		(value "M.n")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "0\\.([1-9]|([0-9][0-9]+))" "[1-9][0-9]*" "[1-9][0-9]*\\.[0-9]+")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "100")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -13104,36 +13146,30 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "100")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "0\\.([1-9]|([0-9][0-9]+))" "[1-9][0-9]*" "[1-9][0-9]*\\.[0-9]+")
-;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass UTF8_Short_String_Collapsed "The UTF8_Short_String_Collapsed class indicates a limited length, whitespace-collapsed string constrained to the UTF-8 character encoding."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:token")
+;+		(value "255")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -13147,15 +13183,10 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "255")
+;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
@@ -13167,10 +13198,15 @@
 (defclass UTF8_Short_String_Preserved "The UTF8_Short_String_Preserved class indicates a limited length, whitespace-preserved string constrained to the UTF-8 character encoding."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "255")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -13184,15 +13220,10 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "255")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
@@ -13204,10 +13235,14 @@
 (defclass UTF8_Text_Preserved "The UTF8_Text_Preserved class indicates an unlimited length, whitespace-preserved text string constrained to the UTF-8 character encoding."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -13221,14 +13256,10 @@
 		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
@@ -13240,12 +13271,6 @@
 (defclass ASCII_String "The ASCII_String class indicates a limited length ASCII text string with whitespaces removed."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
-		(type STRING)
-;+		(value "xsd:token")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot minimum_characters
 ;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
@@ -13257,21 +13282,27 @@
 		(type STRING)
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
-		(create-accessor read-write)))
-
-(defclass UTF8_String "The UTF8_String class indicates a limited length UTF8 text string with whitespaces removed."
-	(is-a Character_Data_Type)
-	(role concrete)
+		(create-accessor read-write))
 	(single-slot xml_schema_base_type
 ;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
 ;+		(value "xsd:token")
 ;+		(cardinality 1 1)
-		(create-accessor read-write))
+		(create-accessor read-write)))
+
+(defclass UTF8_String "The UTF8_String class indicates a limited length UTF8 text string with whitespaces removed."
+	(is-a Character_Data_Type)
+	(role concrete)
 	(single-slot minimum_characters
 ;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "1")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+		(type STRING)
+;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -13284,10 +13315,10 @@
 ;+		(value "YYYY-MM-DDTHH:MM:SS.SSSSSSZ")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "(-)?[0-9]{4}(Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))(Z)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(Z)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(Z)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(Z)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "((1971|1972|1973|1974|1975|1976|1977|1978|1979|1987|1989|1990|1995|1998|2005|2008|2016)-12-31T23:59:60(\\.[0-9]+)?(Z)|(1972|1981|1982|1983|1985|1992|1993|1994|1997|2012|2015)-06-30T23:59:60(\\.[0-9]+)?(Z))")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -13296,10 +13327,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "(-)?[0-9]{4}(Z)" "(-)?[0-9]{4}-((0[1-9])|(1[0-2]))(Z)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(Z)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(Z)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(Z)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?[0-9]{4}-(02-((0[1-9])|(1[0-9])|(2[0-8])))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(-)?[0-9]{4}-((04|06|09|11)-((0[1-9])|([1-2][0-9])|30))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(-)?[0-9]{4}-((01|03|05|07|08|10|12)-((0[1-9])|([1-2][0-9])|(30|31)))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)-02-29)(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-02-29(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "((1971|1972|1973|1974|1975|1976|1977|1978|1979|1987|1989|1990|1995|1998|2005|2008|2016)-12-31T23:59:60(\\.[0-9]+)?(Z)|(1972|1981|1982|1983|1985|1992|1993|1994|1997|2012|2015)-06-30T23:59:60(\\.[0-9]+)?(Z))")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -13312,10 +13343,10 @@
 ;+		(value "YYYY-DOYTHH:MM:SS.SSSSSSZ")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "(-)?[0-9]{4}(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(1981|1982|1983|1985|1993|1994|1997|2015)-181T23:59:60(\\.[0-9]+)?(Z)" "(1972|1992|2012)-182T23:59:60(\\.[0-9]+)?(Z)" "(1971|1973|1974|1975|1977|1978|1979|1987|1989|1990|1995|1998|2005)-365T23:59:60(\\.[0-9]+)?(Z)" "(1972|1976|2008|2016)-366T23:59:60(\\.[0-9]+)?(Z)")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -13324,20 +13355,20 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "(-)?[0-9]{4}(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?[0-9]{4}-((00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3(([0-5][0-9])|(6[0-5]))))(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?([0-9]{2}(04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96))-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(T)(([0-1][0-9])|(2[0-3]))(Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9](Z)" "(-)?(00|04|08|12|16|20|24|28|32|36|40|44|48|52|56|60|64|68|72|76|80|84|88|92|96)00-366(T)(([0-1][0-9])|(2[0-3])):[0-5][0-9]:([0-5][0-9])(\\.([0-9]+))?(Z)" "(1981|1982|1983|1985|1993|1994|1997|2015)-181T23:59:60(\\.[0-9]+)?(Z)" "(1972|1992|2012)-182T23:59:60(\\.[0-9]+)?(Z)" "(1971|1973|1974|1975|1977|1978|1979|1987|1989|1990|1995|1998|2005)-365T23:59:60(\\.[0-9]+)?(Z)" "(1972|1976|2008|2016)-366T23:59:60(\\.[0-9]+)?(Z)")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass ASCII_Local_Identifier "The ASCII Local Identifier class indicates a unique identifier local to the label."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:ID")
+;+		(value "255")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -13352,20 +13383,20 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "255")
+;+		(value "xsd:ID")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass ASCII_Local_Identifier_Reference "The ASCII_Local_Identifier_Reference class indicates a reference to a unique identifier local to the label."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:IDREF")
+;+		(value "255")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -13380,10 +13411,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "255")
+;+		(value "xsd:IDREF")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -13396,10 +13427,10 @@
 ;+		(value "YYYYJJJJJVVVVMPPPPA")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "[0-9]{4}[A-Za-z0-9&\\.]{5}[A-Za-z0-9\\.]{9}[A-Z\\.]")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot character_constraint
@@ -13408,36 +13439,36 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "[0-9]{4}[A-Za-z0-9&\\.]{5}[A-Za-z0-9\\.]{9}[A-Z\\.]")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass UTF8_Text_Collapsed "The UTF8_Text_Collapsed class indicates an unlimited length, whitespace-collapsed text string constrained to the UTF-8 character encoding."
 	(is-a Character_Data_Type)
 	(role concrete)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
-		(type STRING)
-;+		(value "xsd:token")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
 	(single-slot minimum_characters
 ;+		(comment "The minimum_characters attribute provides the lower, inclusive bound on the number of characters.")
 		(type STRING)
 ;+		(value "1")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+		(type STRING)
+;+		(value "xsd:token")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
 (defclass ASCII_String_Base_255 "The ASCII_String_Base_255 class provides a base class for a 255 character ASCII string."
 	(is-a Character_Data_Type)
 	(role abstract)
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "255")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -13452,10 +13483,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "255")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -13468,10 +13499,21 @@
 ;+		(value "urn:xxx:yyy:zzzz")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "urn(:[\\p{Ll}\\p{Nd}\\-._]+){3,5}")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "255")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_value
+;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+		(type STRING)
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -13486,26 +13528,15 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_value
-;+		(comment "The maximum_value attribute provides the upper, inclusive bound on the value.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
-		(type STRING)
-;+		(value "255")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_value
 ;+		(comment "The minimum_value attribute provides the lower inclusive bound on the value.")
 		(type STRING)
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "urn(:[\\p{Ll}\\p{Nd}\\-._]+){3,5}")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -13518,10 +13549,16 @@
 ;+		(value "urn:xxx:yyy:zzzz::M.n")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "urn(:[\\p{Ll}\\p{Nd}\\-._]+){3,5}::\\p{Nd}+\\.\\p{Nd}+")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "255")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -13536,16 +13573,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "255")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "urn(:[\\p{Ll}\\p{Nd}\\-._]+){3,5}::\\p{Nd}+\\.\\p{Nd}+")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
@@ -13558,10 +13589,16 @@
 ;+		(value "urn:xxx:yyy:zzzz/urn:xxx:yyy:zzzz::M.n")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot xml_schema_base_type
-;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
+	(single-slot pattern
+;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
 		(type STRING)
-;+		(value "xsd:string")
+;+		(value "urn(:[\\p{Ll}\\p{Nd}\\-._]+){3,5}(::\\p{Nd}+\\.\\p{Nd}+)?")
+;+		(cardinality 1 1)
+		(create-accessor read-write))
+	(single-slot maximum_characters
+;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+		(type STRING)
+;+		(value "255")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
 	(single-slot minimum_characters
@@ -13576,16 +13613,10 @@
 ;+		(value "ASCII")
 ;+		(cardinality 1 1)
 		(create-accessor read-write))
-	(single-slot maximum_characters
-;+		(comment "The maximum_characters attribute provides the upper, inclusive bound on the number of characters.")
+	(single-slot xml_schema_base_type
+;+		(comment "The xml schema base type attribute provides the data type needed for the XML schema implementation.")
 		(type STRING)
-;+		(value "255")
-;+		(cardinality 1 1)
-		(create-accessor read-write))
-	(single-slot pattern
-;+		(comment "The pattern attribute provides a symbolic instruction for forming values.")
-		(type STRING)
-;+		(value "urn(:[\\p{Ll}\\p{Nd}\\-._]+){3,5}(::\\p{Nd}+\\.\\p{Nd}+)?")
+;+		(value "xsd:string")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 


### PR DESCRIPTION
CCB-336 Add a License_Information class to the Identification_Area 

Add an optional License_Information class to the Identification_Area

The resulting Product_Observational label template should look like the following


    <Identification_Area>
        <logical_identifier>urn:-:-:-</logical_identifier>
        <version_id>0.0</version_id>
        <title>title0</title>
        <information_model_version>information_model_version0</information_model_version>
        <product_class>product_class0</product_class>
				...
        <License_Information>
            <name>name0</name>
            <description>description2</description>
            <Internal_Reference>
                <lid_reference>urn:-:-:-</lid_reference>
                <reference_type>reference_type0</reference_type>
                <comment>comment1</comment>
            </Internal_Reference>
        </License_Information>
    </Identification_Area>
				
Resolves #679
Refs CCB-336