### PR TITLE
IMTool Refactoring - Deprecate the Java "Deprecated Object Array"

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -609,10 +609,6 @@ public class DMDocument extends Object {
 
     // set the deprecated flags
     setObjectDeprecatedFlag();
-// 555
-    for (DeprecatedDefn lDeprecatedDefn : deprecatedObjects2) {
-    	System.out.println("debug1  - " + lDeprecatedDefn.getDeprecatedDefnSerialized());
-    }
 
     // get the 11179 Attribute Dictionary - .pins file
     ProtPinsDOM11179DD lProtPinsDOM11179DD = new ProtPinsDOM11179DD();
@@ -629,7 +625,7 @@ public class DMDocument extends Object {
     if (debugFlag) {
       DOMInfoModel.domWriter(DOMInfoModel.masterDOMClassArr, "DOMModelListPerm.txt");
     }
-
+    
     // export the models
     if (DMDocument.LDDToolFlag) {
       ExportModels lExportModels = new ExportModels();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DeprecatedDefn.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DeprecatedDefn.java
@@ -73,7 +73,6 @@ public class DeprecatedDefn {
     }
   }
   
-  // 555
   String getDeprecatedDefnSerialized() {
 	  String deprecatedDefnSerialized = "title:" + title + " |  classNameSpaceIdNC:"
           + classNameSpaceIdNC + " |  className:" + className

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -384,12 +384,6 @@ public class GetDOMModel extends Object {
       DMDocument.deprecatedObjects2 = DMDocument.masterDOMInfoModel.getDeprecatedObjectsArr();
     }
     DMDocument.deprecatedObjects2 = DMDocument.masterDOMInfoModel.getDeprecatedObjectsArr();
-    
- // 555
-	System.out.println("--- ");
-    for (DeprecatedDefn lDeprecatedDefn : DMDocument.deprecatedObjects2) {
-    	System.out.println("debug2  - " + lDeprecatedDefn.getDeprecatedDefnSerialized());
-    }
 
     // 333 DMDocument.Dump333DeprecatedObjects2 ("DMDocument", DMDocument.deprecatedObjects2);
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFilePClass.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFilePClass.java
@@ -155,7 +155,6 @@ class WriteDOM11179DDPinsFilePClass extends Object {
   // Print the the Protege Pins VD
   private void printPDDPVD(PrintWriter prDDPins) {
     // print the value domain
-
     ArrayList<DOMAttr> lSortedAttrArr = getSortedAttrs();
     for (Iterator<DOMAttr> i = lSortedAttrArr.iterator(); i.hasNext();) {
       DOMAttr lDOMAttr = i.next();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
@@ -66,7 +66,7 @@ class WriteDOMSchematron extends Object {
     // select out the rules for this namespace
     ArrayList<DOMRule> lSelectRuleArr = new ArrayList<>();
     ArrayList<DOMRule> lRuleArr = new ArrayList<>(DOMInfoModel.masterDOMRuleIdMap.values());
-    for (DOMRule lRule : lRuleArr) {     
+    for (DOMRule lRule : lRuleArr) {
       if (lSchemaFileDefn.isMaster) {
         if (lRule.isMissionOnly || !(lRule.alwaysInclude
             || (lSchemaFileDefn.nameSpaceIdNC.compareTo(lRule.classNameSpaceNC) == 0


### PR DESCRIPTION
IMTool Refactoring - Deprecate the Java "Deprecated Object Array"

The "Deprecated" boolean flag has been moved to the Object definitions in the dd11179 Protege ontology file. The hard-coded list of deprecated objects is no longer used. It will be removed during the next build.

There should be no noticeable change in the operational capabilities of the artifacts generated by the software. However, there are some differences.

1.     The order of the deprecation rules in the .sch file and the listing of deprecated items at the end of the .xsd file have changed. They are now ordered by name.
2.     An error in a deprecation rule was found and fixed. Rule for name:Node/name:name -> pds:Node/pds:name for deprecation of the value Navigation Ancillary Information Facility.
3.     The following deprecation rules are now being written to the .sch file.
        pds:Manifest_SIP_Deep_Archive/pds:field_delimiter - comma
        pds:Manifest_SIP_Deep_Archive/pds:field_delimiter - horizontal tab
        pds:Manifest_SIP_Deep_Archive/pds:field_delimiter - semicolon
        pds:Manifest_SIP_Deep_Archive/pds:field_delimiter - vertical bar
        pds:Manifest_SIP_Deep_Archive/pds:record_delimiter - carriage-return line-feed
        pds:Node/pds:name - Navigation Ancillary Information Facility
4.     The following rule was removed since the class Local_Internal_Reference was not deprecated but has a cardinality of (0..0), i.e. it is not allowed. 
         pds:Array/pds:Local_Internal_Reference.
5.     A hand-full of rule titles have changed. However rule titles are not being used and could be considered for deprecation.

Resolves #724



