### PR TITLE
Fixed problem where LDDTool does not include all rules from IngestLDD

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -470,8 +470,8 @@ public class DMDocument extends Object {
 //      if (debugFlag) dirExt = "/bin/../Data/";
       dataDirPath = parentDir + dirExt;
       if (debugFlag) {
-          parentDir = System.getProperty("data.home") + "/git/pds4-information-model/model-ontology/src/ontology";
-    	  dataDirPath = System.getProperty("data.home") + "/git/pds4-information-model/model-ontology/src/ontology/Data/";
+          parentDir = System.getProperty("user.home") + "/git/pds4-information-model/model-ontology/src/ontology";
+    	  dataDirPath = System.getProperty("user.home") + "/git/pds4-information-model/model-ontology/src/ontology/Data/";
       }
       // if this is an LDDTool run then an alternate path is allowed (option "V")
       // IMTool runs ignore the -V option

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -457,6 +457,7 @@ public class DMDocument extends Object {
         }
       }
     } else {
+      registerMessage("0>info - Property data.home is null");   
       String sysUserDir = System.getProperty("user.dir");
       if (sysUserDir == null) {
         registerMessage("3>error Environment variable sysUserDir is null");
@@ -466,8 +467,12 @@ public class DMDocument extends Object {
       sysUserDir = sysUserDir.replace('\\', '/');
       parentDir = sysUserDir;
       String dirExt = "/model-ontology/src/ontology/Data/";
-      if (debugFlag) dirExt = "/bin/../Data/";
+//      if (debugFlag) dirExt = "/bin/../Data/";
       dataDirPath = parentDir + dirExt;
+      if (debugFlag) {
+          parentDir = "C:/Users/jshughes/git/pds4-information-model/model-ontology/src/ontology";
+    	  dataDirPath = "C:/Users/jshughes/git/pds4-information-model/model-ontology/src/ontology/Data/";
+      }
       // if this is an LDDTool run then an alternate path is allowed (option "V")
       // IMTool runs ignore the -V option
       if (LDDToolFlag && alternateIMVersionFlag) {
@@ -476,6 +481,7 @@ public class DMDocument extends Object {
         }
        }
     }
+    registerMessage("0>info - Parent Directory:" + parentDir);
     registerMessage("0>info - IM Directory Path:" + dataDirPath);
     registerMessage("0>info - IM Versions Available:" + alternateIMVersionArr);
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -470,8 +470,8 @@ public class DMDocument extends Object {
 //      if (debugFlag) dirExt = "/bin/../Data/";
       dataDirPath = parentDir + dirExt;
       if (debugFlag) {
-          parentDir = "C:/Users/jshughes/git/pds4-information-model/model-ontology/src/ontology";
-    	  dataDirPath = "C:/Users/jshughes/git/pds4-information-model/model-ontology/src/ontology/Data/";
+          parentDir = System.getProperty("data.home") + "/git/pds4-information-model/model-ontology/src/ontology";
+    	  dataDirPath = System.getProperty("data.home") + "/git/pds4-information-model/model-ontology/src/ontology/Data/";
       }
       // if this is an LDDTool run then an alternate path is allowed (option "V")
       // IMTool runs ignore the -V option

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetDOMModel.java
@@ -239,21 +239,7 @@ public class GetDOMModel extends Object {
       DOMInfoModel.masterDOMRuleMap.put(lRule.rdfIdentifier, lRule);
       DOMInfoModel.masterDOMRuleIdMap.put(lRule.identifier, lRule);
     }
-    DOMInfoModel.masterDOMRuleArr = new ArrayList<>(DOMInfoModel.masterDOMRuleIdMap.values());
-
-    // 006 - get usecases from UpperModel.pins file
-    /*
-     * lProtPinsDOMModel.getUseCasesPins ();
-     * 
-     * // 006.5 - copy in parsed rules from uppermodel.pins ArrayList <DOMUseCase>
-     * testUseCaseDefnArr = new ArrayList <DOMUseCase>
-     * (lProtPinsDOMModel.testUseCaseDefnMap.values()); for (Iterator <DOMUseCase> i =
-     * testUseCaseDefnArr.iterator(); i.hasNext();) { DOMUseCase lUseCase = (DOMUseCase) i.next();
-     * DOMInfoModel.masterDOMUseCaseMap.put(lUseCase.rdfIdentifier, lUseCase);
-     * DOMInfoModel.masterDOMUseCaseIdMap.put(lUseCase.identifier, lUseCase); }
-     * DOMInfoModel.masterDOMUseCaseArr = new ArrayList <DOMUseCase>
-     * (DOMInfoModel.masterDOMUseCaseIdMap.values());
-     */
+    DOMInfoModel.masterDOMRuleArr = new ArrayList<>(DOMInfoModel.masterDOMRuleMap.values()); // use unique rdfIdentifier
 
     // 007 - get list of USER attributes (owned attributes)
     // This must be done before LDD parsing since it needs the USER attributes

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -2249,7 +2249,7 @@ public class LDDDOMParser extends Object {
     ArrayList<DOMRule> tempSchematronRuleArr;
 
     // save the masters
-    tempSchematronRuleArr = new ArrayList<>(DOMInfoModel.masterDOMRuleIdMap.values());
+    tempSchematronRuleArr = new ArrayList<>(DOMInfoModel.masterDOMRuleMap.values());  // use unique rdfIdentifier
 
     // clear the masters
     DOMInfoModel.masterDOMRuleIdMap.clear();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSchematron.java
@@ -65,7 +65,7 @@ class WriteDOMSchematron extends Object {
 
     // select out the rules for this namespace
     ArrayList<DOMRule> lSelectRuleArr = new ArrayList<>();
-    ArrayList<DOMRule> lRuleArr = new ArrayList<>(DOMInfoModel.masterDOMRuleIdMap.values());
+    ArrayList<DOMRule> lRuleArr = new ArrayList<>(DOMInfoModel.masterDOMRuleMap.values()); // use unique rdfIdentifier
     for (DOMRule lRule : lRuleArr) {
       if (lSchemaFileDefn.isMaster) {
         if (lRule.isMissionOnly || !(lRule.alwaysInclude
@@ -93,66 +93,6 @@ class WriteDOMSchematron extends Object {
         DMDocument.registerMessage("1>warning "
             + "Write Schematron - Invalid governance in SchemaFileDefn  - lSchemaFileDefn.identifier:"
             + lSchemaFileDefn.identifier);
-      }
-      lSelectRuleArr.add(lRule);
-    }
-    writeSchematronRuleClasses(lSchemaFileDefn, lSelectRuleArr, prSchematron);
-
-    // write schematron file footer
-    printSchematronFileFtr(prSchematron);
-  }
-
-  // write the schematron rules
-  public void writeSchematronRuleSimplified(SchemaFileDefn lSchemaFileDefn,
-      TreeMap<String, DOMClass> lMasterDOMClassMap, PrintWriter prSchematron) {
-    // write schematron file header
-    printSchematronFileHdr(lSchemaFileDefn, prSchematron);
-    printSchematronFileCmt(prSchematron);
-
-    // select out the rules for this namespace
-    ArrayList<DOMRule> lSelectRuleArr = new ArrayList<>();
-
-    DMDocument.registerMessage("0>info ");
-    DMDocument.registerMessage("0>info " + "writeSchematronRule");
-    DMDocument
-        .registerMessage("0>info " + "  lSchemaFileDefn.isMaster:" + lSchemaFileDefn.isMaster);
-    DMDocument.registerMessage(
-        "0>info " + "  lSchemaFileDefn.isDiscipline:" + lSchemaFileDefn.isDiscipline);
-    DMDocument
-        .registerMessage("0>info " + "  lSchemaFileDefn.isMission:" + lSchemaFileDefn.isMission);
-    DMDocument.registerMessage("0>info " + "  lSchemaFileDefn.isLDD:" + lSchemaFileDefn.isLDD);
-    DMDocument.registerMessage(
-        "0>info " + "  lSchemaFileDefn.nameSpaceIdNC:" + lSchemaFileDefn.nameSpaceIdNC);
-    DMDocument
-        .registerMessage("0>info " + "  lSchemaFileDefn.stewardArr:" + lSchemaFileDefn.stewardArr);
-    DMDocument.registerMessage("0>info " + "  DMDocument.LDDToolSingletonClassTitle:"
-        + DMDocument.LDDToolSingletonClassTitle);
-
-    ArrayList<DOMRule> lRuleArr = new ArrayList<>(DOMInfoModel.masterDOMRuleIdMap.values());
-    for (DOMRule lRule : lRuleArr) {
-      DMDocument.registerMessage("0>info ");
-      DMDocument.registerMessage("0>info " + "writeSchematronRule");
-      DMDocument.registerMessage("0>info " + "  lRule.identifier:" + lRule.identifier);
-      DMDocument.registerMessage("0>info " + "  lRule.nameSpaceIdNC:" + lRule.nameSpaceIdNC);
-      DMDocument.registerMessage("0>info " + "  lRule.isMissionOnly:" + lRule.isMissionOnly);
-      DMDocument.registerMessage("0>info " + "  lRule.classNameSpaceNC:" + lRule.classNameSpaceNC);
-      DMDocument.registerMessage("0>info " + "  lRule.classSteward:" + lRule.classSteward);
-      DMDocument.registerMessage("0>info " + "  lRule.attrNameSpaceNC:" + lRule.attrNameSpaceNC);
-
-      if (lSchemaFileDefn.isMaster) {
-        if (lRule.isMissionOnly || !(lRule.alwaysInclude
-            || (lSchemaFileDefn.nameSpaceIdNC.compareTo(lRule.nameSpaceIdNC) == 0))) continue;
-      } else {
-        // write an LDD schemtron
-        DMDocument.registerMessage(
-            "0>info " + "Found LDD - lSchemaFileDefn.isMission:" + lSchemaFileDefn.isMission);
-        DMDocument
-            .registerMessage("0>info " + "Found LDD - lRule.isMissionOnly:" + lRule.isMissionOnly);
-        if (!(lRule.isMissionOnly && lSchemaFileDefn.isMission)) continue;
-        DMDocument.registerMessage(
-            "0>info " + "Found LDD - lSchemaFileDefn.isMission:" + lSchemaFileDefn.isMission);
-        if (!((lSchemaFileDefn.nameSpaceIdNC.compareTo(lRule.nameSpaceIdNC) == 0)
-            || (lRule.classTitle.compareTo(DMDocument.LDDToolSingletonClassTitle) == 0))) continue;
       }
       lSelectRuleArr.add(lRule);
     }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSpecification.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSpecification.java
@@ -1118,7 +1118,7 @@ public class WriteDOMSpecification extends Object {
    * Print schematron rule for the attribute
    */
   private void printAttrSchematronRuleMsg(DOMAttr lAttr) {
-    ArrayList<DOMRule> lRuleArr = new ArrayList<>(DOMInfoModel.masterDOMRuleIdMap.values());
+    ArrayList<DOMRule> lRuleArr = new ArrayList<>(DOMInfoModel.masterDOMRuleMap.values()); // use unique rdfIdentifier
     for (Iterator<DOMRule> i = lRuleArr.iterator(); i.hasNext();) {
       DOMRule lRule = i.next();
       for (Iterator<DOMAssert> j = lRule.assertArr.iterator(); j.hasNext();) {

--- a/test/smoke-tests.sh
+++ b/test/smoke-tests.sh
@@ -21,7 +21,7 @@ echo "Test 1: ldd-template"
 git clone https://github.com/pds-data-dictionaries/ldd-template.git ldd-repo/
 
 # Run lddtool
-lddtool-pkg/lddtool*/bin/lddtool -lpJ -V 1L00 ldd-repo/src/*IngestLDD.xml
+lddtool-pkg/lddtool*/bin/lddtool -lpJ ldd-repo/src/*IngestLDD.xml
 
 if [ $? -ne 0 ]; then
     echo "Test 1: FAILED"
@@ -36,7 +36,7 @@ git clone https://github.com/pds-data-dictionaries/ldd-cart.git ldd-repo/
 cd ldd-repo/; git submodule update --init --force --remote; cd ..
 
 # Run lddtool
-lddtool-pkg/lddtool*/bin/lddtool -lpJ -V 1L00 ldd-repo/src/dependencies/ldd-*/src/*IngestLDD.xml ldd-repo/src/*IngestLDD.xml
+lddtool-pkg/lddtool*/bin/lddtool -lpJ ldd-repo/src/dependencies/ldd-*/src/*IngestLDD.xml ldd-repo/src/*IngestLDD.xml
 
 if [ $? -ne 0 ]; then
     echo "Test 2: FAILED"
@@ -44,13 +44,26 @@ if [ $? -ne 0 ]; then
 fi
 echo "Test 2: SUCCESS"
 
+echo "Test 3: ldd-nucspec (#771)"
+# Run lddtool with downloaded data
+lddtool-pkg/lddtool*/bin/lddtool -lpJ test/data/771/PDS4_NUCSPEC_IngestLDD.xml
+diff PDS4_NUCSPEC_*_1100.sch test/data/771/expected/PDS4_NUCSPEC_1M00_1100.sch | egrep -v "PDS4 Schematron for Name Space Id:nucspec" | egrep -v "Generated from the PDS4 Information Model" > tmp.txt
+lines=$(wc -l tmp.txt | awk '{print $1}')
+
+if [ $lines -ne 2 ]; then
+    echo "Test 3: FAILED"
+    echo $lines
+    exit $?
+fi
+echo "Test 3: SUCCESS"
+
 # File count check
-echo "Test 3: Check file counts from files generated"
+echo "Test 4: Check file counts from files generated"
 count=$(ls -al PDS* | wc -l)
-if [ $count -ne 12 ]; then
+if [ $count -ne 18 ]; then
     echo "Test 3: FAILED"
     exit 1
 fi
-echo "Test 3: SUCCESS"
+echo "Test 4: SUCCESS"
 
 exit $?


### PR DESCRIPTION
LDDTool does not include all rules from IngestLDD file

Found and fixed the problem in the Schematron (.sch) file writer where the code was not using a unique identifier to reference the Rules defined in IngestLDD.
				 
Test: The missing rules are now written to the Schematron (.sch) file.
				 
The change has caused the order of the rules in the file to changed.
					
Resolves #771

