### PR TITLE
Added micro amps and nano amps as units of current - CCB-16 - P2

### DIFF
--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Wed May 22 16:49:23 EDT 2024
+; Thu Jun 20 16:08:21 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Wed May 22 16:49:23 EDT 2024
+; Thu Jun 20 16:08:21 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -12132,7 +12132,7 @@
 	(single-slot unit_id
 ;+		(comment "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
 		(type STRING)
-;+		(value "A" "mA")
+;+		(value "A" "mA" "microA" "nA")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Wed May 22 16:49:23 EDT 2024
+; Thu Jun 20 16:08:21 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -6,10 +6,10 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[UpperModel_ProjectKB_Class81]
-		[UpperModel_ProjectKB_Class82]
-		[UpperModel_ProjectKB_Class83]
-		[UpperModel_ProjectKB_Class84]))
+		[UpperModel_ProjectKB_Class69]
+		[UpperModel_ProjectKB_Class70]
+		[UpperModel_ProjectKB_Class71]
+		[UpperModel_ProjectKB_Class72]))
 
 ([CLSES_TAB] of  Widget
 
@@ -423,6 +423,9 @@
 	(x 0)
 	(y 120))
 
+([KB_477626_Class0] of  Map
+)
+
 ([KB_663782_Class0] of  Map
 )
 
@@ -547,9 +550,6 @@
 
 	(name "instances_file_name")
 	(string_value "UpperModel.pins"))
-
-([KB_895162_Class0] of  Map
-)
 
 ([PAL_FORM_WIDGET] of  Widget
 
@@ -832,328 +832,328 @@
 ([UpperModel_171209c_1910_ChangeLog_ProjectKB_Class82] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class1] of  Widget
+([UpperModel_ProjectKB_Class1] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class2])
+	(property_list [UpperModel_ProjectKB_Class2])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.widget.OWLFormsTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class10] of  Property_List
+([UpperModel_ProjectKB_Class10] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class11] of  Widget
+([UpperModel_ProjectKB_Class11] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class12])
+	(property_list [UpperModel_ProjectKB_Class12])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.cls.OWLClassesTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class12] of  Property_List
+([UpperModel_ProjectKB_Class12] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class13] of  Widget
+([UpperModel_ProjectKB_Class13] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class14])
+	(property_list [UpperModel_ProjectKB_Class14])
 	(widget_class_name "edu.stanford.smi.protegex.server_changes.prompt.UsersTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class14] of  Property_List
+([UpperModel_ProjectKB_Class14] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class15] of  Widget
+([UpperModel_ProjectKB_Class15] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class16])
+	(property_list [UpperModel_ProjectKB_Class16])
 	(widget_class_name "edu.stanford.smi.protege.query.LuceneQueryPlugin"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class16] of  Property_List
+([UpperModel_ProjectKB_Class16] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class17] of  Widget
+([UpperModel_ProjectKB_Class17] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class18])
+	(property_list [UpperModel_ProjectKB_Class18])
 	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.KnowledgeTreeTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class18] of  Property_List
+([UpperModel_ProjectKB_Class18] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class19] of  Widget
+([UpperModel_ProjectKB_Class19] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class20])
+	(property_list [UpperModel_ProjectKB_Class20])
 	(widget_class_name "edu.stanford.smi.protege.keywordsearch.StringSearch"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class2] of  Property_List
+([UpperModel_ProjectKB_Class2] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class20] of  Property_List
+([UpperModel_ProjectKB_Class20] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class21] of  Widget
+([UpperModel_ProjectKB_Class21] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class22])
+	(property_list [UpperModel_ProjectKB_Class22])
 	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalConstraintsTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class22] of  Property_List
+([UpperModel_ProjectKB_Class22] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class23] of  Widget
+([UpperModel_ProjectKB_Class23] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class24])
+	(property_list [UpperModel_ProjectKB_Class24])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.metadatatab.OWLMetadataTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class24] of  Property_List
+([UpperModel_ProjectKB_Class24] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class25] of  Widget
+([UpperModel_ProjectKB_Class25] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class26])
+	(property_list [UpperModel_ProjectKB_Class26])
 	(widget_class_name "edu.stanford.smi.protegex.owl.swrl.ui.tab.SWRLTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class26] of  Property_List
+([UpperModel_ProjectKB_Class26] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class27] of  Widget
+([UpperModel_ProjectKB_Class27] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class28])
+	(property_list [UpperModel_ProjectKB_Class28])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.individuals.OWLIndividualsTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class28] of  Property_List
+([UpperModel_ProjectKB_Class28] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class29] of  Widget
+([UpperModel_ProjectKB_Class29] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class30])
+	(property_list [UpperModel_ProjectKB_Class30])
 	(widget_class_name "uk.ac.man.cs.mig.coode.debugger.test.DebuggerTestTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class3] of  Widget
+([UpperModel_ProjectKB_Class3] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class4])
+	(property_list [UpperModel_ProjectKB_Class4])
 	(widget_class_name "org.protege.owl.mm.portability.protege3.MappingMasterTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class30] of  Property_List
+([UpperModel_ProjectKB_Class30] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class31] of  Widget
+([UpperModel_ProjectKB_Class31] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class32])
+	(property_list [UpperModel_ProjectKB_Class32])
 	(widget_class_name "ca.uvic.csr.shrimp.jambalaya.JambalayaTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class32] of  Property_List
+([UpperModel_ProjectKB_Class32] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class33] of  Widget
+([UpperModel_ProjectKB_Class33] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class34])
+	(property_list [UpperModel_ProjectKB_Class34])
 	(widget_class_name "edu.stanford.smi.protegex.changes.ChangesTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class34] of  Property_List
+([UpperModel_ProjectKB_Class34] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class35] of  Widget
+([UpperModel_ProjectKB_Class35] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class36])
+	(property_list [UpperModel_ProjectKB_Class36])
 	(widget_class_name "org.protege.owl.axiome.ui.AxiomeTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class36] of  Property_List
+([UpperModel_ProjectKB_Class36] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class37] of  Widget
+([UpperModel_ProjectKB_Class37] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class38])
+	(property_list [UpperModel_ProjectKB_Class38])
 	(widget_class_name "TGViztab.TGVizTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class38] of  Property_List
+([UpperModel_ProjectKB_Class38] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class39] of  Widget
+([UpperModel_ProjectKB_Class39] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class40])
+	(property_list [UpperModel_ProjectKB_Class40])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.properties.OWLPropertiesTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class4] of  Property_List
+([UpperModel_ProjectKB_Class4] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class40] of  Property_List
+([UpperModel_ProjectKB_Class40] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class41] of  Widget
+([UpperModel_ProjectKB_Class41] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class42])
+	(property_list [UpperModel_ProjectKB_Class42])
 	(widget_class_name "uk.ac.man.ac.mig.coode.individuals.ui.OWLDLIndividualsTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class42] of  Property_List
+([UpperModel_ProjectKB_Class42] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class43] of  Widget
+([UpperModel_ProjectKB_Class43] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class44])
+	(property_list [UpperModel_ProjectKB_Class44])
 	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.InstanceTreeTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class44] of  Property_List
+([UpperModel_ProjectKB_Class44] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class45] of  Widget
+([UpperModel_ProjectKB_Class45] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class46])
+	(property_list [UpperModel_ProjectKB_Class46])
 	(widget_class_name "edu.stanford.smi.protegex.evaluation.MetaAnalysis"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class46] of  Property_List
+([UpperModel_ProjectKB_Class46] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class47] of  Widget
+([UpperModel_ProjectKB_Class47] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class48])
+	(property_list [UpperModel_ProjectKB_Class48])
 	(widget_class_name "edu.stanford.smi.protegex.changes.changesKBViewTab.ChangesKBViewTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class48] of  Property_List
+([UpperModel_ProjectKB_Class48] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class49] of  Widget
+([UpperModel_ProjectKB_Class49] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class50])
+	(property_list [UpperModel_ProjectKB_Class50])
 	(widget_class_name "se.liu.ida.JessTab.JessTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class5] of  Widget
+([UpperModel_ProjectKB_Class5] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class6])
+	(property_list [UpperModel_ProjectKB_Class6])
 	(widget_class_name "edu.stanford.smi.protege.widget.ProtegePropertiesTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class50] of  Property_List
+([UpperModel_ProjectKB_Class50] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class51] of  Widget
+([UpperModel_ProjectKB_Class51] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class52])
+	(property_list [UpperModel_ProjectKB_Class52])
 	(widget_class_name "edu.stanford.smi.protegex.changeanalysis.ChangeAnalysisTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class52] of  Property_List
+([UpperModel_ProjectKB_Class52] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class53] of  Widget
+([UpperModel_ProjectKB_Class53] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class54])
+	(property_list [UpperModel_ProjectKB_Class54])
 	(widget_class_name "uk.ac.man.cs.mig.coode.owlviz.ui.OWLVizTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class54] of  Property_List
+([UpperModel_ProjectKB_Class54] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class55] of  Widget
+([UpperModel_ProjectKB_Class55] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class56])
+	(property_list [UpperModel_ProjectKB_Class56])
 	(widget_class_name "edu.stanford.smi.protegex.changes.stats.ChangeStatisticsTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class56] of  Property_List
+([UpperModel_ProjectKB_Class56] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class57] of  Widget
+([UpperModel_ProjectKB_Class57] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class58])
+	(property_list [UpperModel_ProjectKB_Class58])
 	(widget_class_name "script.ProtegeScriptTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class58] of  Property_List
+([UpperModel_ProjectKB_Class58] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class59] of  Widget
+([UpperModel_ProjectKB_Class59] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class60])
+	(property_list [UpperModel_ProjectKB_Class60])
 	(widget_class_name "edu.stanford.smi.protegex.chatPlugin.ChatTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class6] of  Property_List
+([UpperModel_ProjectKB_Class6] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class60] of  Property_List
+([UpperModel_ProjectKB_Class60] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class61] of  Widget
+([UpperModel_ProjectKB_Class61] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class62])
+	(property_list [UpperModel_ProjectKB_Class62])
 	(widget_class_name "edu.stanford.smi.protegex.fctab.FacetConstraintsTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class62] of  Property_List
+([UpperModel_ProjectKB_Class62] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class63] of  Widget
+([UpperModel_ProjectKB_Class63] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class64])
+	(property_list [UpperModel_ProjectKB_Class64])
 	(widget_class_name "edu.stanford.smi.protegex.xml.tab.XMLTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class64] of  Property_List
+([UpperModel_ProjectKB_Class64] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class65] of  Widget
+([UpperModel_ProjectKB_Class65] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class66])
+	(property_list [UpperModel_ProjectKB_Class66])
 	(widget_class_name "edu.stanford.smi.protegex.datamaster.DataMasterTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class66] of  Property_List
+([UpperModel_ProjectKB_Class66] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class67] of  Widget
+([UpperModel_ProjectKB_Class67] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class68])
+	(property_list [UpperModel_ProjectKB_Class68])
 	(widget_class_name "ezpal.EZPalTab"))
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class68] of  Property_List
+([UpperModel_ProjectKB_Class68] of  Property_List
 )
 
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class7] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class8])
-	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalQueriesTab"))
-
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class8] of  Property_List
-)
-
-([UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class9] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_240509_MSN_ModificationDetail_ProjectKB_Class10])
-	(widget_class_name "dfki.protege.ontoviz_tab.OntovizTab"))
-
-([UpperModel_ProjectKB_Class81] of  String
+([UpperModel_ProjectKB_Class69] of  String
 
 	(name "ChangeLog")
 	(string_value "date"))
 
-([UpperModel_ProjectKB_Class82] of  String
+([UpperModel_ProjectKB_Class7] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class8])
+	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalQueriesTab"))
+
+([UpperModel_ProjectKB_Class70] of  String
 
 	(name ":INSTANCE-ANNOTATION")
 	(string_value "%3AANNOTATION-TEXT"))
 
-([UpperModel_ProjectKB_Class83] of  String
+([UpperModel_ProjectKB_Class71] of  String
 
 	(name ":PAL-CONSTRAINT")
 	(string_value "%3APAL-NAME"))
 
-([UpperModel_ProjectKB_Class84] of  String
+([UpperModel_ProjectKB_Class72] of  String
 
 	(name ":META-CLASS")
 	(string_value "%3ANAME"))
+
+([UpperModel_ProjectKB_Class8] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class9] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class10])
+	(widget_class_name "dfki.protege.ontoviz_tab.OntovizTab"))

--- a/model-ontology/src/ontology/Data/dd11179.pont
+++ b/model-ontology/src/ontology/Data/dd11179.pont
@@ -1,4 +1,4 @@
-; Wed May 22 17:38:43 EDT 2024
+; Thu Jun 20 16:19:38 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/dd11179.pprj
+++ b/model-ontology/src/ontology/Data/dd11179.pprj
@@ -1,4 +1,4 @@
-; Wed May 22 17:38:43 EDT 2024
+; Thu Jun 20 16:19:38 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -20,9 +20,9 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[dd11179_ProjectKB_Class10233]
-		[dd11179_ProjectKB_Class10234]
-		[dd11179_ProjectKB_Class10235]))
+		[dd11179_ProjectKB_Class207]
+		[dd11179_ProjectKB_Class208]
+		[dd11179_ProjectKB_Class209]))
 
 ([CLSES_TAB] of  Widget
 
@@ -36,353 +36,353 @@
 
 	(name ":CREATOR"))
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class1] of  Widget
+([dd11179_ProjectKB_Class1] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class2])
+	(property_list [dd11179_ProjectKB_Class2])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.widget.OWLFormsTab"))
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class10] of  Property_List
+([dd11179_ProjectKB_Class10] of  Property_List
 )
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class11] of  Widget
+([dd11179_ProjectKB_Class11] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class12])
+	(property_list [dd11179_ProjectKB_Class12])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.cls.OWLClassesTab"))
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class12] of  Property_List
+([dd11179_ProjectKB_Class12] of  Property_List
 )
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class13] of  Widget
+([dd11179_ProjectKB_Class13] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class14])
+	(property_list [dd11179_ProjectKB_Class14])
 	(widget_class_name "edu.stanford.smi.protegex.server_changes.prompt.UsersTab"))
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class14] of  Property_List
+([dd11179_ProjectKB_Class14] of  Property_List
 )
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class15] of  Widget
+([dd11179_ProjectKB_Class15] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class16])
+	(property_list [dd11179_ProjectKB_Class16])
 	(widget_class_name "edu.stanford.smi.protege.query.LuceneQueryPlugin"))
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class16] of  Property_List
+([dd11179_ProjectKB_Class16] of  Property_List
 )
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class17] of  Widget
+([dd11179_ProjectKB_Class17] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class18])
+	(property_list [dd11179_ProjectKB_Class18])
 	(widget_class_name "edu.stanford.smi.protege.widget.ClsesAndInstancesTab"))
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class18] of  Property_List
+([dd11179_ProjectKB_Class18] of  Property_List
 )
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class19] of  Widget
+([dd11179_ProjectKB_Class19] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class20])
+	(property_list [dd11179_ProjectKB_Class20])
 	(widget_class_name "edu.stanford.smi.protege.widget.KAToolTab"))
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class2] of  Property_List
+([dd11179_ProjectKB_Class2] of  Property_List
 )
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class20] of  Property_List
+([dd11179_ProjectKB_Class20] of  Property_List
 )
 
-([dd11179_240522_Stage_1L00_ProjectKB_Class21] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class22])
-	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.KnowledgeTreeTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class22] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class23] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class24])
-	(widget_class_name "edu.stanford.smi.protege.keywordsearch.StringSearch"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class24] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class25] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class26])
-	(widget_class_name "edu.stanford.smi.protegex.prompt.PromptTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class26] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class27] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class28])
-	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalConstraintsTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class28] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class29] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class30])
-	(widget_class_name "edu.stanford.smi.protegex.owl.ui.metadatatab.OWLMetadataTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class3] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class4])
-	(widget_class_name "org.protege.owl.mm.portability.protege3.MappingMasterTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class30] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class31] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class32])
-	(widget_class_name "edu.stanford.smi.protegex.owl.swrl.ui.tab.SWRLTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class32] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class33] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class34])
-	(widget_class_name "edu.stanford.smi.protegex.owl.ui.individuals.OWLIndividualsTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class34] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class35] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class36])
-	(widget_class_name "uk.ac.man.cs.mig.coode.debugger.test.DebuggerTestTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class36] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class37] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class38])
-	(widget_class_name "ca.uvic.csr.shrimp.jambalaya.JambalayaTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class38] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class39] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class40])
-	(widget_class_name "edu.stanford.smi.protegex.changes.ChangesTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class4] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class40] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class41] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class42])
-	(widget_class_name "org.protege.owl.axiome.ui.AxiomeTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class42] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class43] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class44])
-	(widget_class_name "TGViztab.TGVizTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class44] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class45] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class46])
-	(widget_class_name "edu.stanford.smi.protegex.owl.ui.properties.OWLPropertiesTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class46] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class47] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class48])
-	(widget_class_name "uk.ac.man.ac.mig.coode.individuals.ui.OWLDLIndividualsTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class48] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class49] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class50])
-	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.InstanceTreeTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class5] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class6])
-	(widget_class_name "edu.stanford.smi.protege.widget.ProtegePropertiesTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class50] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class51] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class52])
-	(widget_class_name "edu.stanford.smi.protegex.evaluation.MetaAnalysis"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class52] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class53] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class54])
-	(widget_class_name "edu.stanford.smi.protegex.changes.changesKBViewTab.ChangesKBViewTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class54] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class55] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class56])
-	(widget_class_name "se.liu.ida.JessTab.JessTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class56] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class57] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class58])
-	(widget_class_name "edu.stanford.smi.protegex.changeanalysis.ChangeAnalysisTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class58] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class59] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class60])
-	(widget_class_name "uk.ac.man.cs.mig.coode.owlviz.ui.OWLVizTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class6] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class60] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class61] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class62])
-	(widget_class_name "edu.stanford.smi.protegex.changes.stats.ChangeStatisticsTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class62] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class63] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class64])
-	(widget_class_name "script.ProtegeScriptTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class64] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class65] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class66])
-	(widget_class_name "edu.stanford.smi.protegex.chatPlugin.ChatTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class66] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class67] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class68])
-	(widget_class_name "edu.stanford.smi.protegex.fctab.FacetConstraintsTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class68] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class69] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class70])
-	(widget_class_name "edu.stanford.smi.protegex.xml.tab.XMLTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class7] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class8])
-	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalQueriesTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class70] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class71] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class72])
-	(widget_class_name "edu.stanford.smi.protegex.datamaster.DataMasterTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class72] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class73] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class74])
-	(widget_class_name "ezpal.EZPalTab"))
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class74] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class8] of  Property_List
-)
-
-([dd11179_240522_Stage_1L00_ProjectKB_Class9] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [dd11179_240522_Stage_1L00_ProjectKB_Class10])
-	(widget_class_name "dfki.protege.ontoviz_tab.OntovizTab"))
-
-([dd11179_ProjectKB_Class10233] of  String
+([dd11179_ProjectKB_Class207] of  String
 
 	(name ":INSTANCE-ANNOTATION")
 	(string_value "%3AANNOTATION-TEXT"))
 
-([dd11179_ProjectKB_Class10234] of  String
+([dd11179_ProjectKB_Class208] of  String
 
 	(name ":PAL-CONSTRAINT")
 	(string_value "%3APAL-NAME"))
 
-([dd11179_ProjectKB_Class10235] of  String
+([dd11179_ProjectKB_Class209] of  String
 
 	(name ":META-CLASS")
 	(string_value "%3ANAME"))
+
+([dd11179_ProjectKB_Class21] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class22])
+	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.KnowledgeTreeTab"))
+
+([dd11179_ProjectKB_Class22] of  Property_List
+)
+
+([dd11179_ProjectKB_Class23] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class24])
+	(widget_class_name "edu.stanford.smi.protege.keywordsearch.StringSearch"))
+
+([dd11179_ProjectKB_Class24] of  Property_List
+)
+
+([dd11179_ProjectKB_Class25] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class26])
+	(widget_class_name "edu.stanford.smi.protegex.prompt.PromptTab"))
+
+([dd11179_ProjectKB_Class26] of  Property_List
+)
+
+([dd11179_ProjectKB_Class27] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class28])
+	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalConstraintsTab"))
+
+([dd11179_ProjectKB_Class28] of  Property_List
+)
+
+([dd11179_ProjectKB_Class29] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class30])
+	(widget_class_name "edu.stanford.smi.protegex.owl.ui.metadatatab.OWLMetadataTab"))
+
+([dd11179_ProjectKB_Class3] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class4])
+	(widget_class_name "org.protege.owl.mm.portability.protege3.MappingMasterTab"))
+
+([dd11179_ProjectKB_Class30] of  Property_List
+)
+
+([dd11179_ProjectKB_Class31] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class32])
+	(widget_class_name "edu.stanford.smi.protegex.owl.swrl.ui.tab.SWRLTab"))
+
+([dd11179_ProjectKB_Class32] of  Property_List
+)
+
+([dd11179_ProjectKB_Class33] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class34])
+	(widget_class_name "edu.stanford.smi.protegex.owl.ui.individuals.OWLIndividualsTab"))
+
+([dd11179_ProjectKB_Class34] of  Property_List
+)
+
+([dd11179_ProjectKB_Class35] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class36])
+	(widget_class_name "uk.ac.man.cs.mig.coode.debugger.test.DebuggerTestTab"))
+
+([dd11179_ProjectKB_Class36] of  Property_List
+)
+
+([dd11179_ProjectKB_Class37] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class38])
+	(widget_class_name "ca.uvic.csr.shrimp.jambalaya.JambalayaTab"))
+
+([dd11179_ProjectKB_Class38] of  Property_List
+)
+
+([dd11179_ProjectKB_Class39] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class40])
+	(widget_class_name "edu.stanford.smi.protegex.changes.ChangesTab"))
+
+([dd11179_ProjectKB_Class4] of  Property_List
+)
+
+([dd11179_ProjectKB_Class40] of  Property_List
+)
+
+([dd11179_ProjectKB_Class41] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class42])
+	(widget_class_name "org.protege.owl.axiome.ui.AxiomeTab"))
+
+([dd11179_ProjectKB_Class42] of  Property_List
+)
+
+([dd11179_ProjectKB_Class43] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class44])
+	(widget_class_name "TGViztab.TGVizTab"))
+
+([dd11179_ProjectKB_Class44] of  Property_List
+)
+
+([dd11179_ProjectKB_Class45] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class46])
+	(widget_class_name "edu.stanford.smi.protegex.owl.ui.properties.OWLPropertiesTab"))
+
+([dd11179_ProjectKB_Class46] of  Property_List
+)
+
+([dd11179_ProjectKB_Class47] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class48])
+	(widget_class_name "uk.ac.man.ac.mig.coode.individuals.ui.OWLDLIndividualsTab"))
+
+([dd11179_ProjectKB_Class48] of  Property_List
+)
+
+([dd11179_ProjectKB_Class49] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class50])
+	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.InstanceTreeTab"))
+
+([dd11179_ProjectKB_Class5] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class6])
+	(widget_class_name "edu.stanford.smi.protege.widget.ProtegePropertiesTab"))
+
+([dd11179_ProjectKB_Class50] of  Property_List
+)
+
+([dd11179_ProjectKB_Class51] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class52])
+	(widget_class_name "edu.stanford.smi.protegex.evaluation.MetaAnalysis"))
+
+([dd11179_ProjectKB_Class52] of  Property_List
+)
+
+([dd11179_ProjectKB_Class53] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class54])
+	(widget_class_name "edu.stanford.smi.protegex.changes.changesKBViewTab.ChangesKBViewTab"))
+
+([dd11179_ProjectKB_Class54] of  Property_List
+)
+
+([dd11179_ProjectKB_Class55] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class56])
+	(widget_class_name "se.liu.ida.JessTab.JessTab"))
+
+([dd11179_ProjectKB_Class56] of  Property_List
+)
+
+([dd11179_ProjectKB_Class57] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class58])
+	(widget_class_name "edu.stanford.smi.protegex.changeanalysis.ChangeAnalysisTab"))
+
+([dd11179_ProjectKB_Class58] of  Property_List
+)
+
+([dd11179_ProjectKB_Class59] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class60])
+	(widget_class_name "uk.ac.man.cs.mig.coode.owlviz.ui.OWLVizTab"))
+
+([dd11179_ProjectKB_Class6] of  Property_List
+)
+
+([dd11179_ProjectKB_Class60] of  Property_List
+)
+
+([dd11179_ProjectKB_Class61] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class62])
+	(widget_class_name "edu.stanford.smi.protegex.changes.stats.ChangeStatisticsTab"))
+
+([dd11179_ProjectKB_Class62] of  Property_List
+)
+
+([dd11179_ProjectKB_Class63] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class64])
+	(widget_class_name "script.ProtegeScriptTab"))
+
+([dd11179_ProjectKB_Class64] of  Property_List
+)
+
+([dd11179_ProjectKB_Class65] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class66])
+	(widget_class_name "edu.stanford.smi.protegex.chatPlugin.ChatTab"))
+
+([dd11179_ProjectKB_Class66] of  Property_List
+)
+
+([dd11179_ProjectKB_Class67] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class68])
+	(widget_class_name "edu.stanford.smi.protegex.fctab.FacetConstraintsTab"))
+
+([dd11179_ProjectKB_Class68] of  Property_List
+)
+
+([dd11179_ProjectKB_Class69] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class70])
+	(widget_class_name "edu.stanford.smi.protegex.xml.tab.XMLTab"))
+
+([dd11179_ProjectKB_Class7] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class8])
+	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalQueriesTab"))
+
+([dd11179_ProjectKB_Class70] of  Property_List
+)
+
+([dd11179_ProjectKB_Class71] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class72])
+	(widget_class_name "edu.stanford.smi.protegex.datamaster.DataMasterTab"))
+
+([dd11179_ProjectKB_Class72] of  Property_List
+)
+
+([dd11179_ProjectKB_Class73] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class74])
+	(widget_class_name "ezpal.EZPalTab"))
+
+([dd11179_ProjectKB_Class74] of  Property_List
+)
+
+([dd11179_ProjectKB_Class8] of  Property_List
+)
+
+([dd11179_ProjectKB_Class9] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [dd11179_ProjectKB_Class10])
+	(widget_class_name "dfki.protege.ontoviz_tab.OntovizTab"))
 
 ([FORMS_TAB] of  Widget
 
@@ -525,7 +525,7 @@
 ([KB_860773_Class0] of  Map
 )
 
-([KB_952880_Class0] of  Map
+([KB_891237_Class0] of  Map
 )
 
 ([LAYOUT_PROPERTIES] of  Property_List


### PR DESCRIPTION
CCB-16: Allow micro amps and nano amps as units of current

Added the following units to Units_of_Current

    microA - The abbreviated unit for Units_of_Current is microA
    nA - The abbreviated unit for Units_of_Current is nA


## ⚙️ Test Data and/or Report
-Resulting Schema snippet-
<xs:simpleType name="Units_of_Current">
<xs:restriction base="xs:string">
<xs:enumeration value="A"></xs:enumeration>
<xs:enumeration value="mA"></xs:enumeration>
<xs:enumeration value="microA"></xs:enumeration>
<xs:enumeration value="nA"></xs:enumeration>
</xs:restriction>
</xs:simpleType>

Resolves https://github.com/NASA-PDS/pds4-information-model/issues/753
Refs https://github.com/NASA-PDS/PDS4-CCB/issues/16