### PR TITLE
Code refactor - Remove THE MDPTNConfigClassDisp file, code and references

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -158,8 +158,6 @@ public class DMDocument extends Object {
   static boolean overWriteClass = true; // use dd11179.pins class disp, isDeprecated, and versionId
                                          // to overwrite Master DOMClasses, DOMAttrs, and
                                          // DOMPermvalues
-  static boolean useMDPTNConfig = false; // ProtPontDOMModel; get disposition for the class from
-                                        // MDPTNConfigClassDisp
   static boolean overWriteDeprecated = false; // use dd11179.pins isDeprecated to overwrite
                                               // DMDocument.deprecatedObjects2
 
@@ -277,9 +275,6 @@ public class DMDocument extends Object {
 
   // master class order
   static int masterGroupNum;
-
-  // master class disposition maps
-  static TreeMap<String, DispDefn> masterClassDispoMap2;
 
   // registry classes and attributes
   static ArrayList<String> registryClass;
@@ -577,13 +572,6 @@ public class DMDocument extends Object {
         cleanupLDDInputFileName(lSchemaFileDefn);
       }
     }
-    // get the disposition file, parse out allowed stewards and namespaceids
-    XMLDocParserDomMDPTNConfig lMDPTNConfig = new XMLDocParserDomMDPTNConfig();
-    masterClassDispoMap2 = lMDPTNConfig.getXMLTable2(dataDirPath + "MDPTNConfigClassDisp.xml");
-
-//    // 222 test
-//    DMCheckDispositions dmCheckDispositions = new DMCheckDispositions ();
-//    dmCheckDispositions.printDispositions("", masterClassDispoMap2);
     
     // set up the System Build version
     XMLSchemaLabelBuildNum = pds4BuildId;
@@ -710,16 +698,9 @@ public class DMDocument extends Object {
 
   static public void checkRequiredFiles() {
     // check that all the required data files exist
-    File file = new File(dataDirPath + "MDPTNConfigClassDisp.xml");
+
+    File file = new File(dataDirPath + "UpperModel.pont");
     boolean isFound = file.exists();
-    if (!isFound) {
-      registerMessage("3>error " + "Required data file was not found: " + dataDirPath
-          + "MDPTNConfigClassDisp.xml");
-      printErrorMessages();
-      System.exit(1);
-    }
-    file = new File(dataDirPath + "UpperModel.pont");
-    isFound = file.exists();
     if (!isFound) {
       registerMessage(
           "3>error " + "Required data file was not found: " + dataDirPath + "UpperModel.pont");

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMClass.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMClass.java
@@ -43,7 +43,7 @@ public class DOMClass extends ISOClassOAIS11179 {
   String rootClass; // RDF identifier
   String baseClassName; // Fundamental structure class title
   String localIdentifier; // used temporarily for ingest of LDD
-  String used; // MDPTNConfig used flag - Y, N, or I - Inactive
+  String used; // used flag - Y, N, or I - Inactive
   String extrnTitleQM; // title of external class for query model
 
   int subClassLevel;
@@ -188,57 +188,6 @@ public class DOMClass extends ISOClassOAIS11179 {
   /**
    * get the disposition of a class (from Protege)
    */
-  public boolean getDOMClassDisposition(boolean isFromProtege) {
-    // get disposition identifier - if isFromProtege, then the identifier is set else it is not
-    // since it is from an LDD.
-    String lDispId =
-        this.subModelId + "." + DMDocument.registrationAuthorityIdentifierValue + "." + this.title;
-    if (!isFromProtege) {
-      lDispId = "LDD_" + lDispId;
-    }
-    DispDefn lDispDefn = DMDocument.masterClassDispoMap2.get(lDispId);
-    if (lDispDefn != null) {
-      this.used = lDispDefn.used;
-      this.section = lDispDefn.section;
-      String lDisp = lDispDefn.disposition;
-      this.steward = lDispDefn.intSteward;
-      String lClassNameSpaceIdNC = lDispDefn.intNSId; // needed below for identifier
-      this.nameSpaceIdNC = lClassNameSpaceIdNC;
-      this.nameSpaceId = lClassNameSpaceIdNC + ":";
-
-      // if from protege, the identifier needs to be set; if from LDD it cannot be set here.
-      if (isFromProtege) {
-        this.identifier = DOMInfoModel.getClassIdentifier(lClassNameSpaceIdNC, this.title);
-        set11179Attr(this.identifier);
-        // System.out.println("debug getDOMClassDisposition this.identifier:" + this.identifier);
-      }
-      this.isMasterClass = true;
-      if (lDisp.indexOf("V") > -1) {
-        this.isVacuous = true;
-      }
-      if (lDisp.indexOf("S") > -1) {
-        this.isSchema1Class = true;
-      }
-      if (lDisp.indexOf("R") > -1) {
-        this.isRegistryClass = true;
-      }
-      if (lDisp.indexOf("T") > -1) {
-        this.isTDO = true;
-      }
-      if (lDisp.indexOf("d") > -1) {
-        this.isDataType = true;
-      }
-      if (lDisp.indexOf("u") > -1) {
-        this.isUnitOfMeasure = true;
-      }
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   * get the disposition of a class (from Protege)
-   */
   public boolean getDOMClassDisposition2() {
     if (this.title.compareTo(DMDocument.TopLevelAttrClassName) != 0) {
       this.nameSpaceIdNC = DMDocument.masterNameSpaceIdNCLC;
@@ -248,7 +197,6 @@ public class DOMClass extends ISOClassOAIS11179 {
     this.nameSpaceId = this.nameSpaceIdNC + ":";
     this.identifier = DOMInfoModel.getClassIdentifier(this.nameSpaceIdNC, this.title);
     set11179Attr(this.identifier);
-    // System.out.println("debug getDOMClassDisposition2 this.identifier:" + this.identifier);
     return true;
   }
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -709,12 +709,6 @@ public class LDDDOMParser extends Object {
                                                // written
           lDOMClass.steward = lSchemaFileDefn.stewardId;
 
-          // get disposition
-          // if (! lDOMClass.getDOMClassDisposition(false)) {
-          // System.out.println("debug getClass getLDDClassDisposition FAILED lClass.identifier:" +
-          // lDOMClass.identifier);
-          // }
-
           String lDescription = getTextValue(el, "definition");
           // escape any user provided values of "TBD"
           if (lDescription.indexOf("TBD") == 0) {
@@ -2547,7 +2541,6 @@ public class LDDDOMParser extends Object {
         "   IM Label Version Id:" + "   " + DMDocument.masterPDSSchemaFileDefn.labelVersionId);
     prLocalDD.println("   IM Object Model" + "        " + "[" + "UpperModel.pont" + "]");
     prLocalDD.println("   IM Data Dictionary" + "     " + "[" + "dd11179.pins" + "]");
-    prLocalDD.println("   IM Configuration File" + "  " + "[" + "MDPTNConfigClassDisp.xml" + "]");
     prLocalDD.println("   IM Glossary" + "            " + "[" + "Glossary.pins" + "]");
     prLocalDD.println("   IM Document Spec" + "       " + "[" + "DMDocument.pins" + "]");
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
@@ -123,9 +123,6 @@ class ProtPontDOMModel extends DOMInfoModel {
           lClass.registeredByValue = DMDocument.registeredByValue;
           lClass.subModelId = subModelId;
 
-          // get disposition for the class from MDPTNConfig
-          boolean isInParsedClassMap = false;
-
           // get disposition for the class from dd11179
           if (DMDocument.overWriteClass && (lClass.title.compareTo(DMDocument.TopLevelAttrClassName) != 0)) {
             lClass.getDOMClassDisposition2(); // from protege (new)


### PR DESCRIPTION
The IMTool/LDDTool code no longer uses the MDPTNConfigClassDisp file and so it can be removed. This file provided various properties for PDS IM classes. These properties have been moved to the Protege database. In addition to removing the file, all code and references associated with the file have been removed.

## ⚙️ Test Data and/or Report
The software has not been using this file for two builds.  This is simply cleanup.

Resolves #766