### PR TITLE
IMTool Refactoring Phase 6 - use Protege dd11179.pins for class disposition

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -162,10 +162,10 @@ public class DMDocument extends Object {
 
   // 555 static boolean overWriteClass = true; // use dd11179.pins class disp, isDeprecated, and
   // versionId to overwrite Master DOMClasses, DOMAttrs, and DOMPermvalues
-  static boolean overWriteClass = false; // use dd11179.pins class disp, isDeprecated, and versionId
+  static boolean overWriteClass = true; // use dd11179.pins class disp, isDeprecated, and versionId
                                          // to overwrite Master DOMClasses, DOMAttrs, and
                                          // DOMPermvalues
-  static boolean useMDPTNConfig = true; // ProtPontDOMModel; get disposition for the class from
+  static boolean useMDPTNConfig = false; // ProtPontDOMModel; get disposition for the class from
                                         // MDPTNConfigClassDisp
   static boolean overWriteDeprecated = false; // use dd11179.pins isDeprecated to overwrite
                                               // DMDocument.deprecatedObjects2

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -201,7 +201,7 @@ public class DMDocument extends Object {
   static boolean LDDToolFlag;
 
   // misc flags
-  static boolean debugFlag = true;
+  static boolean debugFlag = false;
 
   // in an LDDTool run, when true indicates that a mission LDD is being processed
   // this flag was deprecated with the addition of <dictionary_type> to Ingest_LDD IM V1E00

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -201,7 +201,7 @@ public class DMDocument extends Object {
   static boolean LDDToolFlag;
 
   // misc flags
-  static boolean debugFlag = false;
+  static boolean debugFlag = true;
 
   // in an LDDTool run, when true indicates that a mission LDD is being processed
   // this flag was deprecated with the addition of <dictionary_type> to Ingest_LDD IM V1E00

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMClass.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMClass.java
@@ -291,7 +291,6 @@ public class DOMClass extends ISOClassOAIS11179 {
     return lISOArr;
   }
   
-  // 555
   // set the Class and owned Properties, Attributes, and the PermissibleValue isInactive flags
   void setIsInactive(Boolean lIsInactive) {
 	  

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMClass.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMClass.java
@@ -290,4 +290,33 @@ public class DOMClass extends ISOClassOAIS11179 {
     ArrayList<DOMProp> lISOArr = new ArrayList<>(lISOMap.values());
     return lISOArr;
   }
+  
+  // 555
+  // set the Class and owned Properties, Attributes, and the PermissibleValue isInactive flags
+  void setIsInactive(Boolean lIsInactive) {
+	  
+	  // set the class inactive
+	  this.isInactive = lIsInactive;
+		  
+	  // iterate through the owned attributes - via their properties
+      for (DOMProp lDOMProp : ownedAttrArr) {
+    	  lDOMProp.isInactive = lIsInactive;
+    	  if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMAttr) {
+    		  DOMAttr lDOMAttr = (DOMAttr) lDOMProp.hasDOMObject;
+    		  lDOMAttr.isInactive = lIsInactive;
+    		  
+    		  // iterate through the permissible values - via their properties
+    		  for (DOMProp lDOMProp2 : lDOMAttr.domPermValueArr) {
+    			  if (lDOMProp2.hasDOMObject != null && lDOMProp2.hasDOMObject instanceof DOMPermValDefn) {
+    				  DOMPermValDefn lDOMPermVal = (DOMPermValDefn) lDOMProp2.hasDOMObject;
+    				  lDOMPermVal.isInactive = lIsInactive;
+    			  }
+    		  }
+    	  }
+      }
+      // interate through the owned associations - ignore the classes since they are already set
+      for (DOMProp lDOMProp : ownedAssocArr) {
+        lDOMProp.isInactive = lIsInactive;
+      }
+  }
 }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -73,12 +73,6 @@ public class GetDOMModel extends Object {
     ArrayList<DOMClass> lClassArr = new ArrayList<>(DOMInfoModel.parsedClassMap.values());
     for (Iterator<DOMClass> i = lClassArr.iterator(); i.hasNext();) {
       DOMClass lClass = i.next();
-      
-// 555
-//      if (!lClass.isMasterClass) {
-//        continue;
-//      }
-      
       if (!DOMInfoModel.masterDOMClassMap.containsKey(lClass.rdfIdentifier)) {
         DOMInfoModel.masterDOMClassMap.put(lClass.rdfIdentifier, lClass);
       } else {
@@ -135,11 +129,8 @@ public class GetDOMModel extends Object {
               DOMInfoModel.masterDOMAttrMap.put(lDOMAttr.rdfIdentifier, lDOMAttr);
               lDOMProp.hasDOMObject = lDOMAttr;
               lDOMAttr.hasDOMPropInverse = lDOMProp;
-              
-// 555
               lDOMProp.isInactive = lClass.isInactive;
               lDOMAttr.isInactive = lClass.isInactive;
-
             } else {
               DMDocument.registerMessage(
                   "1>error " + "Duplicate Found - ADDING Attribute lDOMAttr.rdfIdentifier:"
@@ -174,7 +165,6 @@ public class GetDOMModel extends Object {
               lDOMProp.hasDOMObject = lDOMClass;
               lDOMClass.hasDOMPropInverse = lDOMProp;
               
-              // 5555
               lDOMProp.isInactive = lClass.isInactive;
               
             } else {
@@ -348,21 +338,11 @@ public class GetDOMModel extends Object {
 
     // 017b - overwrite master classes from the 11179 DD
     // - either import from JSON 11179 file or overwrite from 11179 dictionary
-    // Overwrite is needed to set classes and attribute defined in protege but not in JSON11179 ???
-
-// 555
-//  for (DOMClass lClass : DOMInfoModel.masterDOMClassArr) {
-//		System.out.println("identifier:" + lClass.identifier + "	used:" + lClass.used + "	isMasterClass:" + lClass.isMasterClass + "	isVacuous:" + lClass.isVacuous + "	isSchema1Class:" + lClass.isSchema1Class + "	isRegistryClass:" + lClass.isRegistryClass + "	isTDO:" + lClass.isTDO + "	isDataType:" + lClass.isDataType + "	isUnitOfMeasure:" + lClass.isUnitOfMeasure + "	section:" + lClass.section + "	nameSpaceIdNC:" + lClass.nameSpaceIdNC + "	steward:" + lClass.steward + "	-protege1-");
-//	}
+    // Overwrite is needed to set classes and attribute defined in protege but not in JSON11179
     
     if (!DMDocument.LDDToolFlag) {
       lISO11179DOMMDR.OverwriteClassFrom11179DataDict();
     }
-    
-// 555
-//  for (DOMClass lClass : DOMInfoModel.masterDOMClassArr) {
-//    System.out.println("identifier:" + lClass.identifier + "	used:" + lClass.used + "	isMasterClass:" + lClass.isMasterClass + "	isVacuous:" + lClass.isVacuous + "	isSchema1Class:" + lClass.isSchema1Class + "	isRegistryClass:" + lClass.isRegistryClass + "	isTDO:" + lClass.isTDO + "	isDataType:" + lClass.isDataType + "	isUnitOfMeasure:" + lClass.isUnitOfMeasure + "	section:" + lClass.section + "	nameSpaceIdNC:" + lClass.nameSpaceIdNC + "	steward:" + lClass.steward + "	-protege2-");
-//  }    
 
     // 018 - overwrite any LDD attributes from the cloned USER attributes
     // this is not really needed since the definitions are in the external class

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -39,45 +39,6 @@ import java.util.Set;
 public class GetDOMModel extends Object {
 
   ISO11179DOMMDR lISO11179DOMMDR;
-  
-  // 555
-  ArrayList <String> classInactiveIdentifierArr = new ArrayList <> (Arrays.asList(
-		  "0001_NASA_PDS_1.pds.Activity",
-		  "0001_NASA_PDS_1.pds.Agent",
-		  "0001_NASA_PDS_1.pds.Array_3D_Map",
-		  "0001_NASA_PDS_1.pds.Array_3D_Spectral_Map",
-		  "0001_NASA_PDS_1.pds.Array_3D_Spectral_Movie",
-		  "0001_NASA_PDS_1.pds.ChangeLog",
-		  "0001_NASA_PDS_1.pds.Config",
-		  "0001_NASA_PDS_1.pds.DD_Static_Permissible_Value",
-		  "0001_NASA_PDS_1.pds.Encoded_Telemetry",
-		  "0001_NASA_PDS_1.pds.Entity",
-		  "0001_NASA_PDS_1.pds.File_Area_Ingest_LDD",
-		  "0001_NASA_PDS_1.pds.File_Area_Telemetry",
-		  "0001_NASA_PDS_1.pds.Ingest_LDD_File",
-		  "0001_NASA_PDS_1.pds.Ingest_LDD_File_Desc",
-		  "0001_NASA_PDS_1.pds.Input_Data",
-		  "0001_NASA_PDS_1.pds.LIDVID_ID_Reference",
-		  "0001_NASA_PDS_1.pds.LIDVID_ID_Reference_From",
-		  "0001_NASA_PDS_1.pds.LIDVID_ID_Reference_To",
-		  "0001_NASA_PDS_1.pds.LID_ID_Reference",
-		  "0001_NASA_PDS_1.pds.LID_ID_Reference_From",
-		  "0001_NASA_PDS_1.pds.LID_ID_Reference_To",
-		  "0001_NASA_PDS_1.pds.Methods",
-		  "0001_NASA_PDS_1.pds.Output_Data",
-		  "0001_NASA_PDS_1.pds.Product_Ingest_LDD",
-		  "0001_NASA_PDS_1.pds.Product_Telemetry",
-		  "0001_NASA_PDS_1.pds.Product_Virtual",
-		  "0001_NASA_PDS_1.pds.Property_Map_External",
-		  "0001_NASA_PDS_1.pds.Schematron_Assert",
-		  "0001_NASA_PDS_1.pds.Schematron_Rule",
-		  "0001_NASA_PDS_1.pds.Tracking",
-		  "0001_NASA_PDS_1.pds.Tracking_Detail",
-		  "0001_NASA_PDS_1.pds.Virtual_Area",
-		  "0001_NASA_PDS_1.pds.Virtual_Reference",
-		  "0001_NASA_PDS_1.pds.Virtual_Relation",
-		  "0001_NASA_PDS_1.pds.Virtual_Structure",
-		  "0001_NASA_PDS_1.pds.XSChoice%23"));
 
   public GetDOMModel() {}
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -31,6 +31,7 @@
 package gov.nasa.pds.model.plugin;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Set;
@@ -38,6 +39,45 @@ import java.util.Set;
 public class GetDOMModel extends Object {
 
   ISO11179DOMMDR lISO11179DOMMDR;
+  
+  // 555
+  ArrayList <String> classInactiveIdentifierArr = new ArrayList <> (Arrays.asList(
+		  "0001_NASA_PDS_1.pds.Activity",
+		  "0001_NASA_PDS_1.pds.Agent",
+		  "0001_NASA_PDS_1.pds.Array_3D_Map",
+		  "0001_NASA_PDS_1.pds.Array_3D_Spectral_Map",
+		  "0001_NASA_PDS_1.pds.Array_3D_Spectral_Movie",
+		  "0001_NASA_PDS_1.pds.ChangeLog",
+		  "0001_NASA_PDS_1.pds.Config",
+		  "0001_NASA_PDS_1.pds.DD_Static_Permissible_Value",
+		  "0001_NASA_PDS_1.pds.Encoded_Telemetry",
+		  "0001_NASA_PDS_1.pds.Entity",
+		  "0001_NASA_PDS_1.pds.File_Area_Ingest_LDD",
+		  "0001_NASA_PDS_1.pds.File_Area_Telemetry",
+		  "0001_NASA_PDS_1.pds.Ingest_LDD_File",
+		  "0001_NASA_PDS_1.pds.Ingest_LDD_File_Desc",
+		  "0001_NASA_PDS_1.pds.Input_Data",
+		  "0001_NASA_PDS_1.pds.LIDVID_ID_Reference",
+		  "0001_NASA_PDS_1.pds.LIDVID_ID_Reference_From",
+		  "0001_NASA_PDS_1.pds.LIDVID_ID_Reference_To",
+		  "0001_NASA_PDS_1.pds.LID_ID_Reference",
+		  "0001_NASA_PDS_1.pds.LID_ID_Reference_From",
+		  "0001_NASA_PDS_1.pds.LID_ID_Reference_To",
+		  "0001_NASA_PDS_1.pds.Methods",
+		  "0001_NASA_PDS_1.pds.Output_Data",
+		  "0001_NASA_PDS_1.pds.Product_Ingest_LDD",
+		  "0001_NASA_PDS_1.pds.Product_Telemetry",
+		  "0001_NASA_PDS_1.pds.Product_Virtual",
+		  "0001_NASA_PDS_1.pds.Property_Map_External",
+		  "0001_NASA_PDS_1.pds.Schematron_Assert",
+		  "0001_NASA_PDS_1.pds.Schematron_Rule",
+		  "0001_NASA_PDS_1.pds.Tracking",
+		  "0001_NASA_PDS_1.pds.Tracking_Detail",
+		  "0001_NASA_PDS_1.pds.Virtual_Area",
+		  "0001_NASA_PDS_1.pds.Virtual_Reference",
+		  "0001_NASA_PDS_1.pds.Virtual_Relation",
+		  "0001_NASA_PDS_1.pds.Virtual_Structure",
+		  "0001_NASA_PDS_1.pds.XSChoice%23"));
 
   public GetDOMModel() {}
 
@@ -72,9 +112,12 @@ public class GetDOMModel extends Object {
     ArrayList<DOMClass> lClassArr = new ArrayList<>(DOMInfoModel.parsedClassMap.values());
     for (Iterator<DOMClass> i = lClassArr.iterator(); i.hasNext();) {
       DOMClass lClass = i.next();
-      if (!lClass.isMasterClass) {
-        continue;
-      }
+      
+// 555
+//      if (!lClass.isMasterClass) {
+//        continue;
+//      }
+      
       if (!DOMInfoModel.masterDOMClassMap.containsKey(lClass.rdfIdentifier)) {
         DOMInfoModel.masterDOMClassMap.put(lClass.rdfIdentifier, lClass);
       } else {
@@ -131,6 +174,11 @@ public class GetDOMModel extends Object {
               DOMInfoModel.masterDOMAttrMap.put(lDOMAttr.rdfIdentifier, lDOMAttr);
               lDOMProp.hasDOMObject = lDOMAttr;
               lDOMAttr.hasDOMPropInverse = lDOMProp;
+              
+// 555
+              lDOMProp.isInactive = lClass.isInactive;
+              lDOMAttr.isInactive = lClass.isInactive;
+
             } else {
               DMDocument.registerMessage(
                   "1>error " + "Duplicate Found - ADDING Attribute lDOMAttr.rdfIdentifier:"
@@ -164,6 +212,10 @@ public class GetDOMModel extends Object {
                 && DOMInfoModel.masterDOMClassMap.get(lDOMClass.rdfIdentifier) != null) {
               lDOMProp.hasDOMObject = lDOMClass;
               lDOMClass.hasDOMPropInverse = lDOMProp;
+              
+              // 5555
+              lDOMProp.isInactive = lClass.isInactive;
+              
             } else {
               DMDocument.registerMessage(
                   "1>error " + "Class not found - ADDING Class lDOMClass.rdfIdentifier:"
@@ -336,10 +388,20 @@ public class GetDOMModel extends Object {
     // 017b - overwrite master classes from the 11179 DD
     // - either import from JSON 11179 file or overwrite from 11179 dictionary
     // Overwrite is needed to set classes and attribute defined in protege but not in JSON11179 ???
-    // 555
+
+// 555
+//  for (DOMClass lClass : DOMInfoModel.masterDOMClassArr) {
+//		System.out.println("identifier:" + lClass.identifier + "	used:" + lClass.used + "	isMasterClass:" + lClass.isMasterClass + "	isVacuous:" + lClass.isVacuous + "	isSchema1Class:" + lClass.isSchema1Class + "	isRegistryClass:" + lClass.isRegistryClass + "	isTDO:" + lClass.isTDO + "	isDataType:" + lClass.isDataType + "	isUnitOfMeasure:" + lClass.isUnitOfMeasure + "	section:" + lClass.section + "	nameSpaceIdNC:" + lClass.nameSpaceIdNC + "	steward:" + lClass.steward + "	-protege1-");
+//	}
+    
     if (!DMDocument.LDDToolFlag) {
       lISO11179DOMMDR.OverwriteClassFrom11179DataDict();
     }
+    
+// 555
+//  for (DOMClass lClass : DOMInfoModel.masterDOMClassArr) {
+//    System.out.println("identifier:" + lClass.identifier + "	used:" + lClass.used + "	isMasterClass:" + lClass.isMasterClass + "	isVacuous:" + lClass.isVacuous + "	isSchema1Class:" + lClass.isSchema1Class + "	isRegistryClass:" + lClass.isRegistryClass + "	isTDO:" + lClass.isTDO + "	isDataType:" + lClass.isDataType + "	isUnitOfMeasure:" + lClass.isUnitOfMeasure + "	section:" + lClass.section + "	nameSpaceIdNC:" + lClass.nameSpaceIdNC + "	steward:" + lClass.steward + "	-protege2-");
+//  }    
 
     // 018 - overwrite any LDD attributes from the cloned USER attributes
     // this is not really needed since the definitions are in the external class

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISO11179DOMMDR.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISO11179DOMMDR.java
@@ -131,9 +131,14 @@ class ISO11179DOMMDR extends Object {
     // iterate through the master attribute array
     for (Iterator<DOMAttr> i = DOMInfoModel.masterDOMAttrArr.iterator(); i.hasNext();) {
       DOMAttr lAttr = i.next();
-      if (!lAttr.isAttribute || lAttr.isFromLDD) {
-        continue;
-      }
+      
+// 555
+      if (!lAttr.isAttribute || lAttr.isFromLDD || lAttr.isInactive) continue;
+      
+//      if (!lAttr.isAttribute || lAttr.isFromLDD) {
+//        continue;
+//      }
+      
       DOMClass lParentClass = lAttr.attrParentClass;
       if (lParentClass == null) {
         continue;
@@ -359,9 +364,14 @@ class ISO11179DOMMDR extends Object {
     // iterate through the master class array
     for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
       DOMClass lDOMClass = i.next();
-      if (lDOMClass.isFromLDD) {
-        continue;
-      }
+      
+// 555
+      if (lDOMClass.isInactive || lDOMClass.isFromLDD) continue;
+  
+//      if (lDOMClass.isFromLDD) {
+//        continue;
+//      }
+      
       lSuffix = DOMInfoModel.getClassIdentifier(lDOMClass.nameSpaceIdNC, lDOMClass.title);
       lInstId = "ObjectClass" + "." + "OC" + "." + lSuffix;
       InstDefn lOCInst = DOMInfoModel.master11179DataDict.get(lInstId);

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISO11179DOMMDR.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISO11179DOMMDR.java
@@ -131,14 +131,7 @@ class ISO11179DOMMDR extends Object {
     // iterate through the master attribute array
     for (Iterator<DOMAttr> i = DOMInfoModel.masterDOMAttrArr.iterator(); i.hasNext();) {
       DOMAttr lAttr = i.next();
-      
-// 555
       if (!lAttr.isAttribute || lAttr.isFromLDD || lAttr.isInactive) continue;
-      
-//      if (!lAttr.isAttribute || lAttr.isFromLDD) {
-//        continue;
-//      }
-      
       DOMClass lParentClass = lAttr.attrParentClass;
       if (lParentClass == null) {
         continue;
@@ -364,20 +357,14 @@ class ISO11179DOMMDR extends Object {
     // iterate through the master class array
     for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
       DOMClass lDOMClass = i.next();
-      
-// 555   
-//     earlier attribute and property classes are set from Class, so need yet another flag
-//      if (lDOMClass.isInactive || lDOMClass.isFromLDD) continue;
       if (lDOMClass.isFromLDD) continue;
-      
       lSuffix = DOMInfoModel.getClassIdentifier(lDOMClass.nameSpaceIdNC, lDOMClass.title);
       lInstId = "ObjectClass" + "." + "OC" + "." + lSuffix;
       InstDefn lOCInst = DOMInfoModel.master11179DataDict.get(lInstId);
       if (lOCInst != null) {
         lInstMap = lOCInst.genSlotMap;
         
-     // 555
-        // update isInactive
+        // set isInactive
         // *** ProtPontDOMModel - All .pont classes have isInactive = false during initial parse;
         // during overwrite from dd11179, if isInactive = true then set class.isInactive = true
         // note that some classes are defined in the .pont file (inactive) but not in dd11179
@@ -523,9 +510,7 @@ class ISO11179DOMMDR extends Object {
       } else {
     	  
     	  // the class does not exist in dd11179; set the class and its components to inactive
-    	  lDOMClass.setIsInactive(true);
-    	  
-// 555    	  
+    	  lDOMClass.setIsInactive(true); 	  
     	  if (lDOMClass.title.compareTo("USER") != 0) {
     		  DMDocument.registerMessage("1>error "
 // 555 change needed   		  DMDocument.registerMessage("1>warning "

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISO11179DOMMDR.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISO11179DOMMDR.java
@@ -365,18 +365,31 @@ class ISO11179DOMMDR extends Object {
     for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
       DOMClass lDOMClass = i.next();
       
-// 555
-      if (lDOMClass.isInactive || lDOMClass.isFromLDD) continue;
-  
-//      if (lDOMClass.isFromLDD) {
-//        continue;
-//      }
+// 555   
+//     earlier attribute and property classes are set from Class, so need yet another flag
+//      if (lDOMClass.isInactive || lDOMClass.isFromLDD) continue;
+      if (lDOMClass.isFromLDD) continue;
       
       lSuffix = DOMInfoModel.getClassIdentifier(lDOMClass.nameSpaceIdNC, lDOMClass.title);
       lInstId = "ObjectClass" + "." + "OC" + "." + lSuffix;
       InstDefn lOCInst = DOMInfoModel.master11179DataDict.get(lInstId);
       if (lOCInst != null) {
         lInstMap = lOCInst.genSlotMap;
+        
+     // 555
+        // update isInactive
+        // *** ProtPontDOMModel - All .pont classes have isInactive = false during initial parse;
+        // during overwrite from dd11179, if isInactive = true then set class.isInactive = true
+        // note that some classes are defined in the .pont file (inactive) but not in dd11179
+        lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "isInactive", "false");
+        if (lVal != null && lVal.compareTo("true") == 0) {
+          if (lDebugFlag) {
+            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
+                + " - updating Class.isInactive:" + lDOMClass.isInactive + "  - with lVal:"
+                + lVal);
+          }
+          lDOMClass.isInactive = true;
+        }        
 
         // update isDeprecated
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "isDeprecated", "false");
@@ -507,11 +520,17 @@ class ISO11179DOMMDR extends Object {
           lDOMClass.versionId = lVal;
         }
 
-      } else // DMDocument.registerMessage ("1>error " + "11179 data dictionary class is missing for
-             // overwrite - Identifier:" + lInstId);
-      if (lDOMClass.title.compareTo("USER") != 0) {
-        DMDocument.registerMessage("1>error "
-            + "11179 data dictionary class is missing for overwrite - Identifier:" + lInstId);
+      } else {
+    	  
+    	  // the class does not exist in dd11179; set the class and its components to inactive
+    	  lDOMClass.setIsInactive(true);
+    	  
+// 555    	  
+    	  if (lDOMClass.title.compareTo("USER") != 0) {
+    		  DMDocument.registerMessage("1>error "
+// 555 change needed   		  DMDocument.registerMessage("1>warning "
+    				  + "11179 data dictionary class is missing for overwrite - Identifier:" + lInstId);
+    	  }
       }
     }
   }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
@@ -1366,6 +1366,9 @@ class MasterDOMInfoModel extends DOMInfoModel {
   public void sethasAttributeOverride2(ArrayList<DOMAttr> lMasterDOMAttrArr) {
     TreeMap<String, DOMAttr> lSortAttrMap = new TreeMap<>();
     TreeMap<String, ArrayList<DOMAttr>> lTitleAttrsMap = new TreeMap<>();
+    
+	System.out.println("\n\ndebug MasterDOMInfoModel -sethasAttributeOverride2");
+
 
     // *** Need to add steward to partition attributes ***
 
@@ -1385,6 +1388,13 @@ class MasterDOMInfoModel extends DOMInfoModel {
     ArrayList<DOMAttr> lAttrArr = new ArrayList<>();
     for (Iterator<DOMAttr> i = lSortAttrArr.iterator(); i.hasNext();) {
       DOMAttr lAttr = i.next();
+      
+      if (lAttr.title.compareTo("archive_status_note") == 0) {
+			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr.identifier:" + lAttr.identifier);
+			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr.parentClassTitle:" + lAttr.parentClassTitle);
+			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr.title:" + lAttr.title);
+      }
+      
       if (lTitleArr.contains(lAttr.title)) {
         lAttrArr.add(lAttr);
       } else {
@@ -1406,6 +1416,12 @@ class MasterDOMInfoModel extends DOMInfoModel {
       boolean isFirst = true;
       for (Iterator<DOMAttr> i = lAttrArr2.iterator(); i.hasNext();) {
         DOMAttr lAttr1 = i.next();
+        
+        if (lAttr1.title.compareTo("archive_status_note") == 0) {
+  			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr1.identifier:" + lAttr1.identifier);
+  			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr1.parentClassTitle:" + lAttr1.parentClassTitle);
+  			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr1.title:" + lAttr1.title);
+        }
 
         // if this is the first attribute, it gets to use its own name
         if (isFirst) {
@@ -1417,6 +1433,12 @@ class MasterDOMInfoModel extends DOMInfoModel {
           boolean isEquivalentAll = true;
           for (Iterator<DOMAttr> j = lAttrArr2.iterator(); j.hasNext();) {
             DOMAttr lAttr2 = j.next();
+            
+            if (lAttr1.title.compareTo("archive_status_note") == 0) {
+      			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr2.identifier:" + lAttr2.identifier);
+      			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr2.parentClassTitle:" + lAttr2.parentClassTitle);
+      			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr2.title:" + lAttr2.title);
+            }            
 
             // omit checking an attribute against itself
             if (lAttr1.rdfIdentifier.compareTo(lAttr2.rdfIdentifier) == 0) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
@@ -1366,15 +1366,13 @@ class MasterDOMInfoModel extends DOMInfoModel {
   public void sethasAttributeOverride2(ArrayList<DOMAttr> lMasterDOMAttrArr) {
     TreeMap<String, DOMAttr> lSortAttrMap = new TreeMap<>();
     TreeMap<String, ArrayList<DOMAttr>> lTitleAttrsMap = new TreeMap<>();
-    
-	System.out.println("\n\ndebug MasterDOMInfoModel -sethasAttributeOverride2");
-
 
     // *** Need to add steward to partition attributes ***
 
     // put attributes in sorted order; attr.title_class.title
     for (Iterator<DOMAttr> i = lMasterDOMAttrArr.iterator(); i.hasNext();) {
       DOMAttr lAttr = i.next();
+      if (lAttr.isInactive) continue;
       if ((lAttr.XMLSchemaName.indexOf("TBD") == 0) && lAttr.isAttribute) {
         // all remaining attributes have overrides, i.e. different constraints than those in the
         // data type
@@ -1387,14 +1385,7 @@ class MasterDOMInfoModel extends DOMInfoModel {
     ArrayList<DOMAttr> lSortAttrArr = new ArrayList<>(lSortAttrMap.values());
     ArrayList<DOMAttr> lAttrArr = new ArrayList<>();
     for (Iterator<DOMAttr> i = lSortAttrArr.iterator(); i.hasNext();) {
-      DOMAttr lAttr = i.next();
-      
-      if (lAttr.title.compareTo("archive_status_note") == 0) {
-			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr.identifier:" + lAttr.identifier);
-			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr.parentClassTitle:" + lAttr.parentClassTitle);
-			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr.title:" + lAttr.title);
-      }
-      
+      DOMAttr lAttr = i.next();      
       if (lTitleArr.contains(lAttr.title)) {
         lAttrArr.add(lAttr);
       } else {
@@ -1411,17 +1402,11 @@ class MasterDOMInfoModel extends DOMInfoModel {
     while (iter1.hasNext()) {
       String lTitle = iter1.next();
       ArrayList<DOMAttr> lAttrArr2 = lTitleAttrsMap.get(lTitle);
-
+		
       // iterate through this attribute array
       boolean isFirst = true;
       for (Iterator<DOMAttr> i = lAttrArr2.iterator(); i.hasNext();) {
         DOMAttr lAttr1 = i.next();
-        
-        if (lAttr1.title.compareTo("archive_status_note") == 0) {
-  			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr1.identifier:" + lAttr1.identifier);
-  			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr1.parentClassTitle:" + lAttr1.parentClassTitle);
-  			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr1.title:" + lAttr1.title);
-        }
 
         // if this is the first attribute, it gets to use its own name
         if (isFirst) {
@@ -1432,13 +1417,7 @@ class MasterDOMInfoModel extends DOMInfoModel {
           // nested iteration through this attribute array to find the duplicates
           boolean isEquivalentAll = true;
           for (Iterator<DOMAttr> j = lAttrArr2.iterator(); j.hasNext();) {
-            DOMAttr lAttr2 = j.next();
-            
-            if (lAttr1.title.compareTo("archive_status_note") == 0) {
-      			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr2.identifier:" + lAttr2.identifier);
-      			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr2.parentClassTitle:" + lAttr2.parentClassTitle);
-      			System.out.println("debug MasterDOMInfoModel -sethasAttributeOverride2 - lAttr2.title:" + lAttr2.title);
-            }            
+            DOMAttr lAttr2 = j.next();            
 
             // omit checking an attribute against itself
             if (lAttr1.rdfIdentifier.compareTo(lAttr2.rdfIdentifier) == 0) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
@@ -126,11 +126,9 @@ class ProtPontDOMModel extends DOMInfoModel {
           // get disposition for the class from MDPTNConfig
           boolean isInParsedClassMap = false;
 
-// 555
           // get disposition for the class from dd11179
           if (DMDocument.overWriteClass && (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) != 0)) {
             lClass.getDOMClassDisposition2(); // from protege (new)
-            // 555
             lClass.isInactive = false; // could be reset in overwrite from dd11179
             parsedClassMap.put(lClass.rdfIdentifier, lClass);
             classNameSpaceIdNC = lClass.nameSpaceIdNC;  // set the namespace for the attributes

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
@@ -128,8 +128,10 @@ class ProtPontDOMModel extends DOMInfoModel {
 
 // 555
           // get disposition for the class from dd11179
-            if (DMDocument.overWriteClass && (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) != 0)) {
+          if (DMDocument.overWriteClass && (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) != 0)) {
             lClass.getDOMClassDisposition2(); // from protege (new)
+            // 555
+            lClass.isInactive = false; // could be reset in overwrite from dd11179
             parsedClassMap.put(lClass.rdfIdentifier, lClass);
             classNameSpaceIdNC = lClass.nameSpaceIdNC;  // set the namespace for the attributes
             String token1 = tokenIter.next();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
@@ -125,69 +125,19 @@ class ProtPontDOMModel extends DOMInfoModel {
 
           // get disposition for the class from MDPTNConfig
           boolean isInParsedClassMap = false;
-          if (DMDocument.useMDPTNConfig) {
-            classNameSpaceIdNC = "tbd";
-            lClass.getDOMClassDisposition(true);
-            if (lClass != null) {
-              if (lClass.used.compareTo("Y") == 0) {
-                classNameSpaceIdNC = lClass.nameSpaceIdNC; // global needed for parser
-                parsedClassMap.put(lClass.rdfIdentifier, lClass);
-                isInParsedClassMap = true;
-                String token1 = tokenIter.next();
-                if (token1.compareTo("(") != 0) {
-                  lClass.definition = DOMInfoModel.unEscapeProtegeString(token1);
-                }
-              } else if (lClass.used.compareTo("I") == 0) {
-                // class is "hidden" ignore it and do not print warning
 
-                // *** added ***
-                /*
-                 * if (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) == 0) continue; //
-                 * omit %3ACLIPS_TOP_LEVEL_SLOT_CLASS lClass.isInactive = true; classNameSpaceIdNC =
-                 * lClass.nameSpaceIdNC; // global needed for parser
-                 * parsedClassMap.put(lClass.rdfIdentifier, lClass); isInParsedClassMap = true;
-                 * String token1 = (String) tokenIter.next(); if (token1.compareTo("(") != 0) {
-                 * lClass.definition = DOMInfoModel.unEscapeProtegeString(token1); }
-                 */
-                // *** end of added ***
-
-              } else { // disposition exists but not clear why, print warning
-                if (lClass.identifier.compareTo("TBD_identifier") != 0) {
-                  DMDocument.registerMessage("1>warning "
-                      + "Class omitted from build - Class Identifier:" + lClass.identifier);
-                }
-
-                // *** added ***
-                /*
-                 * 555 lClass.isInactive = true; classNameSpaceIdNC = lClass.nameSpaceIdNC; //
-                 * global needed for parser parsedClassMap.put(lClass.rdfIdentifier, lClass);
-                 * isInParsedClassMap = true; String token1 = (String) tokenIter.next(); if
-                 * (token1.compareTo("(") != 0) { lClass.definition =
-                 * DOMInfoModel.unEscapeProtegeString(token1); }
-                 */
-                // *** end of added ***
-
-              }
-            } else if (!DMDocument.LDDToolFlag) {
-              DMDocument.registerMessage("1>warning " + "Class disposition was not found - "
-                  + "<Record> <Field>Y</Field> <Field>UpperModel."
-                  + DMDocument.registrationAuthorityIdentifierValue + "." + lClass.title
-                  + "</Field> <Field>1M</Field> <Field>#nm</Field> <Field>ns</Field> </Record>");
-            }
-            lClass.setIdentifier(classNameSpaceIdNC, className);
-          }
-
+// 555
           // get disposition for the class from dd11179
-          if (DMDocument.overWriteClass) {
+            if (DMDocument.overWriteClass && (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) != 0)) {
             lClass.getDOMClassDisposition2(); // from protege (new)
-            if (!isInParsedClassMap) {
-              parsedClassMap.put(lClass.rdfIdentifier, lClass);
-            }
+            parsedClassMap.put(lClass.rdfIdentifier, lClass);
+            classNameSpaceIdNC = lClass.nameSpaceIdNC;  // set the namespace for the attributes
             String token1 = tokenIter.next();
             if (token1.compareTo("(") != 0) {
               lClass.definition = DOMInfoModel.unEscapeProtegeString(token1);
             }
             lClass.setIdentifier(lClass.nameSpaceIdNC, className);
+//            System.out.println("debug ProtPontDOMModel lClass.identifier2:" + lClass.identifier + " - Protege");
           }
           type = 0;
           break;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSpecification.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSpecification.java
@@ -474,7 +474,6 @@ public class WriteDOMSpecification extends Object {
 
     TreeMap<String, DOMClass> lDOMClassMap = new TreeMap<>();
     for (DOMClass lClass : subClasses) {
-// 555
       if (lClass.isInactive) continue;
       String className = lClass.title;
       lDOMClassMap.put(className, lClass);

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSpecification.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSpecification.java
@@ -474,6 +474,8 @@ public class WriteDOMSpecification extends Object {
 
     TreeMap<String, DOMClass> lDOMClassMap = new TreeMap<>();
     for (DOMClass lClass : subClasses) {
+// 555
+      if (lClass.isInactive) continue;
       String className = lClass.title;
       lDOMClassMap.put(className, lClass);
     }

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Thu Oct 05 14:38:16 EDT 2023
+; Mon Nov 13 21:53:10 EST 2023
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -349,7 +349,8 @@
 		"name=\"urn_esa\" value=\"'urn:esa:psa:'\""
 		"name=\"urn_ros\" value=\"'urn:ros:rssa:'\""
 		"name=\"urn_jaxa\" value=\"'urn:jaxa:darts:'\""
-		"name=\"urn_isro\" value=\"'urn:isro:isda:'\"")
+		"name=\"urn_isro\" value=\"'urn:isro:isda:'\""
+		"name=\"urn_kari\" value=\"'urn:kari:kpds:'\"")
 	(type "TBD_type")
 	(xpath "pds:Bundle_Member_Entry"))
 
@@ -373,8 +374,8 @@
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3ABundle_Member_Entry.100002516.103] of  Schematron_Assert
 
-	(assertMsg "The value of the attribute lid_reference must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/>")
-	(assertStmt "if (pds:lid_reference) then starts-with(pds:lid_reference, $urn_nasa) or starts-with(pds:lid_reference, $urn_esa) or starts-with(pds:lid_reference, $urn_jaxa) or starts-with(pds:lid_reference, $urn_ros) or starts-with(pds:lid_reference, $urn_isro) else true()")
+	(assertMsg "The value of the attribute lid_reference must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/> or <sch:value-of select=\"$urn_kari\"/>")
+	(assertStmt "if (pds:lid_reference) then starts-with(pds:lid_reference, $urn_nasa) or starts-with(pds:lid_reference, $urn_esa) or starts-with(pds:lid_reference, $urn_jaxa) or starts-with(pds:lid_reference, $urn_ros) or starts-with(pds:lid_reference, $urn_isro) or starts-with(pds:lid_reference, $urn_kari) else true()")
 	(assertType "RAW")
 	(attrTitle "lid_reference")
 	(identifier "lid_reference")
@@ -382,8 +383,8 @@
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3ABundle_Member_Entry.100002516.104] of  Schematron_Assert
 
-	(assertMsg "The value of the attribute lidvid_reference must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/>")
-	(assertStmt "if (pds:lidvid_reference) then starts-with(pds:lidvid_reference, $urn_nasa) or starts-with(pds:lidvid_reference, $urn_esa) or starts-with(pds:lidvid_reference, $urn_jaxa) or starts-with(pds:lidvid_reference, $urn_ros) or starts-with(pds:lidvid_reference, $urn_isro) else true()")
+	(assertMsg "The value of the attribute lidvid_reference must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/> or <sch:value-of select=\"$urn_kari\"/>")
+	(assertStmt "if (pds:lidvid_reference) then starts-with(pds:lidvid_reference, $urn_nasa) or starts-with(pds:lidvid_reference, $urn_esa) or starts-with(pds:lidvid_reference, $urn_jaxa) or starts-with(pds:lidvid_reference, $urn_ros) or starts-with(pds:lidvid_reference, $urn_isro) or starts-with(pds:lidvid_reference, $urn_kari) else true()")
 	(assertType "RAW")
 	(attrTitle "lidvid_reference")
 	(identifier "lidvid_reference")
@@ -966,7 +967,8 @@
 		"name=\"urn_ros\" value=\"'urn:ros:rssa:'\""
 		"name=\"urn_jaxa\" value=\"'urn:jaxa:darts:'\""
 		"name=\"urn_isro\" value=\"'urn:isro:isda:'\""
-		"name=\"parentObj\" value=\"local-name(/*) = 'Product_External'\"")
+		"name=\"parentObj\" value=\"local-name(/*) = 'Product_External'\""
+		"name=\"urn_kari\" value=\"'urn:kari:kpds:'\"")
 	(type "TBD_type")
 	(xpath "pds:Identification_Area"))
 
@@ -990,8 +992,8 @@
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AIdentification_Area.100002521.103] of  Schematron_Assert
 
-	(assertMsg "The parent-value of the attribute logical_identifier must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/>")
-	(assertStmt "if (not ($parentObj) and pds:logical_identifier) then starts-with(pds:logical_identifier, $urn_nasa) or starts-with(pds:logical_identifier, $urn_esa) or starts-with(pds:logical_identifier, $urn_jaxa) or starts-with(pds:logical_identifier, $urn_ros) or starts-with(pds:logical_identifier, $urn_isro) else true()")
+	(assertMsg "The value of the attribute logical_identifier must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/> or <sch:value-of select=\"$urn_kari\"/>")
+	(assertStmt "if (pds:logical_identifier) then starts-with(pds:logical_identifier, $urn_nasa) or starts-with(pds:logical_identifier, $urn_esa) or starts-with(pds:logical_identifier, $urn_jaxa) or starts-with(pds:logical_identifier, $urn_ros) or starts-with(pds:logical_identifier, $urn_isro) or starts-with(pds:logical_identifier, $urn_kari) else true()")
 	(assertType "RAW")
 	(attrTitle "logical_identifier")
 	(identifier "logical_identifier")
@@ -1059,7 +1061,8 @@
 		"name=\"urn_esa\" value=\"'urn:esa:psa:'\""
 		"name=\"urn_ros\" value=\"'urn:ros:rssa:'\""
 		"name=\"urn_jaxa\" value=\"'urn:jaxa:darts:'\""
-		"name=\"urn_isro\" value=\"'urn:isro:isda:'\"")
+		"name=\"urn_isro\" value=\"'urn:isro:isda:'\""
+		"name=\"urn_kari\" value=\"'urn:kari:kpds:'\"")
 	(type "TBD_type")
 	(xpath "pds:Internal_Reference"))
 
@@ -1092,8 +1095,8 @@
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AInternal_Reference.100002522.104] of  Schematron_Assert
 
-	(assertMsg "The value of the attribute lid_reference must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/>")
-	(assertStmt "if (pds:lid_reference) then starts-with(pds:lid_reference, $urn_nasa) or starts-with(pds:lid_reference, $urn_esa) or starts-with(pds:lid_reference, $urn_jaxa) or starts-with(pds:lid_reference, $urn_ros) or starts-with(pds:lid_reference, $urn_isro) else true()")
+	(assertMsg "The value of the attribute lid_reference must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/> or <sch:value-of select=\"$urn_kari\"/>")
+	(assertStmt "if (pds:lid_reference) then starts-with(pds:lid_reference, $urn_nasa) or starts-with(pds:lid_reference, $urn_esa) or starts-with(pds:lid_reference, $urn_jaxa) or starts-with(pds:lid_reference, $urn_ros) or starts-with(pds:lid_reference, $urn_isro)  or starts-with(pds:lid_reference, $urn_kari) else true()")
 	(assertType "RAW")
 	(attrTitle "lid_reference")
 	(identifier "lid_reference")
@@ -1101,8 +1104,8 @@
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AInternal_Reference.100002522.105] of  Schematron_Assert
 
-	(assertMsg "The value of the attribute lidvid_reference must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/>")
-	(assertStmt "if (pds:lidvid_reference) then starts-with(pds:lidvid_reference, $urn_nasa) or starts-with(pds:lidvid_reference, $urn_esa) or starts-with(pds:lidvid_reference, $urn_jaxa) or starts-with(pds:lidvid_reference, $urn_ros) or starts-with(pds:lidvid_reference, $urn_isro) else true()")
+	(assertMsg "The value of the attribute lidvid_reference must start with either: <sch:value-of select=\"$urn_nasa\"/> or <sch:value-of select=\"$urn_esa\"/> or <sch:value-of select=\"$urn_jaxa\"/> or <sch:value-of select=\"$urn_ros\"/> or <sch:value-of select=\"$urn_isro\"/> or <sch:value-of select=\"$urn_kari\"/>")
+	(assertStmt "if (pds:lidvid_reference) then starts-with(pds:lidvid_reference, $urn_nasa) or starts-with(pds:lidvid_reference, $urn_esa) or starts-with(pds:lidvid_reference, $urn_jaxa) or starts-with(pds:lidvid_reference, $urn_ros) or starts-with(pds:lidvid_reference, $urn_isro) or starts-with(pds:lidvid_reference, $urn_kari) else true()")
 	(assertType "RAW")
 	(attrTitle "lidvid_reference")
 	(identifier "lidvid_reference")


### PR DESCRIPTION
This PR completes Phase 6 of the IMTool refactoring task, a several month effort that will ultimately allow the deprecation of the MDPTNConfigClassDisp.xml file, the PDS4 Class disposition file (XML format). The Class definition information in MDPTNConfigClassDisp was moved to the dd11179.pins file, a Protege database file based on the ISO 11179 schema and used by IMTool/LDDTool. The dd11179.pins file had been limited to PDS4 Attribute definition information. The dd11179.pins file schema was updated to also capture PDS4 class definition information.

This issue is related to issues #239, #306, #428, and #676. Only phases 1, 2, and 3 resulted in PR requests. Phases 4 and 5 were simply for accounting.


## ⚙️ Test Data and/or Report
The new output files were DIFFed against the previous output files. The only differences found were in the PDS4 Information Model Specification where certain entity lists were reordered. They are now in the correct order. For example, see the "data_object" entities after "curating_node_id". Below is a snippet illustrating the old order.

                                curating_node_id in Volume_PDS3
				    The curating_node_id attribute provides the id of the node currently maintaining the data set or volume and is responsible for maintaining catalog information.				

				data_object in DD_Attribute
				    The data_object association is a relationship to Data Object.
				
				    Type: Association
				data_object in DD_Attribute_Full
				    The data_object association is a relationship to Data Object.
				
				    Type: Association
				data_object in DD_Class
				    The data_object association is a relationship to Data Object.
				
				    Type: Association
				data_object in DD_Class_Full
				    The data_object association is a relationship to Data Object.

Resolves #717



