### PR TITLE
NASA-PDS/PDS4-CCB#26 - Part 2 - Fixed definition of Units_of_Amount_of_Substance

### DIFF
--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Thu Jun 20 16:08:21 EDT 2024
+; Thu Jun 20 21:07:12 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Thu Jun 20 16:08:21 EDT 2024
+; Thu Jun 20 21:07:12 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -11542,7 +11542,7 @@
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 
-(defclass Units_of_Amount_Of_Substance "Units_of_Amount_Of_Substance is a magnitude of mass."
+(defclass Units_of_Amount_Of_Substance "Units_of_Amount_Of_Substance is a magnitude of quantity of chemically unique and identifiable particles (atoms, molecules, ions, etc.)."
 	(is-a Unit_Of_Measure)
 	(role concrete)
 	(single-slot type

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Thu Jun 20 16:08:21 EDT 2024
+; Thu Jun 20 21:07:12 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -423,7 +423,7 @@
 	(x 0)
 	(y 120))
 
-([KB_477626_Class0] of  Map
+([KB_252122_Class0] of  Map
 )
 
 ([KB_663782_Class0] of  Map


### PR DESCRIPTION
Update the definition of the Units_of_Amount_of_Substance class. 

-    Original: Units_of_Amount_Of_Substance is a magnitude of mass.
-    New: Units_of_Amount_Of_Substance is a magnitude of quantity of chemically unique and identifiable particles (atoms, molecules, ions, etc.). 

## ⚙️ Test Data and/or Report
No test is necessary. A class  definition was changed.

Resolves #782
Refs NASA-PDS/PDS4-CCB#26

