### PR TITLE
Updated Product_External LID Schematron rules as per CCB-357.

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMCSVFileClassHier.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMCSVFileClassHier.java
@@ -59,18 +59,20 @@ class WriteDOMCSVFileClassHier extends Object {
 	  // set up the output file
 	  String lFileName = lSchemaFileDefn.relativeFileSpecDDCSV;
 	  lFileName = lSchemaFileDefn.relativeFileSpecDDCSV + "_EIMSpreadSheet" ;
-//	  lFileName += ".csv";
 	  lFileName += ".txt";
 	  FileOutputStream lFileOutputStream = new FileOutputStream(lFileName);
 	  BufferedWriter prCSVAttr =
 			  new BufferedWriter(new OutputStreamWriter(lFileOutputStream, "UTF8"));
-	  System.out.println("\ndebug WriteDOMCSVFileEIMSpreadSheet selectedClasses:" + selectedUpperLevelClasses);
+	  prCSVAttr.write("Class Name" + "	" + "Class Definition" + "	" + "Attribute Name" + "	" + "Attribute Definition" + "	" + "Attribute Value" + "	" + "Value Meaning");
+	  prCSVAttr.newLine();
     
 	  // get the selected classes
 	  for (DOMClass selectedInputClass : inputClassArr) {
 		  if ((selectedInputClass.isInactive || selectedInputClass.isUSERClass || selectedInputClass.isUnitOfMeasure || selectedInputClass.isDataType || selectedInputClass.isVacuous)) continue;
 		  if (selectedInputClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue;
 		  if (! selectedUpperLevelClasses.contains(selectedInputClass.title)) continue;
+		  prCSVAttr.write(selectedInputClass.title + "	" + selectedInputClass.definition);
+		  prCSVAttr.newLine();
 		  
 		  // *** get all components of the selected class ***
 		  getAllComponentClasses(selectedInputClass, 1);

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Thu Aug 31 16:30:18 EDT 2023
+; Thu Oct 05 14:38:16 EDT 2023
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -158,7 +158,7 @@
 	(isMissionOnly "false")
 	(roleId "TBD_roleId")
 	(type "TBD_type")
-	(xpath "/*[not(contains(name(), 'Ingest') or contains(name(), 'Bundle') or contains(name(), 'Collection'))]/pds:Identification_Area/pds:logical_identifier"))
+	(xpath "/*[not(contains(name(), 'External') or contains(name(), 'Ingest') or contains(name(), 'Bundle') or contains(name(), 'Collection'))]/pds:Identification_Area/pds:logical_identifier"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3A%2FProduct_Observational%2Fpds%3AIdentification_Area%2Fpds%3Alogical_identifier.100002512.101] of  Schematron_Assert
 
@@ -168,6 +168,41 @@
 	(attrTitle "logical_identifier")
 	(identifier "logical_identifier")
 	(specMesg "pds:logical_identifier must have the form \"urn:agencyId:authorityId:bundleID:collectionID:productID\""))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3A%2FProduct_Observational%2Fpds%3AIdentification_Area%2Fpds%3Alogical_identifier.100002513] of  Schematron_Rule
+
+	(alwaysInclude "true")
+	(attrNameSpaceNC "pds")
+	(attrTitle "logical_identifier")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Identification_Area")
+	(has_Schematron_Assert
+		[http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3A%2FProduct_Observational%2Fpds%3AIdentification_Area%2Fpds%3Alogical_identifier.100002513.101]
+		[http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3A%2FProduct_Observational%2Fpds%3AIdentification_Area%2Fpds%3Alogical_identifier.100002513.102])
+	(identifier "pds:/Product_Observational/pds:Identification_Area/pds:logical_identifier_external")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "/*[contains(name(), 'External')]/pds:Identification_Area/pds:logical_identifier"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3A%2FProduct_Observational%2Fpds%3AIdentification_Area%2Fpds%3Alogical_identifier.100002513.101] of  Schematron_Assert
+
+	(assertMsg "pds:logical_identifier must have the form \"urn:agencyId:authorityId:productID...\"/>).")
+	(assertStmt "string-length(.) - string-length(translate(., ':', '')) lt 4")
+	(assertType "RAW")
+	(attrTitle "logical_identifier")
+	(identifier "logical_identifier")
+	(specMesg "pds:logical_identifier must have the form \"urn:agencyId:authorityId:productID...\"/>)."))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3A%2FProduct_Observational%2Fpds%3AIdentification_Area%2Fpds%3Alogical_identifier.100002513.102] of  Schematron_Assert
+
+	(assertMsg "The parent-value of the attribute logical_identifier must start with 'urn:'/>.")
+	(assertStmt "starts-with(., 'urn:')")
+	(assertType "RAW")
+	(attrTitle "logical_identifier")
+	(identifier "logical_identifier")
+	(specMesg "The parent-value of the attribute logical_identifier must start with 'urn:'/>."))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AArray.100004548] of  Schematron_Rule
 
@@ -930,7 +965,8 @@
 		"name=\"urn_esa\" value=\"'urn:esa:psa:'\""
 		"name=\"urn_ros\" value=\"'urn:ros:rssa:'\""
 		"name=\"urn_jaxa\" value=\"'urn:jaxa:darts:'\""
-		"name=\"urn_isro\" value=\"'urn:isro:isda:'\"")
+		"name=\"urn_isro\" value=\"'urn:isro:isda:'\""
+		"name=\"parentObj\" value=\"local-name(/*) = 'Product_External'\"")
 	(type "TBD_type")
 	(xpath "pds:Identification_Area"))
 
@@ -954,12 +990,12 @@
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AIdentification_Area.100002521.103] of  Schematron_Assert
 
-	(assertMsg "The value of the attribute logical_identifier must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/>")
-	(assertStmt "if (pds:logical_identifier) then starts-with(pds:logical_identifier, $urn_nasa) or starts-with(pds:logical_identifier, $urn_esa) or starts-with(pds:logical_identifier, $urn_jaxa) or starts-with(pds:logical_identifier, $urn_ros) or starts-with(pds:logical_identifier, $urn_isro) else true()")
+	(assertMsg "The parent-value of the attribute logical_identifier must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/>")
+	(assertStmt "if (not ($parentObj) and pds:logical_identifier) then starts-with(pds:logical_identifier, $urn_nasa) or starts-with(pds:logical_identifier, $urn_esa) or starts-with(pds:logical_identifier, $urn_jaxa) or starts-with(pds:logical_identifier, $urn_ros) or starts-with(pds:logical_identifier, $urn_isro) else true()")
 	(assertType "RAW")
 	(attrTitle "logical_identifier")
 	(identifier "logical_identifier")
-	(specMesg "The value of the attribute logical_identifier must start with either: 'urn:nasa:pds:', 'urn:esa:psa:', 'urn:jaxa:darts:', 'urn:ros:rssa:', or 'urn:isro:isda:'."))
+	(specMesg "The parent-value of the attribute logical_identifier must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/>"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AIdentification_Area.100002521.104] of  Schematron_Assert
 

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Thu Aug 31 16:30:18 EDT 2023
+; Thu Oct 05 14:38:16 EDT 2023
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")


### PR DESCRIPTION
Issue #698  CCB-357: Create Product_External - LID Schematron Rule Update
				
Updated Product_External LID Schematron rules and asserts as per CCB-357. 
Any Product_External LID must validate against "urn:xxx:yyy:zzz" where xxx, yyy, and zzz are any identifying terms. Four terms are required.

Resolves #698
Refs CCB-357

Testing: The released PDS4_PDS_1L00.sch file should contain the three schematron rules pasted in below.
@rsjoyner can provide test cases.

  <sch:pattern>
    <sch:rule context="pds:Identification_Area">
      <sch:let name="urn_nasa" value="'urn:nasa:pds:'"/>
      <sch:let name="urn_esa" value="'urn:esa:psa:'"/>
      <sch:let name="urn_ros" value="'urn:ros:rssa:'"/>
      <sch:let name="urn_jaxa" value="'urn:jaxa:darts:'"/>
      <sch:let name="urn_isro" value="'urn:isro:isda:'"/>
      <sch:let name="parentObj" value="local-name(/*) = 'Product_External'"/>

      <sch:assert test="pds:product_class = local-name(/*)">
        <title>pds:Identification_Area/logical_identifier</title>
        The attribute pds:product_class must match parent product class of '<sch:value-of select="local-name(/*)" />'.</sch:assert>

      <sch:assert test="pds:logical_identifier eq lower-case(pds:logical_identifier)">
        <title>pds:Identification_Area/logical_identifier</title>
        The value of the attribute logical_identifier must only contain lower-case letters</sch:assert>

      <sch:assert test="if (not ($parentObj) and pds:logical_identifier) then starts-with(pds:logical_identifier, $urn_nasa) or starts-with(pds:logical_identifier, $urn_esa) or starts-with(pds:logical_identifier, $urn_jaxa) or starts-with(pds:logical_identifier, $urn_ros) or starts-with(pds:logical_identifier, $urn_isro) else true()">
        <title>pds:Identification_Area/logical_identifier</title>
        The parent-value of the attribute logical_identifier must start with either: <sch:value-of select="$urn_nasa"/> or <sch:value-of select="$urn_esa"/> or <sch:value-of select="$urn_jaxa"/> or <sch:value-of select="$urn_ros"/> or <sch:value-of select="$urn_isro"/></sch:assert>

      <sch:assert test="if (pds:logical_identifier) then not(contains(pds:logical_identifier,'::')) else true()">
        <title>pds:Identification_Area/logical_identifier</title>
        The value of the attribute logical_identifier must not include a value that contains '::'</sch:assert>
    </sch:rule>
  </sch:pattern>
  
  <sch:pattern>
    <sch:rule context="/*[not(contains(name(), 'External') or contains(name(), 'Ingest') or contains(name(), 'Bundle') or contains(name(), 'Collection'))]/pds:Identification_Area/pds:logical_identifier">
      <sch:assert test="string-length(.) - string-length(translate(., ':', '')) eq 5">
        <title>pds:/Product_Observational/pds:Identification_Area/pds:logical_identifier/logical_identifier</title>
        pds:logical_identifier must have the form "urn:agencyId:authorityId:bundleID:collectionID:productID"/>).</sch:assert>
    </sch:rule>
  </sch:pattern>

  <sch:pattern>
    <sch:rule context="/*[contains(name(), 'External')]/pds:Identification_Area/pds:logical_identifier">
      <sch:assert test="string-length(.) - string-length(translate(., ':', '')) lt 4">
        <title>pds:/Product_Observational/pds:Identification_Area/pds:logical_identifier_external/logical_identifier</title>
        pds:logical_identifier must have the form "urn:agencyId:authorityId:productID..."/>).</sch:assert>
      <sch:assert test="starts-with(., 'urn:')">
        <title>pds:/Product_Observational/pds:Identification_Area/pds:logical_identifier_external/logical_identifier</title>
        The parent-value of the attribute logical_identifier must start with 'urn:'/>.</sch:assert>
    </sch:rule>
  </sch:pattern>



