### PR TITLE
#733 - LDDTool is throwing ERROR SetMasterAttrXMLBaseDataTypeFromDataType - Data Type is missing

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -211,7 +211,8 @@ public class DMDocument extends Object {
   static boolean LDDToolFlag;
 
   // misc flags
-  static boolean debugFlag = false;
+  static boolean debugFlag = true;
+
 
   // in an LDDTool run, when true indicates that a mission LDD is being processed
   // this flag was deprecated with the addition of <dictionary_type> to Ingest_LDD IM V1E00
@@ -343,6 +344,8 @@ public class DMDocument extends Object {
 
   public static void main(String args[]) throws Throwable {
 
+	if (debugFlag) System.out.println(">>  DEBUG DMDocument 240311.2.0");
+	  
     // process state for used flags, files, and directories
     dmProcessState = new DMProcessState();
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -156,22 +156,7 @@ public class DMDocument extends Object {
   static boolean PDS4MergeFlag = false; // create protege output; not currently used
   // static boolean LDDClassElementFlag = false; // if true, write XML elements for classes
   static boolean LDDAttrElementFlag = false; // if true, write XML elements for attributes
-  static boolean LDDNuanceFlag = false; //
-
-  // refactor into Protege switches
-  /*
-   * Possibilities re: refactoring fix. 1) Check buildIMVersionId, if less than 1.18.0.0, then
-   * process MDPTNConfig, else use protege. a) currently
-   * lISO11179DOMMDR.OverwriteClassFrom11179DataDict is only used for IMTool runs, not LDDTool runs.
-   * ==> b) currently all IM version prior to 1.18.0.0 do not have object classes 2)
-   * lISO11179DOMMDR.OverwriteClassFrom11179DataDict requires "Object Classes" in protege 3)
-   * Removing MDPTNConfig requires that "I" and "N" classes be included in protege as
-   * "Object Classes" 4) ProtPontDOMModel is currently ignoring "I" and "N" classes a) this means
-   * that dd11179_GenPClass.pins does not include "I" and "N" classes
-   */
-
-  // 555 static boolean overWriteClass = true; // use dd11179.pins class disp, isDeprecated, and
-  // versionId to overwrite Master DOMClasses, DOMAttrs, and DOMPermvalues
+  static boolean LDDNuanceFlag = false; 
   static boolean overWriteClass = true; // use dd11179.pins class disp, isDeprecated, and versionId
                                          // to overwrite Master DOMClasses, DOMAttrs, and
                                          // DOMPermvalues
@@ -211,8 +196,7 @@ public class DMDocument extends Object {
   static boolean LDDToolFlag;
 
   // misc flags
-  static boolean debugFlag = true;
-
+  static boolean debugFlag = false;
 
   // in an LDDTool run, when true indicates that a mission LDD is being processed
   // this flag was deprecated with the addition of <dictionary_type> to Ingest_LDD IM V1E00

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
@@ -36,6 +36,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 // import org.apache.commons.lang.WordUtils;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.TreeMap;
 
@@ -133,6 +134,10 @@ public abstract class DOMInfoModel extends Object {
   // static String LDDToolSingletonClassTitle = "USER";
   static DOMClass LDDToolSingletonDOMClass = null; // Class for LDD singleton attributes (Discipline
                                                    // or Mission)
+  
+  // 666
+  // Inactive Attributes Array *** temporary until attr.isInactive is added to dd11179
+  static ArrayList <String> attrIsInactiveArr;
 
   // global science discipline facet map
   static TreeMap<String, SFDisciplineFacetDefn> sfDisciplineFacetDefnMap = new TreeMap<>();
@@ -181,7 +186,50 @@ public abstract class DOMInfoModel extends Object {
     // set up special rdfIdentifiers
     protegeRootClassRdfId = DMDocument.rdfPrefix + "USER";
     protegeSlotClassRdfId = DMDocument.rdfPrefix + "%3ASYSTEM-CLASS";
-
+    
+    // 666
+    // Inactive Attributes Array *** temporary until attr.isInactive is added to dd11179
+    attrIsInactiveArr = new ArrayList<>( Arrays.asList(
+    		"0001_NASA_PDS_1.pds.Activity.pds.activity_type", 
+    		"0001_NASA_PDS_1.pds.Activity.pds.description", 
+    		"0001_NASA_PDS_1.pds.Activity.pds.title", 
+    		"0001_NASA_PDS_1.pds.Agent.pds.agent_type", 
+    		"0001_NASA_PDS_1.pds.Agent.pds.description", 
+    		"0001_NASA_PDS_1.pds.Agent.pds.title", 
+    		"0001_NASA_PDS_1.pds.ChangeLog.pds.date", 
+    		"0001_NASA_PDS_1.pds.ChangeLog.pds.desc", 
+    		"0001_NASA_PDS_1.pds.DD_Static_Permissible_Value.pds.local_identifier", 
+    		"0001_NASA_PDS_1.pds.DD_Static_Permissible_Value.pds.value", 
+    		"0001_NASA_PDS_1.pds.Encoded_Telemetry.pds.encoding_standard_id", 
+    		"0001_NASA_PDS_1.pds.Entity.pds.description", 
+    		"0001_NASA_PDS_1.pds.Entity.pds.entity_type", 
+    		"0001_NASA_PDS_1.pds.Entity.pds.title", 
+    		"0001_NASA_PDS_1.pds.Ingest_LDD_File.pds.parsing_standard_id", 
+    		"0001_NASA_PDS_1.pds.Ingest_LDD_File_Desc.pds.description", 
+    		"0001_NASA_PDS_1.pds.Ingest_LDD_File_Desc.pds.ldd_version_id", 
+    		"0001_NASA_PDS_1.pds.Ingest_LDD_File_Desc.pds.name", 
+    		"0001_NASA_PDS_1.pds.LIDVID_ID_Reference.pds.id_reference", 
+    		"0001_NASA_PDS_1.pds.LIDVID_ID_Reference.pds.lidvid_reference", 
+    		"0001_NASA_PDS_1.pds.LID_ID_Reference.pds.id_reference", 
+    		"0001_NASA_PDS_1.pds.LID_ID_Reference.pds.lid_reference", 
+    		"0001_NASA_PDS_1.pds.Property_Map_External.pds.description", 
+    		"0001_NASA_PDS_1.pds.Property_Map_External.pds.property_map_id", 
+    		"0001_NASA_PDS_1.pds.Tracking.pds.description", 
+    		"0001_NASA_PDS_1.pds.Tracking.pds.identifier", 
+    		"0001_NASA_PDS_1.pds.Tracking_Detail.pds.archive_status", 
+    		"0001_NASA_PDS_1.pds.Tracking_Detail.pds.archive_status_note", 
+    		"0001_NASA_PDS_1.pds.Tracking_Detail.pds.certified_flag", 
+    		"0001_NASA_PDS_1.pds.Tracking_Detail.pds.modification_date", 
+    		"0001_NASA_PDS_1.pds.Virtual_Reference.pds.comment", 
+    		"0001_NASA_PDS_1.pds.Virtual_Reference.pds.id_reference_to", 
+    		"0001_NASA_PDS_1.pds.Virtual_Reference.pds.virtual_reference_type", 
+    		"0001_NASA_PDS_1.pds.Virtual_Relation.pds.comment", 
+    		"0001_NASA_PDS_1.pds.Virtual_Relation.pds.id_reference_from", 
+    		"0001_NASA_PDS_1.pds.Virtual_Relation.pds.id_reference_to", 
+    		"0001_NASA_PDS_1.pds.Virtual_Relation.pds.virtual_reference_type", 
+    		"0001_NASA_PDS_1.pds.Virtual_Structure.pds.description", 
+    		"0001_NASA_PDS_1.pds.Virtual_Structure.pds.title", 
+    		"0001_NASA_PDS_1.pds.Virtual_Structure.pds.type_description"));
 
     // masterMetaAttribute list
     masterMetaAttribute = new ArrayList<>();
@@ -422,6 +470,13 @@ public abstract class DOMInfoModel extends Object {
     return masterDOMUnitArr;
   }
 
+  // 666
+  // test for inactive attribute
+  static public boolean isAttInactive (String lIdentifier) {
+	  if (attrIsInactiveArr.contains(lIdentifier)) return true;
+	  return false;
+  }
+  
   /**********************************************************************************************************
    * miscellaneous routines
    ***********************************************************************************************************/

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMInfoModel.java
@@ -135,7 +135,6 @@ public abstract class DOMInfoModel extends Object {
   static DOMClass LDDToolSingletonDOMClass = null; // Class for LDD singleton attributes (Discipline
                                                    // or Mission)
   
-  // 666
   // Inactive Attributes Array *** temporary until attr.isInactive is added to dd11179
   static ArrayList <String> attrIsInactiveArr;
 
@@ -187,7 +186,6 @@ public abstract class DOMInfoModel extends Object {
     protegeRootClassRdfId = DMDocument.rdfPrefix + "USER";
     protegeSlotClassRdfId = DMDocument.rdfPrefix + "%3ASYSTEM-CLASS";
     
-    // 666
     // Inactive Attributes Array *** temporary until attr.isInactive is added to dd11179
     attrIsInactiveArr = new ArrayList<>( Arrays.asList(
     		"0001_NASA_PDS_1.pds.Activity.pds.activity_type", 
@@ -470,7 +468,6 @@ public abstract class DOMInfoModel extends Object {
     return masterDOMUnitArr;
   }
 
-  // 666
   // test for inactive attribute
   static public boolean isAttInactive (String lIdentifier) {
 	  if (attrIsInactiveArr.contains(lIdentifier)) return true;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -193,21 +193,6 @@ public class GetDOMModel extends Object {
     }
     DOMInfoModel.masterDOMAttrArr = new ArrayList<>(DOMInfoModel.masterDOMAttrIdMap.values());
 
-    // Overwrite from JSON 11179 file (new classes and attributes)
-    // if (DMDocument.mastModelId.compareTo("WRC") == 0) {
-    // GetJSON11179 lGetJSON11179 = new GetJSON11179 ();
-    // lGetJSON11179.parseJSON();
-    // GetCSVMetadataFile lGetCSVMetadataFile = new GetCSVMetadataFile ();
-    // lGetCSVMetadataFile.readParseCSVFile ();
-    // ArrayList <DOMClass> lDOMClassArr = new ArrayList <DOMClass>
-    // (DOMInfoModel.masterDOMClassIdMap.values());
-    // DOMInfoModel.domWriter (lDOMClassArr, "GetCSVMetadataFile.txt");
-    // }
-    // if (DMDocument.mastModelId.compareTo("SWOT") == 0) {
-    // GetCSV lGetCSV = new GetCSV ();
-    // lGetCSV.readParseCSVFile();
-    // }
-
     // set up the LDDToolSingletonClass - The following classes need to be defined:USER,
     // Discipline_Area, and Mission_Area
     if (DMDocument.LDDToolSingletonClassTitle.compareTo("USER") == 0) {
@@ -275,11 +260,6 @@ public class GetDOMModel extends Object {
     // The attributes are updated later (data type, etc)
     
     DMDocument.masterDOMInfoModel.getUserClassAttrIdMap();
-    
-    // 666
-    ArrayList <String> userDOMClassAttrIdArr = new ArrayList <> (DOMInfoModel.userDOMClassAttrIdMap.keySet());
-    System.out.println("debug GetDOMModel - ID LIST - userDOMClassAttrIdArr:" + userDOMClassAttrIdArr);
-
 
     // 008 - if this is an LDD Tool run, parse the LDD(s)
     if (DMDocument.LDDToolFlag) {
@@ -338,9 +318,7 @@ public class GetDOMModel extends Object {
     DMDocument.masterDOMInfoModel.setMasterAttrisUsedInClassFlag();
 
     // 017a - overwrite master attributes from the 11179 DD
-    // - either import from JSON 11179 file or overwrite from 11179 dictionary
     // Overwrite is needed to set classes and attribute defined in protege
-
     lISO11179DOMMDR.OverwriteFrom11179DataDict(); 			// Attribute overwrite
     lISO11179DOMMDR.OverwriteClassFrom11179DataDict();		// Class overwrite
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -273,7 +273,13 @@ public class GetDOMModel extends Object {
     // 007 - get list of USER attributes (owned attributes)
     // This must be done before LDD parsing since it needs the USER attributes
     // The attributes are updated later (data type, etc)
+    
     DMDocument.masterDOMInfoModel.getUserClassAttrIdMap();
+    
+    // 666
+    ArrayList <String> userDOMClassAttrIdArr = new ArrayList <> (DOMInfoModel.userDOMClassAttrIdMap.keySet());
+    System.out.println("debug GetDOMModel - ID LIST - userDOMClassAttrIdArr:" + userDOMClassAttrIdArr);
+
 
     // 008 - if this is an LDD Tool run, parse the LDD(s)
     if (DMDocument.LDDToolFlag) {
@@ -333,16 +339,10 @@ public class GetDOMModel extends Object {
 
     // 017a - overwrite master attributes from the 11179 DD
     // - either import from JSON 11179 file or overwrite from 11179 dictionary
-    // Overwrite is needed to set classes and attribute defined in protege but not in JSON11179 ???
-    lISO11179DOMMDR.OverwriteFrom11179DataDict();
+    // Overwrite is needed to set classes and attribute defined in protege
 
-    // 017b - overwrite master classes from the 11179 DD
-    // - either import from JSON 11179 file or overwrite from 11179 dictionary
-    // Overwrite is needed to set classes and attribute defined in protege but not in JSON11179
-    
-    if (!DMDocument.LDDToolFlag) {
-      lISO11179DOMMDR.OverwriteClassFrom11179DataDict();
-    }
+    lISO11179DOMMDR.OverwriteFrom11179DataDict(); 			// Attribute overwrite
+    lISO11179DOMMDR.OverwriteClassFrom11179DataDict();		// Class overwrite
 
     // 018 - overwrite any LDD attributes from the cloned USER attributes
     // this is not really needed since the definitions are in the external class

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISO11179DOMMDR.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ISO11179DOMMDR.java
@@ -31,6 +31,7 @@
 package gov.nasa.pds.model.plugin;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.TreeMap;
@@ -46,7 +47,7 @@ class ISO11179DOMMDR extends Object {
     hashCodedValueMeaningMap = new TreeMap<>();
     hashCodedIsDeprecatedMap = new TreeMap<>();
     valueChangeMap = new TreeMap<>();
-
+    
     // set up permissible value / value meaning map; need identifier from map
     ArrayList<InstDefn> lMaster11179DataDictArr =
         new ArrayList<>(DOMInfoModel.master11179DataDict.values());
@@ -94,6 +95,20 @@ class ISO11179DOMMDR extends Object {
         }
       }
     }
+    
+//    // get attributes with isInactive = true
+//    for (Iterator<InstDefn> i = lMaster11179DataDictArr.iterator(); i.hasNext();) {
+//        InstDefn lInstDefn = i.next();
+//        if (lInstDefn.className.compareTo("PermissibleValue") == 0) {
+//            // get isInactive
+//            String lSlotIsInactive = lInstDefn.getSlotValueSingleton("isInactive");
+//            if (lSlotIsInactive != null && lSlotIsInactive.compareTo("true") == 0) {
+//            	hashCodedIsInactiveArr.add("xxx");
+//            }
+//        }
+//    }
+    
+    
     return;
   }
 
@@ -126,7 +141,6 @@ class ISO11179DOMMDR extends Object {
     String lInstId;
     String lVal;
     boolean isEnumerated = false;
-    boolean lDebugFlag = false;
 
     // iterate through the master attribute array
     for (Iterator<DOMAttr> i = DOMInfoModel.masterDOMAttrArr.iterator(); i.hasNext();) {
@@ -151,20 +165,12 @@ class ISO11179DOMMDR extends Object {
         // update isDeprecated
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "isDeprecated", "false");
         if (lVal != null && lVal.compareTo("true") == 0) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.isDeprecated:" + lAttr.isDeprecated + "  - with lVal:" + lVal);
-          }
           lAttr.isDeprecated = true;
         }
 
         // update steward
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "steward", lAttr.steward);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.steward:" + lAttr.steward + "  - with lVal:" + lVal);
-          }
           lAttr.steward = lVal;
         }
 
@@ -173,19 +179,11 @@ class ISO11179DOMMDR extends Object {
             lAttr.classConcept);
         if (lVal != null) {
           lVal = lVal.substring(4, lVal.length());
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.classConcept:" + lAttr.classConcept + "  - with lVal:" + lVal);
-          }
           lAttr.classConcept = lVal;
         }
 
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "isNillable", "false");
         if (lVal != null && lVal.compareTo("true") == 0) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.isNilable:" + lAttr.isNilable + "  - with lVal:" + lVal);
-          }
           lAttr.isNilable = true;
         }
 
@@ -213,10 +211,6 @@ class ISO11179DOMMDR extends Object {
         lVal =
             ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "datatype", lAttr.valueType);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.valueType:" + lAttr.valueType + "  - with lVal:" + lVal);
-          }
           lAttr.valueType = lVal;
         }
 
@@ -225,10 +219,6 @@ class ISO11179DOMMDR extends Object {
             lAttr.dataConcept);
         if (lVal != null) {
           lVal = lVal.substring(3, lVal.length());
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.dataConcept:" + lAttr.dataConcept + "  - with lVal:" + lVal);
-          }
           lAttr.dataConcept = lVal;
         }
 
@@ -236,11 +226,6 @@ class ISO11179DOMMDR extends Object {
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "minimumValue",
             lAttr.minimum_value);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.minimum_value:" + lAttr.minimum_value + "  - with lVal:"
-                + lVal);
-          }
           lAttr.minimum_value = lVal;
         }
 
@@ -248,11 +233,6 @@ class ISO11179DOMMDR extends Object {
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "maximumValue",
             lAttr.maximum_value);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.maximum_value:" + lAttr.maximum_value + "  - with lVal:"
-                + lVal);
-          }
           lAttr.maximum_value = lVal;
         }
 
@@ -260,11 +240,6 @@ class ISO11179DOMMDR extends Object {
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "minimumCharacterQuantity",
             lAttr.minimum_characters);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.minimum_characters:" + lAttr.minimum_characters
-                + "  - with lVal:" + lVal);
-          }
           lAttr.minimum_characters = lVal;
         }
 
@@ -272,11 +247,6 @@ class ISO11179DOMMDR extends Object {
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "maximumCharacterQuantity",
             lAttr.maximum_characters);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.maximum_characters:" + lAttr.maximum_characters
-                + "  - with lVal:" + lVal);
-          }
           lAttr.maximum_characters = lVal;
         }
 
@@ -284,10 +254,6 @@ class ISO11179DOMMDR extends Object {
         lVal = ProtPinsDOM11179DD.getStringValueUpdatePattern(true, lInstMap, "pattern",
             lAttr.pattern);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.pattern:" + lAttr.pattern + "  - with lVal:" + lVal);
-          }
           lAttr.pattern = lVal;
         }
 
@@ -295,11 +261,6 @@ class ISO11179DOMMDR extends Object {
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "unitOfMeasure",
             lAttr.unit_of_measure_type);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.unit_of_measure_type:" + lAttr.unit_of_measure_type
-                + "  - with lVal:" + lVal);
-          }
           lAttr.unit_of_measure_type = lVal;
         }
 
@@ -307,11 +268,6 @@ class ISO11179DOMMDR extends Object {
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "defaultUnitId",
             lAttr.default_unit_id);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite with 11179 - got lInstId:" + lInstId
-                + " - updating lAttr.default_unit_id:" + lAttr.default_unit_id + "  - with lVal:"
-                + lVal);
-          }
           lAttr.default_unit_id = lVal;
         }
 
@@ -352,7 +308,6 @@ class ISO11179DOMMDR extends Object {
     String lSuffix;
     String lInstId;
     String lVal;
-    boolean lDebugFlag = false;
 
     // iterate through the master class array
     for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
@@ -363,39 +318,20 @@ class ISO11179DOMMDR extends Object {
       InstDefn lOCInst = DOMInfoModel.master11179DataDict.get(lInstId);
       if (lOCInst != null) {
         lInstMap = lOCInst.genSlotMap;
-        
-        // set isInactive
-        // *** ProtPontDOMModel - All .pont classes have isInactive = false during initial parse;
-        // during overwrite from dd11179, if isInactive = true then set class.isInactive = true
-        // note that some classes are defined in the .pont file (inactive) but not in dd11179
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "isInactive", "false");
         if (lVal != null && lVal.compareTo("true") == 0) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.isInactive:" + lDOMClass.isInactive + "  - with lVal:"
-                + lVal);
-          }
-          lDOMClass.isInactive = true;
+          lDOMClass.isInactive = true;  
         }        
 
         // update isDeprecated
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "isDeprecated", "false");
         if (lVal != null && lVal.compareTo("true") == 0) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.isDeprecated:" + lDOMClass.isDeprecated + "  - with lVal:"
-                + lVal);
-          }
           lDOMClass.isDeprecated = true;
         }
 
         // update used
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "used", lDOMClass.used);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.used:" + lDOMClass.used + "  - with lVal:" + lVal);
-          }
           lDOMClass.used = lVal;
         }
 
@@ -403,10 +339,6 @@ class ISO11179DOMMDR extends Object {
         lVal =
             ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "section", lDOMClass.section);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.section:" + lDOMClass.section + "  - with lVal:" + lVal);
-          }
           lDOMClass.section = lVal;
         }
 
@@ -414,10 +346,6 @@ class ISO11179DOMMDR extends Object {
         lVal =
             ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "steward", lDOMClass.steward);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.steward:" + lDOMClass.steward + "  - with lVal:" + lVal);
-          }
           lDOMClass.steward = lVal;
         }
 
@@ -425,74 +353,42 @@ class ISO11179DOMMDR extends Object {
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "nameSpaceIdNC",
             lDOMClass.nameSpaceIdNC);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.nameSpaceIdNC:" + lDOMClass.nameSpaceIdNC + "  - with lVal:"
-                + lVal);
-          }
           lDOMClass.nameSpaceIdNC = lVal;
         }
 
         // update isVacuous
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "isVacuous", "false");
         if (lVal != null && lVal.compareTo("true") == 0) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.isVacuous:" + lDOMClass.isVacuous + "  - with lVal:" + lVal);
-          }
           lDOMClass.isVacuous = true;
         }
 
         // update isSchema1Class
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "isSchema1Class", "false");
         if (lVal != null && lVal.compareTo("true") == 0) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.isSchema1Class:" + lDOMClass.isSchema1Class + "  - with lVal:"
-                + lVal);
-          }
           lDOMClass.isSchema1Class = true;
         }
 
         // update isRegistryClass
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "isRegistryClass", "false");
         if (lVal != null && lVal.compareTo("true") == 0) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.isRegistryClass:" + lDOMClass.isRegistryClass
-                + "  - with lVal:" + lVal);
-          }
           lDOMClass.isRegistryClass = true;
         }
 
         // update isTDO
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "isTDO", "false");
         if (lVal != null && lVal.compareTo("true") == 0) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.isTDO:" + lDOMClass.isTDO + "  - with lVal:" + lVal);
-          }
           lDOMClass.isTDO = true;
         }
 
         // update isDataType
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "isDataType", "false");
         if (lVal != null && lVal.compareTo("true") == 0) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.isDataType:" + lDOMClass.isDataType + "  - with lVal:" + lVal);
-          }
           lDOMClass.isDataType = true;
         }
 
         // update isUnitOfMeasure
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "isUnitOfMeasure", "false");
         if (lVal != null && lVal.compareTo("true") == 0) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.isUnitOfMeasure:" + lDOMClass.isUnitOfMeasure
-                + "  - with lVal:" + lVal);
-          }
           lDOMClass.isUnitOfMeasure = true;
         }
 
@@ -500,10 +396,6 @@ class ISO11179DOMMDR extends Object {
         lVal = ProtPinsDOM11179DD.getStringValueUpdate(false, lInstMap, "versionIdentifier",
             lDOMClass.versionId);
         if (lVal != null) {
-          if (lDebugFlag) {
-            System.out.println("debug Overwrite Class with 11179 - got lInstId:" + lInstId
-                + " - updating Class.versionId:" + lDOMClass.versionId + "  - with lVal:" + lVal);
-          }
           lDOMClass.versionId = lVal;
         }
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -1747,21 +1747,9 @@ public class LDDDOMParser extends Object {
     // will be looking for something like "0001_NASA_PDS_1.pds.USER.standard_deviation"
     String lLocalIdentifier = lDOMProp.localIdentifier;
     
-//    // 666
-//    if (lLocalIdentifier.contains("pds.comment")) System.out.println("debug LDDDOMParser getLocalOrExternAttr -1- lDOMProp.localIdentifier:" + lDOMProp.localIdentifier);
-
     // check if attribute is an LDD attribute or an external added in an earlier iteration
     DOMAttr lDOMAttr = attrMapLocal.get(lLocalIdentifier);
-    if (lDOMAttr != null) {
-      // System.out.println("debug getLocalOrExternAttr - FOUND IN attrMapLocal - lLocalIdentifier:"
-      // + lLocalIdentifier);
-    } else {
-      // System.out.println("debug getLocalOrExternAttr - NOT FOUND IN attrMapLocal -
-      // lLocalIdentifier:" + lLocalIdentifier);
-      // else get a USER attribute
-    	
-    //  if (lLocalIdentifier.contains("pds.comment")) System.out.println("debug LDDDOMParser getLocalOrExternAttr -2- lLocalIdentifier:" + lLocalIdentifier);
-    	
+    if (lDOMAttr == null) {
       int lStringInd = lLocalIdentifier.lastIndexOf(".");
       String lLDDExtTitle = lLocalIdentifier;
       String lLDDExtNS = "xxx";
@@ -1775,37 +1763,16 @@ public class LDDDOMParser extends Object {
       String lAttrIdentifier =
           DOMInfoModel.getAttrIdentifier(DMDocument.masterUserClassNamespaceIdNC,
               DMDocument.masterUserClassName, lLDDExtNS, lLDDExtTitle);
-      
-//      if (lLocalIdentifier.contains("pds.comment")) {
-//    	  System.out.println("debug LDDDOMParser getLocalOrExternAttr -3- lAttrIdentifier:" + lAttrIdentifier);
-////    	  ArrayList <String> userDOMClassAttrIdArr = new ArrayList <> (DOMInfoModel.userDOMClassAttrIdMap.keySet());
-////    	  System.out.println("debug GetDOMModel - ID LIST2 - userDOMClassAttrIdArr:" + userDOMClassAttrIdArr);
-//      }
-      
       lDOMAttr = DOMInfoModel.userDOMClassAttrIdMap.get(lAttrIdentifier);
       if (lDOMAttr == null) {
-        // DMDocument.registerMessage ("2>error Class:" + lDOMClass.identifier + " Association:" +
-        // lDOMProp.localIdentifier + " Attribute: " + lLocalIdentifier + " - Missing Attribute");
-        // return null;
         // *** for qmsre process, when referencing external namespaces, e.g., msn, the attributes
         // are not present locally. Need some other solution. ***
-    	  
-//        if (lLocalIdentifier.contains("pds.comment")) System.out.println("debug LDDDOMParser getLocalOrExternAttr -4- NOT FOUND - lAttrIdentifier:" + lAttrIdentifier);
-	  
         if (lSchemaFileDefn.nameSpaceIdNC.compareTo("qmsre") != 0) {
           DMDocument.registerMessage(
               "2>error Class:" + lDOMClass.identifier + "  Association:" + lDOMProp.localIdentifier
                   + "  Attribute: " + lLocalIdentifier + " - Missing Attribute");
         }
         return null;
-      } else {
-//          if (lLocalIdentifier.contains("pds.comment")) {
-//        	  System.out.println("debug LDDDOMParser getLocalOrExternAttr -5- FOUND - lAttrIdentifier:" + lAttrIdentifier);
-//        	  if (lDOMAttr.valueType == null)
-//            	  System.out.println("debug LDDDOMParser getLocalOrExternAttr -5- lDOMAttr.valueType:" +  "-NULL-");
-//        	  else
-//        		  System.out.println("debug LDDDOMParser getLocalOrExternAttr -5- lDOMAttr.valueType:" +  lDOMAttr.valueType);
-//          }
       }
     }
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -1746,6 +1746,9 @@ public class LDDDOMParser extends Object {
       DOMProp lDOMProp) {
     // will be looking for something like "0001_NASA_PDS_1.pds.USER.standard_deviation"
     String lLocalIdentifier = lDOMProp.localIdentifier;
+    
+//    // 666
+//    if (lLocalIdentifier.contains("pds.comment")) System.out.println("debug LDDDOMParser getLocalOrExternAttr -1- lDOMProp.localIdentifier:" + lDOMProp.localIdentifier);
 
     // check if attribute is an LDD attribute or an external added in an earlier iteration
     DOMAttr lDOMAttr = attrMapLocal.get(lLocalIdentifier);
@@ -1756,6 +1759,9 @@ public class LDDDOMParser extends Object {
       // System.out.println("debug getLocalOrExternAttr - NOT FOUND IN attrMapLocal -
       // lLocalIdentifier:" + lLocalIdentifier);
       // else get a USER attribute
+    	
+    //  if (lLocalIdentifier.contains("pds.comment")) System.out.println("debug LDDDOMParser getLocalOrExternAttr -2- lLocalIdentifier:" + lLocalIdentifier);
+    	
       int lStringInd = lLocalIdentifier.lastIndexOf(".");
       String lLDDExtTitle = lLocalIdentifier;
       String lLDDExtNS = "xxx";
@@ -1769,6 +1775,13 @@ public class LDDDOMParser extends Object {
       String lAttrIdentifier =
           DOMInfoModel.getAttrIdentifier(DMDocument.masterUserClassNamespaceIdNC,
               DMDocument.masterUserClassName, lLDDExtNS, lLDDExtTitle);
+      
+//      if (lLocalIdentifier.contains("pds.comment")) {
+//    	  System.out.println("debug LDDDOMParser getLocalOrExternAttr -3- lAttrIdentifier:" + lAttrIdentifier);
+////    	  ArrayList <String> userDOMClassAttrIdArr = new ArrayList <> (DOMInfoModel.userDOMClassAttrIdMap.keySet());
+////    	  System.out.println("debug GetDOMModel - ID LIST2 - userDOMClassAttrIdArr:" + userDOMClassAttrIdArr);
+//      }
+      
       lDOMAttr = DOMInfoModel.userDOMClassAttrIdMap.get(lAttrIdentifier);
       if (lDOMAttr == null) {
         // DMDocument.registerMessage ("2>error Class:" + lDOMClass.identifier + " Association:" +
@@ -1776,12 +1789,23 @@ public class LDDDOMParser extends Object {
         // return null;
         // *** for qmsre process, when referencing external namespaces, e.g., msn, the attributes
         // are not present locally. Need some other solution. ***
+    	  
+//        if (lLocalIdentifier.contains("pds.comment")) System.out.println("debug LDDDOMParser getLocalOrExternAttr -4- NOT FOUND - lAttrIdentifier:" + lAttrIdentifier);
+	  
         if (lSchemaFileDefn.nameSpaceIdNC.compareTo("qmsre") != 0) {
           DMDocument.registerMessage(
               "2>error Class:" + lDOMClass.identifier + "  Association:" + lDOMProp.localIdentifier
                   + "  Attribute: " + lLocalIdentifier + " - Missing Attribute");
         }
         return null;
+      } else {
+//          if (lLocalIdentifier.contains("pds.comment")) {
+//        	  System.out.println("debug LDDDOMParser getLocalOrExternAttr -5- FOUND - lAttrIdentifier:" + lAttrIdentifier);
+//        	  if (lDOMAttr.valueType == null)
+//            	  System.out.println("debug LDDDOMParser getLocalOrExternAttr -5- lDOMAttr.valueType:" +  "-NULL-");
+//        	  else
+//        		  System.out.println("debug LDDDOMParser getLocalOrExternAttr -5- lDOMAttr.valueType:" +  lDOMAttr.valueType);
+//          }
       }
     }
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
@@ -128,9 +128,6 @@ class MasterDOMInfoModel extends DOMInfoModel {
   public void getUserClassAttrIdMap() {
     for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
       DOMClass lClass = i.next();
-      
-      // 666
-//      if (!lClass.isMasterClass || (lClass.title.indexOf("PDS3") > -1)) continue;
       if (lClass.isInactive || (lClass.title.indexOf("PDS3") > -1)) continue;
       for (Iterator<DOMProp> j = lClass.ownedAttrArr.iterator(); j.hasNext();) {
         DOMProp lDOMProp = j.next();
@@ -145,20 +142,6 @@ class MasterDOMInfoModel extends DOMInfoModel {
           String lUserAttrIdentifier =
               DOMInfoModel.getAttrIdentifier(DMDocument.masterUserClassNamespaceIdNC,
                   DMDocument.masterUserClassName, lDOMAttr.nameSpaceIdNC, lDOMAttr.title);
-          // 666
-//          if (lUserAttrIdentifier.compareTo("0001_NASA_PDS_1.all.USER.pds.comment") == 0) { 
-           if (lDOMAttr.title.compareTo("comment") == 0 || lDOMAttr.title.compareTo("name") == 0) { 
-//    		  System.out.println("\ndebug MasterDOMInfoModel -FOUND- getUserClassAttrIdMap - lClass.identifier:" + lClass.identifier);
-//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lClass.isInactive:" + lClass.isInactive);
-//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lUserAttrIdentifier:" + lUserAttrIdentifier);
-//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lDOMAttr.identifier:" + lDOMAttr.identifier);
-//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lDOMAttr.isInactive:" + lDOMAttr.isInactive);
-//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lDOMAttr.valueType:" + lDOMAttr.valueType);
-//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lDOMAttr.isInactive:" + lDOMAttr.isInactive);
-//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lDOMAttr.protValType:" + lDOMAttr.protValType);
-//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lDOMAttr.xmlBaseDataType:" + lDOMAttr.xmlBaseDataType);
-          }
-         
           DOMInfoModel.userDOMClassAttrIdMap.put(lUserAttrIdentifier, lDOMAttr);
         }
       }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
@@ -128,20 +128,37 @@ class MasterDOMInfoModel extends DOMInfoModel {
   public void getUserClassAttrIdMap() {
     for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
       DOMClass lClass = i.next();
-      if (!lClass.isMasterClass || (lClass.title.indexOf("PDS3") > -1)) {
-        continue; // kludge until boolean is set up
-      }
+      
+      // 666
+//      if (!lClass.isMasterClass || (lClass.title.indexOf("PDS3") > -1)) continue;
+      if (lClass.isInactive || (lClass.title.indexOf("PDS3") > -1)) continue;
       for (Iterator<DOMProp> j = lClass.ownedAttrArr.iterator(); j.hasNext();) {
         DOMProp lDOMProp = j.next();
 
         if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMAttr) {
           DOMAttr lDOMAttr = (DOMAttr) lDOMProp.hasDOMObject;
-
           // the namespace of the USER class for any attribute is the same as the namespace of the
           // attribute
+          
+          if (isAttInactive (lDOMAttr.identifier)) continue;
+          
           String lUserAttrIdentifier =
               DOMInfoModel.getAttrIdentifier(DMDocument.masterUserClassNamespaceIdNC,
                   DMDocument.masterUserClassName, lDOMAttr.nameSpaceIdNC, lDOMAttr.title);
+          // 666
+//          if (lUserAttrIdentifier.compareTo("0001_NASA_PDS_1.all.USER.pds.comment") == 0) { 
+           if (lDOMAttr.title.compareTo("comment") == 0 || lDOMAttr.title.compareTo("name") == 0) { 
+//    		  System.out.println("\ndebug MasterDOMInfoModel -FOUND- getUserClassAttrIdMap - lClass.identifier:" + lClass.identifier);
+//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lClass.isInactive:" + lClass.isInactive);
+//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lUserAttrIdentifier:" + lUserAttrIdentifier);
+//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lDOMAttr.identifier:" + lDOMAttr.identifier);
+//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lDOMAttr.isInactive:" + lDOMAttr.isInactive);
+//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lDOMAttr.valueType:" + lDOMAttr.valueType);
+//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lDOMAttr.isInactive:" + lDOMAttr.isInactive);
+//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lDOMAttr.protValType:" + lDOMAttr.protValType);
+//    		  System.out.println("debug MasterDOMInfoModel -FOUND-  getUserClassAttrIdMap - lDOMAttr.xmlBaseDataType:" + lDOMAttr.xmlBaseDataType);
+          }
+         
           DOMInfoModel.userDOMClassAttrIdMap.put(lUserAttrIdentifier, lDOMAttr);
         }
       }
@@ -989,7 +1006,7 @@ class MasterDOMInfoModel extends DOMInfoModel {
   public void setInactiveFlag() {
     // iterate through the classes
     for (DOMClass lDOMClass : DOMInfoModel.masterDOMClassArr) {
-
+    	
       // iterate through the owned attribute properties and the attributes
       for (DOMProp lDOMProp : lDOMClass.ownedAttrArr) {
         lDOMProp.isInactive = lDOMClass.isInactive;


### PR DESCRIPTION
#733 - LDDTool is throwing ERROR SetMasterAttrXMLBaseDataTypeFromDataType - Data Type is missing

When LDDTool ran against any LDDs (e.g. geom) that references common pds: attributes, LDDTool threw "Data Type is missing" errors. Example attributes were pds.name and pds.comment.

The IMTool/LDDTool refactoring task to move class and attribute information to the protege ontology database from external files had not been sufficiently debugged. Three bugs were found and fixed. One error was intermittent and was found to be dependent on sort order.

Why the Maven build example did not catch this error earlier is yet to be determined.

## ⚙️ Test Data and/or Report
LDDTool runs against valid LDDs will no longer throw "Data Type is missing" errors for common pds: attributes.

Resolves #733
