### PR TITLE
Code refactoring and cleanup - Remove deprecated objects2 array

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -158,9 +158,6 @@ public class DMDocument extends Object {
   static boolean overWriteClass = true; // use dd11179.pins class disp, isDeprecated, and versionId
                                          // to overwrite Master DOMClasses, DOMAttrs, and
                                          // DOMPermvalues
-  static boolean overWriteDeprecated = false; // use dd11179.pins isDeprecated to overwrite
-                                              // DMDocument.deprecatedObjects2
-
   // alternate IM Version
   // if no option "V" is provided on the command line, then the default is the current IM version.
   static boolean alternateIMVersionFlag = false;
@@ -292,8 +289,7 @@ public class DMDocument extends Object {
   // the set of deprecated classes, attributes, and values
   static ArrayList<DeprecatedDefn> deprecatedObjects2;
   static String Literal_DEPRECATED = " *Deprecated*";
-  static boolean deprecatedAdded;
-  static boolean deprecatedAddedDOM;
+  static boolean deprecatedAddedDOM = false;
 
   // the set of classes and attributes that will be externalized (defined as xs:Element)
   static ArrayList<String> exposedElementArr;
@@ -323,6 +319,8 @@ public class DMDocument extends Object {
 
     // process state for used flags, files, and directories
     dmProcessState = new DMProcessState();
+    
+    // System.out.println("Debug main 240515");
 
     PDSOptionalFlag = false;
     LDDToolFlag = false;
@@ -598,9 +596,6 @@ public class DMDocument extends Object {
 
     registerMessage("1>info Date: " + sTodaysDate);
     registerMessage("1>info PARENT_DIR: " + parentDir);
-
-    // set the deprecated flags
-    setObjectDeprecatedFlag();
 
     // get the 11179 Attribute Dictionary - .pins file
     ProtPinsDOM11179DD lProtPinsDOM11179DD = new ProtPinsDOM11179DD();
@@ -958,331 +953,8 @@ public class DMDocument extends Object {
   }
 
   /**********************************************************************************************************
-   * set object flags, e.g., deprecated
+   * set object flags
    ***********************************************************************************************************/
-
-  static void setObjectDeprecatedFlag() {
-    // deprecated objects *** Inconsistency here to be fixed - Earth base identifier is different
-    // ***
-    deprecatedAdded = false;
-    deprecatedAddedDOM = false;
-    deprecatedObjects2 = new ArrayList<>();
-
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Product_Update", "pds", "Product_Update", "", "", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Update", "pds", "Update", "", "", "", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("File_Area_Update", "pds", "File_Area_Update", "", "", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Update.update_purpose", "pds", "Update", "pds",
-        "update_purpose", "", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Information_Package_Component_Deep_Archive.checksum_type", "pds",
-            "Information_Package_Component_Deep_Archive", "pds", "checksum_type", "MD5Deep 4.n",
-            false));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Airborne", "pds", "Airborne", "", "", "", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("Product_Context.Airborne.type", "pds",
-    // "Airborne", "pds", "type", "Aircraft", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("Product_Context.Airborne.type", "pds",
-    // "Airborne", "pds", "type", "Balloon", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("Product_Context.Airborne.type", "pds",
-    // "Airborne", "pds", "type", "Suborbital Rocket", false));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Observing_System_Component.type", "pds",
-        "Observing_System_Component", "pds", "type", "Airborne", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Observing_System_Component.type", "pds",
-        "Observing_System_Component", "pds", "type", "Aircraft", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Observing_System_Component.type", "pds",
-        "Observing_System_Component", "pds", "type", "Balloon", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Observing_System_Component.type", "pds",
-        "Observing_System_Component", "pds", "type", "Suborbital Rocket", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Observing_System_Component.type", "pds",
-        "Observing_System_Component", "pds", "type", "Computer", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Observing_System_Component.type", "pds",
-        "Observing_System_Component", "pds", "type", "Facility", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Observing_System_Component.type", "pds",
-        "Observing_System_Component", "pds", "type", "Laboratory", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Observing_System_Component.type", "pds",
-        "Observing_System_Component", "pds", "type", "Naked Eye", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Observing_System_Component.type", "pds",
-        "Observing_System_Component", "pds", "type", "Observatory", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Observing_System_Component.type", "pds",
-        "Observing_System_Component", "pds", "type", "Spacecraft", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Observing_System_Component.type", "pds",
-        "Observing_System_Component", "pds", "type", "Artificial Illumination", false));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Internal_Reference.reference_type", "pds",
-        "Internal_Reference", "pds", "reference_type", "is_airborne", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Bundle_Member_Entry.reference_type", "pds",
-        "Bundle_Member_Entry", "pds", "reference_type", "bundle_has_member_collection", false));
-
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Display_2D_Image", "pds", "Display_2D_Image", "", "", "", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Band_Bin_Set", "pds", "Band_Bin_Set", "", "", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Band_Bin", "pds", "Band_Bin", "", "", "", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Axis_Array.unit", "pds", "Axis_Array", "pds", "unit", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Array.Local_Internal_Reference", "pds", "Array",
-        "pds", "Local_Internal_Reference", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Instrument_Host.type.Earth Based", "pds",
-        "Instrument_Host", "pds", "type", "Earth Based", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Instrument_Host.type.Earth-based", "pds",
-        "Instrument_Host", "pds", "type", "Earth-based", false));
-
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Instrument.type", "pds", "Instrument", "pds", "type", "", false));
-    deprecatedObjects2.add(
-        new DeprecatedDefn("Instrument.subtype", "pds", "Instrument", "pds", "subtype", "", false));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Target_Identification.type", "pds",
-        "Target_Identification", "pds", "type", "Calibration", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Target_Identification.type", "pds",
-        "Target_Identification", "pds", "type", "Open Cluster", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Target_Identification.type", "pds",
-        "Target_Identification", "pds", "type", "Globular Cluster", false));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Target_Identification.type", "pds",
-        "Target_Identification", "pds", "type", "Terrestrial Sample", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Target_Identification.type", "pds",
-        "Target_Identification", "pds", "type", "Lunar Sample", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Target_Identification.type", "pds",
-        "Target_Identification", "pds", "type", "Synthetic Sample", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Target_Identification.type", "pds",
-        "Target_Identification", "pds", "type", "Meteorite", false));
-
-    deprecatedObjects2.add(
-        new DeprecatedDefn("Target.type", "pds", "Target", "pds", "type", "Calibration", false));
-    deprecatedObjects2.add(
-        new DeprecatedDefn("Target.type", "pds", "Target", "pds", "type", "Open Cluster", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Target.type", "pds", "Target", "pds", "type",
-        "Globular Cluster", false));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Target.type", "pds", "Target", "pds", "type",
-        "Terrestrial Sample", false));
-    deprecatedObjects2.add(
-        new DeprecatedDefn("Target.type", "pds", "Target", "pds", "type", "Lunar Sample", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Target.type", "pds", "Target", "pds", "type",
-        "Synthetic Sample", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Target.type", "pds", "Target", "pds", "type", "Meteorite", false));
-
-    deprecatedObjects2.add(
-        new DeprecatedDefn("Node.name.Imaging", "pds", "Node", "pds", "name", "Imaging", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Node.name.Planetary Rings", "pds", "Node", "pds",
-        "name", "Planetary Rings", false));
-    deprecatedObjects2.add(new DeprecatedDefn("PDS_Affiliate.team_name.Imaging", "pds",
-        "PDS_Affiliate", "pds", "team_name", "Imaging", false));
-    deprecatedObjects2.add(new DeprecatedDefn("PDS_Affiliate.team_name.Planetary Rings", "pds",
-        "PDS_Affiliate", "pds", "team_name", "Planetary Rings", false));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Primary_Result_Summary.data_regime", "pds",
-        "Primary_Result_Summary", "pds", "data_regime", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Primary_Result_Summary.type", "pds",
-        "Primary_Result_Summary", "pds", "type", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Primary_Result_Summary.processing_level_id", "pds",
-        "Primary_Result_Summary", "pds", "processing_level_id", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("DD_Association.reference_type", "pds",
-        "DD_Association", "pds", "reference_type", "subclass_of", false));
-    deprecatedObjects2.add(new DeprecatedDefn("DD_Association.reference_type", "pds",
-        "DD_Association", "pds", "reference_type", "restriction_of", false));
-    deprecatedObjects2.add(new DeprecatedDefn("DD_Association.reference_type", "pds",
-        "DD_Association", "pds", "reference_type", "extension_of", false));
-    deprecatedObjects2.add(new DeprecatedDefn("DD_Association_External", "pds",
-        "DD_Association_External", "", "", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("DD_Association.local_identifier", "pds",
-        "DD_Association", "pds", "local_identifier", "", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("DD_Association_External.reference_type", "pds",
-    // "DD_Association_External", "pds", "reference_type", "subclass_of", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("DD_Association_External.reference_type", "pds",
-    // "DD_Association_External", "pds", "reference_type", "restriction_of", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("DD_Association_External.reference_type", "pds",
-    // "DD_Association_External", "pds", "reference_type", "extension_of", false));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Table_Binary.record_delimiter", "pds",
-        "Table_Binary", "pds", "record_delimiter", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Field_Bit.start_bit", "pds", "Field_Bit", "pds",
-        "start_bit", "", false));
-    deprecatedObjects2.add(
-        new DeprecatedDefn("Field_Bit.stop_bit", "pds", "Field_Bit", "pds", "stop_bit", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Table_Delimited.record_delimiter", "pds",
-        "Table_Delimited", "pds", "record_delimiter", "carriage-return line-feed", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Table_Delimited_Source_Product_External.record_delimiter", "pds",
-            "Table_Delimited_Source_Product_External", "pds", "record_delimiter",
-            "carriage-return line-feed", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Table_Delimited_Source_Product_Internal.record_delimiter", "pds",
-            "Table_Delimited_Source_Product_Internal", "pds", "record_delimiter",
-            "carriage-return line-feed", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Table_Character.record_delimiter", "pds",
-        "Table_Character", "pds", "record_delimiter", "carriage-return line-feed", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Stream_Text.record_delimiter", "pds", "Stream_Text",
-        "pds", "record_delimiter", "carriage-return line-feed", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Checksum_Manifest.record_delimiter", "pds",
-        "Checksum_Manifest", "pds", "record_delimiter", "carriage-return line-feed", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Inventory.record_delimiter", "pds", "Inventory",
-        "pds", "record_delimiter", "carriage-return line-feed", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Transfer_Manifest.record_delimiter", "pds",
-        "Transfer_Manifest", "pds", "record_delimiter", "carriage-return line-feed", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Uniformly_Sampled.sampling_parameters", "pds",
-        "Uniformly_Sampled", "pds", "sampling_parameters", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Object_Statistics.bit_mask", "pds",
-        "Object_Statistics", "pds", "bit_mask", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Object_Statistics.md5_checksum", "pds",
-        "Object_Statistics", "pds", "md5_checksum", "", false));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Table_Delimited.field_delimiter", "pds",
-        "Table_Delimited", "pds", "field_delimiter", "comma", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Table_Delimited.field_delimiter", "pds",
-        "Table_Delimited", "pds", "field_delimiter", "horizontal tab", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Table_Delimited.field_delimiter", "pds",
-        "Table_Delimited", "pds", "field_delimiter", "semicolon", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Table_Delimited.field_delimiter", "pds",
-        "Table_Delimited", "pds", "field_delimiter", "vertical bar", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Table_Delimited_Source_Product_External.field_delimiter", "pds",
-            "Table_Delimited_Source_Product_External", "pds", "field_delimiter", "comma", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Table_Delimited_Source_Product_External.field_delimiter", "pds",
-            "Table_Delimited_Source_Product_External", "pds", "field_delimiter", "horizontal tab",
-            false));
-    deprecatedObjects2.add(new DeprecatedDefn(
-        "Table_Delimited_Source_Product_External.field_delimiter", "pds",
-        "Table_Delimited_Source_Product_External", "pds", "field_delimiter", "semicolon", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Table_Delimited_Source_Product_External.field_delimiter", "pds",
-            "Table_Delimited_Source_Product_External", "pds", "field_delimiter", "vertical bar",
-            false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Table_Delimited_Source_Product_Internal.field_delimiter", "pds",
-            "Table_Delimited_Source_Product_Internal", "pds", "field_delimiter", "comma", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Table_Delimited_Source_Product_Internal.field_delimiter", "pds",
-            "Table_Delimited_Source_Product_Internal", "pds", "field_delimiter", "horizontal tab",
-            false));
-    deprecatedObjects2.add(new DeprecatedDefn(
-        "Table_Delimited_Source_Product_Internal.field_delimiter", "pds",
-        "Table_Delimited_Source_Product_Internal", "pds", "field_delimiter", "semicolon", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Table_Delimited_Source_Product_Internal.field_delimiter", "pds",
-            "Table_Delimited_Source_Product_Internal", "pds", "field_delimiter", "vertical bar",
-            false));
-    deprecatedObjects2.add(new DeprecatedDefn("Inventory.field_delimiter", "pds", "Inventory",
-        "pds", "field_delimiter", "comma", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Inventory.field_delimiter", "pds", "Inventory",
-        "pds", "field_delimiter", "horizontal tab", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Inventory.field_delimiter", "pds", "Inventory",
-        "pds", "field_delimiter", "semicolon", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Inventory.field_delimiter", "pds", "Inventory",
-        "pds", "field_delimiter", "vertical bar", false));
-
-    // deprecatedObjects2.add(new DeprecatedDefn ("Update.Update_Entry", "pds", "Update_Entry", "",
-    // "", "", false));
-
-    deprecatedObjects2.add(
-        new DeprecatedDefn("Telescope.altitude", "pds", "Telescope", "pds", "altitude", "", false));
-
-
-    deprecatedObjects2.add(new DeprecatedDefn("Document_Format.format_type", "pds",
-        "Document_Format", "pds", "format_type", "single file", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Document_Format.format_type", "pds",
-        "Document_Format", "pds", "format_type", "multiple file", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type", "pds", "Instrument", "pds",
-    // "type", "Thermal And Electrical Conductivity Probe", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type", "pds", "Instrument", "pds",
-    // "type", "X-ray Defraction Spectrometer", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type", "pds", "Instrument", "pds",
-    // "type", "Alpha Particle Xray Spectrometer", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type", "pds", "Instrument", "pds",
-    // "type", "X-ray Fluorescence", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("Instrument.type", "pds", "Instrument", "pds",
-    // "type", "Grinding And Drilling Tool", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Node.type", "name", "Node", "pds", "name",
-        "Navigation Ancillary Information Facility", false));
-    deprecatedObjects2.add(new DeprecatedDefn("PDS_Affiliate.team_name", "pds", "PDS_Affiliate",
-        "pds", "team_name", "Navigation Ancillary Information Facility", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("Encoded_Binary.encoding_standard_id", "pds",
-    // "Encoded_Binary", "pds", "encoding_standard_id", "CCSDS Communications Protocols", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Encoded_Binary.encoding_standard_id", "pds", "Encoded_Binary",
-            "pds", "encoding_standard_id", "CCSDS Space Communications Protocols", false));
-    // deprecatedObjects2.add(new DeprecatedDefn ("Encoded_Image.encoding_standard_id", "pds",
-    // "Encoded_Image", "pds", "encoding_standard_id", "J2C", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Software.version_id", "pds", "Software", "pds",
-        "version_id", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Instrument_Host.version_id", "pds",
-        "Instrument_Host", "pds", "version_id", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Instrument_Host.instrument_host_version_id", "pds",
-        "Instrument_Host", "pds", "instrument_host_version_id", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Data_Set_PDS3.start_date_time", "pds",
-        "Data_Set_PDS3", "pds", "start_date_time", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Data_Set_PDS3.stop_date_time", "pds",
-        "Data_Set_PDS3", "pds", "stop_date_time", "", false));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Document_File.document_standard_id", "pds",
-        "Document_File", "pds", "document_standard_id", "HTML 2.0", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Document_File.document_standard_id", "pds",
-        "Document_File", "pds", "document_standard_id", "HTML 3.2", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Document_File.document_standard_id", "pds",
-        "Document_File", "pds", "document_standard_id", "HTML 4.0", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Document_File.document_standard_id", "pds",
-        "Document_File", "pds", "document_standard_id", "HTML 4.01", false));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Radiance.unit_id", "pds",
-        "Units_of_Radiance", "pds", "unit_id", "W*m**-2*sr**-1", true));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Spectral_Irradiance.unit_id", "pds",
-        "Units_of_Spectral_Irradiance", "pds", "unit_id", "SFU", true));
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Spectral_Irradiance.unit_id", "pds",
-        "Units_of_Spectral_Irradiance", "pds", "unit_id", "W*m**-2*Hz**-1", true));
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Spectral_Irradiance.unit_id", "pds",
-        "Units_of_Spectral_Irradiance", "pds", "unit_id", "W*m**-2*nm**-1", true));
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Spectral_Irradiance.unit_id", "pds",
-        "Units_of_Spectral_Irradiance", "pds", "unit_id", "W*m**-3", true));
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Spectral_Irradiance.unit_id", "pds",
-        "Units_of_Spectral_Irradiance", "pds", "unit_id", "uW*cm**-2*um**-1", true));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Spectral_Radiance.unit_id", "pds",
-        "Units_of_Spectral_Radiance", "pds", "unit_id", "W*m**-2*sr**-1*Hz**-1", true));
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Spectral_Radiance.unit_id", "pds",
-        "Units_of_Spectral_Radiance", "pds", "unit_id", "W*m**-2*sr**-1*nm**-1", true));
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Spectral_Radiance.unit_id", "pds",
-        "Units_of_Spectral_Radiance", "pds", "unit_id", "W*m**-2*sr**-1*um**-1", true));
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Spectral_Radiance.unit_id", "pds",
-        "Units_of_Spectral_Radiance", "pds", "unit_id", "W*m**-3*sr**-1", true));
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Spectral_Radiance.unit_id", "pds",
-        "Units_of_Spectral_Radiance", "pds", "unit_id", "uW*cm**-2*sr**-1*um**-1", true));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Wavenumber.unit_id", "pds",
-        "Units_of_Wavenumber", "pds", "unit_id", "cm**-1", true));
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Wavenumber.unit_id", "pds",
-        "Units_of_Wavenumber", "pds", "unit_id", "m**-1", true));
-    deprecatedObjects2.add(new DeprecatedDefn("Units_of_Wavenumber.unit_id", "pds",
-        "Units_of_Wavenumber", "pds", "unit_id", "nm**-1", true));
-
-    deprecatedObjects2.add(
-        new DeprecatedDefn("Units_of_Map_Scale", "pds", "Units_of_Map_Scale", "", "", "", false));
-
-    deprecatedObjects2
-        .add(new DeprecatedDefn("ASCII_Date", "pds", "ASCII_Date", "", "", "", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("ASCII_Date_Time", "pds", "ASCII_Date_Time", "", "", "", false));
-    deprecatedObjects2.add(
-        new DeprecatedDefn("ASCII_Date_Time_UTC", "pds", "ASCII_Date_Time_UTC", "", "", "", false));
-
-    deprecatedObjects2.add(new DeprecatedDefn("Vector", "pds", "Vector", "", "", "", false));
-    deprecatedObjects2
-        .add(new DeprecatedDefn("Vector_Component", "pds", "Vector_Component", "", "", "", false));
-    deprecatedObjects2.add(
-        new DeprecatedDefn("Vector_Cartesian_3", "pds", "Vector_Cartesian_3", "", "", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Vector_Cartesian_3_Acceleration", "pds",
-        "Vector_Cartesian_3_Acceleration", "", "", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Vector_Cartesian_3_Position", "pds",
-        "Vector_Cartesian_3_Position", "", "", "", false));
-    deprecatedObjects2.add(new DeprecatedDefn("Vector_Cartesian_3_Velocity", "pds",
-        "Vector_Cartesian_3_Velocity", "", "", "", false));
-  }
 
   static void setexposedElementFlag() {
     // the set of classes and attributes that will be externalized (defined as xs:Element)

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -339,10 +339,6 @@ public class GetDOMModel extends Object {
     // used) use flags.
     DMDocument.masterDOMInfoModel.setInactiveFlag();
 
-    // 333
-    // 018.7 - get the Deprecated Objects array
-    // DMDocument.deprecatedObjects2 = DMDocument.masterDOMInfoModel.getDeprecatedObjectsArr();
-
     // 019 - general master attribute fixup
     // anchorString; sort_identifier; sort attribute.valArr
     DMDocument.masterDOMInfoModel.setMasterAttrGeneral();
@@ -357,16 +353,7 @@ public class GetDOMModel extends Object {
     DMDocument.masterDOMInfoModel.setRegistrationStatus();
 
     // 018.7 - get the Deprecated Objects array
-    // 333
-    if (DMDocument.overWriteDeprecated) {
-      DMDocument.deprecatedObjects2 = DMDocument.masterDOMInfoModel.getDeprecatedObjectsArr();
-    }
     DMDocument.deprecatedObjects2 = DMDocument.masterDOMInfoModel.getDeprecatedObjectsArr();
-
-    // 333 DMDocument.Dump333DeprecatedObjects2 ("DMDocument", DMDocument.deprecatedObjects2);
-
-    // 333 DMDocument.Dump333DeprecatedObjects2 ("DD11179",
-    // DMDocument.masterDOMInfoModel.getDeprecatedObjectsArr());
 
     // 024 - set up master data types - the data type map
     DMDocument.masterDOMInfoModel.setMasterDataType2();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
@@ -1077,12 +1077,6 @@ class MasterDOMInfoModel extends DOMInfoModel {
 		  sortedDeprecatedObjectsAMap.put(getNormalizedTitle(lDeprecatedDefn), lDeprecatedDefn);
 	  }
 	  return(new ArrayList <DeprecatedDefn> (sortedDeprecatedObjectsAMap.values()));
-	  
-	  
-//	  return deprecatedObjectsArr;
-//    return addOddDeprecations(deprecatedObjectsArr);
-//    return getDeprecatedObjectsArrReordered(addOddDeprecations(deprecatedObjectsArr));
-//    return getDeprecatedObjectsArrReordered(deprecatedObjectsArr);
   }
 
   // reorder deprecated object array as before 1.21.0.0 -- order listed in DMDocument.deprecatedObjects2
@@ -1110,52 +1104,10 @@ class MasterDOMInfoModel extends DOMInfoModel {
     	titles1Arr.add(normTitle);
     	String newSeqno = deprecatedObjectsTitleMap.get(normTitle);
     	if (newSeqno == null) {
-//    	    System.out.println ("\ndebug MasterDOMInfoModel - NOTFOUND - normTitle:" + normTitle);
     		newSeqno = "9999";
     	}
     	deprecatedObjectsNewMap.put(newSeqno, lDeprecatedDefn);
     }
-    
-//    // reorder deprecated object array as before 1.21.0.0 -- order listed in DMDocument.deprecatedObjects2
-//    public ArrayList<DeprecatedDefn> getDeprecatedObjectsArrReordered(ArrayList<DeprecatedDefn> deprecatedObjectsArr) {
-//
-//  	// get the order of the original deprecated ArrayList - deprecatedObjects2
-//  	TreeMap <String, String> deprecatedObjectsTitleMap = new TreeMap <> ();
-//      TreeMap <String, DeprecatedDefn> deprecatedObjectsNewMap = new TreeMap <> ();
-//      ArrayList<String> titles20Arr = new ArrayList <> ();
-//      ArrayList<String> seqNum20Arr = new ArrayList <> ();
-//      int seqNum = 1000;
-//      for (DeprecatedDefn lDeprecatedDefn2 : DMDocument.deprecatedObjects2) {
-//      	seqNum += 10;
-//      	String seqNumStr = String.valueOf(seqNum);
-//      	String normTitle = getNormalizedTitle(lDeprecatedDefn2);
-//      	deprecatedObjectsTitleMap.put(normTitle, seqNumStr);
-//      	seqNum20Arr.add(seqNumStr);
-//      	titles20Arr.add(normTitle);
-//      }
-//      
-//      // add odd deprecations - not in protege entity model
-//      ArrayList<String> titles1Arr = new ArrayList <> ();
-//      for (DeprecatedDefn lDeprecatedDefn : addOddDeprecations(deprecatedObjectsArr)) {
-//      	String normTitle = getNormalizedTitle(lDeprecatedDefn);
-//      	titles1Arr.add(normTitle);
-//      	String newSeqno = deprecatedObjectsTitleMap.get(normTitle);
-//      	if (newSeqno == null) {
-////      	    System.out.println ("\ndebug MasterDOMInfoModel - NOTFOUND - normTitle:" + normTitle);
-//      		newSeqno = "9999";
-//      	}
-//      	deprecatedObjectsNewMap.put(newSeqno, lDeprecatedDefn);
-//      }
-    
-    // debug print
-//    System.out.println ("debug MasterDOMInfoModel - titles1Arr:" + titles1Arr);				// titles of new
-//    ArrayList<String> seqNum3Arr = new ArrayList <> (deprecatedObjectsNewMap.keySet());
-//    System.out.println ("debug MasterDOMInfoModel - deprecatedObjectsNewMap.keySet() - newSeqno3Arr:" + seqNum3Arr);				// seqNum of original
-//    ArrayList<DeprecatedDefn> defn3Arr = new ArrayList <> (deprecatedObjectsNewMap.values());
-//    ArrayList<String> defn3TitleArr = new ArrayList <> ();
-//    for (DeprecatedDefn defn3 : defn3Arr) defn3TitleArr.add(defn3.title);
-//    System.out.println ("debug MasterDOMInfoModel - deprecatedObjectsNewMap.values() - defn3TitleArr:" + defn3TitleArr);				// titles of original
-
     ArrayList<DeprecatedDefn> deprecatedObjectsArrReordered = new ArrayList <> (deprecatedObjectsNewMap.values());
     return deprecatedObjectsArrReordered;
   }
@@ -1178,7 +1130,6 @@ class MasterDOMInfoModel extends DOMInfoModel {
       }
       return normTitle;
   }
-  
   
   public ArrayList<DeprecatedDefn> addOddDeprecations(ArrayList<DeprecatedDefn> deprecatedObjectsArr) {
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/SchemaFileDefn.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/SchemaFileDefn.java
@@ -31,6 +31,7 @@
 package gov.nasa.pds.model.plugin;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 
 public class SchemaFileDefn {
@@ -43,8 +44,13 @@ public class SchemaFileDefn {
   // each namespace has a version identifier - model version id
   String versionId;
 
-  // each namespace has a label version identifier - xml product version id
-  String labelVersionId;
+  // various version identifiers
+  String ont_version_id; // 0.1.0.0
+  String lab_version_id; // 0100
+  String sch_version_id; // 1.0.0
+  String ns_version_id; // 01
+  String identifier_version_id; // 0.1
+  String labelVersionId; // each namespace has a label version identifier - xml product version id
 
   // steward_id is the primary steward identifier; the steward assigns the namespaceid
   String stewardId;
@@ -120,13 +126,6 @@ public class SchemaFileDefn {
   // stewarArr is a list of all stewards that share authority over this namespaceid
   ArrayList<String> stewardArr;
 
-  // various version identifiers
-  String ont_version_id; // 0.1.0.0.a
-  String lab_version_id; // 0100a
-  String sch_version_id; // 1.0.0
-  String ns_version_id; // 01
-  String identifier_version_id; // 0.1
-
   public SchemaFileDefn(String id) {
     identifier = id;
     versionId = "0.0.0.0.n";
@@ -188,6 +187,38 @@ public class SchemaFileDefn {
     stewardArr = new ArrayList<>();
   }
 
+  // getters
+  
+  //get ont_version_id
+  public String getOntologyVersionId() {
+	  return ont_version_id;
+  }
+
+  //get lab_version_id
+  public String getLabVersionId() {
+	  return lab_version_id;
+  }
+
+  //get sch_version_id
+  public String getSchemaVersionId() {
+	  return sch_version_id;
+  }
+
+  //get ns_version_id
+  public String getNameSpaceVersionId() {
+	  return ns_version_id;
+  }
+
+  //get identifier_version_id
+  public String getIdentiferVersionId() {
+	  return identifier_version_id;
+  }
+
+  //get labelVersionId
+  public String getLabelVersionId() {
+	  return labelVersionId;
+  }
+ 
   public void setStewardIds(String lSteward) {
     stewardId = lSteward;
     stewardArr.add(lSteward);
@@ -241,17 +272,12 @@ public class SchemaFileDefn {
 
   // set the various version identifiers
   public void setVersionIds() {
-    // get a cleaned up version id
-    // the following attributes are updated.
-    // ont_version_id, lab_version_id, identifier_version_id
+    // cleanup version id; ont_version_id, lab_version_id, identifier_version_id
     getCleanVersionId(versionId);
-    // *** ont_version_id = DOMInfoModel.ont_version_id; // 1.0.0.0
-    sch_version_id = ont_version_id; // 1.0.0.0
-    // *** identifier_version_id = DOMInfoModel.identifier_version_id; // 1.0
-    // ***lab_version_id = DOMInfoModel.lab_version_id; // 1000
-    ns_version_id = lab_version_id.substring(0, 1); // 1
+//    sch_version_id = ont_version_id; // 1.0.0.0
+//    ns_version_id = lab_version_id.substring(0, 1); // 1
 
-    String lLabelVersionId = getCleanLabelVersionId(DMDocument.infoModelVersionId);
+    String lFileNameIMVersionId = getCleanLabelVersionId(DMDocument.infoModelVersionId);
 
     // set the relative file spec now that we have a version id
     relativeFileSpecModelSpec_DOM =
@@ -264,7 +290,7 @@ public class SchemaFileDefn {
       relativeFileNameXMLSchema =
           DMDocument.mastModelId + "_" + nameSpaceIdNCUC + "_" + lab_version_id + ".xsd";
       relativeFileNameXMLSchema2 = DMDocument.mastModelId + "_" + nameSpaceIdNCUC + "_"
-          + lLabelVersionId + "_" + lab_version_id + ".xsd";
+          + lFileNameIMVersionId + "_" + lab_version_id + ".xsd";
       relativeFileNameSchematron =
           DMDocument.mastModelId + "_" + nameSpaceIdNCUC + "_" + lab_version_id + ".sch";
       relativeFileSpecXMLLabel = DMDocument.outputDirPath + "SchemaXML4/" + DMDocument.mastModelId
@@ -336,180 +362,81 @@ public class SchemaFileDefn {
     relativeFileSpecClassDefn = DMDocument.outputDirPath + "export/defnClass/";
     return;
   }
-
+  
   // get clean version id
-  void getCleanVersionId(String versionId) {
-    // parse out the version id into an array of strings, one string for each digit
-    char ic = 'x';
-    ArrayList<String> vIdDigitArr = new ArrayList<>();
-    String vIdDigit = "";
-    StringBuffer sbVersionId = new StringBuffer(versionId);
-    for (int i = 0; i < sbVersionId.length(); i++) {
-      ic = sbVersionId.charAt(i);
-      if (ic != '.') {
-        if (Character.isDigit(ic)) {
-          vIdDigit += new Character(ic).toString();
-        } else {
-          vIdDigit += "x";
-        }
-      } else {
-        vIdDigitArr.add(vIdDigit);
-        vIdDigit = "";
-      }
-    }
-    vIdDigitArr.add(vIdDigit);
+  void getCleanVersionId(String versionId) { 
+	  
+	// split the version id on "." 
+    ArrayList<String> versionIdPartArr = new ArrayList<>(Arrays.asList(versionId.split("\\.")));
 
-    // ensure that there are four digits
-    for (int i = vIdDigitArr.size(); i < 4; i++) {
-      vIdDigitArr.add("0");
-    }
-
-    // get ont_version_id - 1.0.0.0
-    String lId = "";
-    String lDel = "";
-    for (Iterator<String> i = vIdDigitArr.iterator(); i.hasNext();) {
-      String lDigit = i.next();
-      lId += lDel + lDigit;
-      lDel = ".";
-    }
-    ont_version_id = lId;
-
-    // get lab_version_id - 1000
-    lId = "";
-    for (Iterator<String> i = vIdDigitArr.iterator(); i.hasNext();) {
-      String lDigit = i.next();
-      if (lDigit.compareTo("10") == 0) {
-        lDigit = "A";
-      }
-      if (lDigit.compareTo("11") == 0) {
-        lDigit = "B";
-      }
-      if (lDigit.compareTo("12") == 0) {
-        lDigit = "C";
-      }
-      if (lDigit.compareTo("13") == 0) {
-        lDigit = "D";
-      }
-      if (lDigit.compareTo("14") == 0) {
-        lDigit = "E";
-      }
-      if (lDigit.compareTo("15") == 0) {
-        lDigit = "F";
-      }
-      if (lDigit.compareTo("16") == 0) {
-        lDigit = "G";
-      }
-      if (lDigit.compareTo("17") == 0) {
-        lDigit = "H";
-      }
-      if (lDigit.compareTo("18") == 0) {
-        lDigit = "I";
-      }
-      if (lDigit.compareTo("19") == 0) {
-        lDigit = "J";
-      }
-      if (lDigit.compareTo("20") == 0) {
-        lDigit = "K";
-      }
-      if (lDigit.compareTo("21") == 0) {
-        lDigit = "L";
-      }
-      if (lDigit.compareTo("22") == 0) {
-          lDigit = "M";
-      }
-      lId += lDigit;
-    }
-    lab_version_id = lId;
-
-    // get identifier_version_id - 1.0
-    lId = "";
-    int cnt = 0;
-    lDel = "";
-    for (Iterator<String> i = vIdDigitArr.iterator(); i.hasNext();) {
-      String lDigit = i.next();
-      lId += lDel + lDigit;
-      lDel = ".";
-      cnt++;
-      if (cnt >= 2) {
-        break;
-      }
-    }
-    identifier_version_id = lId;
+    // ensure that there are at least four parts
+    for (int i = versionIdPartArr.size(); i < 4; i++) {
+    	versionIdPartArr.add("0");
+    }	  
+	
+    // set the version ids
+	ont_version_id = getIMVersionId(versionIdPartArr);
+	lab_version_id = getFileNameVersionId(versionIdPartArr);	  
+	sch_version_id = ont_version_id; // 1.0.0.0
+	ns_version_id = versionIdPartArr.get(0);
+    identifier_version_id = versionIdPartArr.get(0) + "." + versionIdPartArr.get(1);
     return;
   }
 
   // get clean label version id
   String getCleanLabelVersionId(String versionId) {
-    // parse out the version id into an array of strings, one string for each digit
-    String labelVersionID = "";
-    char ic = 'x';
-    ArrayList<String> vIdDigitArr = new ArrayList<>();
-    String vIdDigit = "";
-    StringBuffer sbVersionId = new StringBuffer(versionId);
-    for (int i = 0; i < sbVersionId.length(); i++) {
-      ic = sbVersionId.charAt(i);
-      if (ic != '.') {
-        if (Character.isDigit(ic)) {
-          vIdDigit += new Character(ic).toString();
-        } else {
-          vIdDigit += "x";
+	  
+		// split the version id on "." 
+	    ArrayList<String> versionIdPartArr = new ArrayList<>(Arrays.asList(versionId.split("\\.")));
+
+	    // ensure that there are at least four parts
+	    for (int i = versionIdPartArr.size(); i < 4; i++) {
+	    	versionIdPartArr.add("0");
+	    }	  
+		
+	    // set the version ids
+	    return getFileNameVersionId(versionIdPartArr);	  
+  }
+  
+  // validate version id (1.12.0.0)
+  private String getIMVersionId(ArrayList<String> versionIdPartArr) {
+
+    // get lab_version_id - 1.0.0.0
+    String lab_version_id = "";
+    String lDel = "";
+    for (String versionIdPart: versionIdPartArr) {
+    	lab_version_id += lDel + versionIdPart;
+      lDel = ".";
+    }
+    return lab_version_id;
+  }
+  
+  // get filename version id (1C00)
+  private String getFileNameVersionId(ArrayList<String> versionIdPartArr) {
+
+    // get lab_version_id - 1X00
+    String lab_version_id = "";
+    int versionIdPartInt;
+    for (String versionIdPart : versionIdPartArr) {
+        try {
+            versionIdPartInt = Integer.parseInt(versionIdPart);
+            // use 0..9 otherwise 10..35 -> A ..Z
+    		if (versionIdPartInt > 9) {
+    			int digit = versionIdPartInt - 9;
+    			if (digit >= 1 && digit <= 26) {
+    				char letter = (char) (digit + 64); // ASCII value of 'A' is 65
+    				versionIdPart = String.valueOf(letter);
+    			} else {
+    	        	versionIdPart = "x";	
+    			}
+    		} else if (versionIdPartInt < 0) {
+	        	versionIdPart = "x";
+    		}
+        } catch (NumberFormatException e) {
+        	versionIdPart = "x";
         }
-      } else {
-        vIdDigitArr.add(vIdDigit);
-        vIdDigit = "";
-      }
+    	lab_version_id += versionIdPart;
     }
-    vIdDigitArr.add(vIdDigit);
-
-    // ensure that there are four digits
-    for (int i = vIdDigitArr.size(); i < 4; i++) {
-      vIdDigitArr.add("0");
-    }
-
-    // get lab_version_id - 1000
-    String lId = "";
-    for (Iterator<String> i = vIdDigitArr.iterator(); i.hasNext();) {
-      String lDigit = i.next();
-      if (lDigit.compareTo("10") == 0) {
-        lDigit = "A";
-      }
-      if (lDigit.compareTo("11") == 0) {
-        lDigit = "B";
-      }
-      if (lDigit.compareTo("12") == 0) {
-        lDigit = "C";
-      }
-      if (lDigit.compareTo("13") == 0) {
-        lDigit = "D";
-      }
-      if (lDigit.compareTo("14") == 0) {
-        lDigit = "E";
-      }
-      if (lDigit.compareTo("15") == 0) {
-        lDigit = "F";
-      }
-      if (lDigit.compareTo("16") == 0) {
-        lDigit = "G";
-      }
-      if (lDigit.compareTo("17") == 0) {
-        lDigit = "H";
-      }
-      if (lDigit.compareTo("18") == 0) {
-        lDigit = "I";
-      }
-      if (lDigit.compareTo("19") == 0) {
-        lDigit = "J";
-      }
-      if (lDigit.compareTo("20") == 0) {
-        lDigit = "K";
-      }
-      if (lDigit.compareTo("21") == 0) {
-        lDigit = "L";
-      }
-      lId += lDigit;
-    }
-    labelVersionID = lId;
-
-    return labelVersionID;
+    return lab_version_id;
   }
 }


### PR DESCRIPTION
Removed the Deprecated Objects Array (deprecatedObjects2) from the IMTool/LDDTool source code since this information is now in the Protege database. This was a list of the classes, attributes, and standard  values that had been deprecated since V1.0. 

Also rewrote getCleanVersionId  and getCleanLabelVersionId in the SchemaFileDefn class. This class generates the various version ids and file names used for the generation of the PDS4 stds documents.


## ⚙️ Test Data and/or Report
There should be no changes in the generated documents. Diffs were performed against previously generated documents 

Resolves #768
