### PR TITLE
Add missing standard values for relating a bundle to targets 

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetValueMeanings.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetValueMeanings.java
@@ -949,6 +949,48 @@ class GetValueMeanings extends Object {
         "pds:DD_Attribute/pds:Internal_Reference.reference_type.attribute_to_document",
         "attribute_to_document", "The attribute is associated to a document");
     masterValueMeaningMap.put(lPVD.identifier, lPVD);
+    
+
+    lPVD = new PermValueDefn(
+        "pds:Product_Observational/pds:Observation_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.data_to_target",
+        "data_to_target", "The observational product is associated to a target product");
+    masterValueMeaningMap.put(lPVD.identifier, lPVD);
+
+    lPVD = new PermValueDefn(
+        "pds:Product_Bundle/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.bundle_to_target",
+        "bundle_to_target", "The bundle product is associated to a target product");
+    masterValueMeaningMap.put(lPVD.identifier, lPVD);
+
+    lPVD = new PermValueDefn(
+        "pds:Product_Collection/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.collection_to_target",
+        "collection_to_target", "The collection product is associated to a target product");
+    masterValueMeaningMap.put(lPVD.identifier, lPVD);
+
+    lPVD = new PermValueDefn(
+        "pds:Product_Browse/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.browse_to_target",
+        "browse_to_target", "The browse product is associated to a target product");
+    masterValueMeaningMap.put(lPVD.identifier, lPVD);
+
+    lPVD = new PermValueDefn(
+        "pds:Product_External/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.external_to_target",
+        "external_to_target", "The external product is associated to a target product");
+    masterValueMeaningMap.put(lPVD.identifier, lPVD);
+
+    lPVD = new PermValueDefn(
+        "pds:Product_Native/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.native_to_target",
+        "native_to_target", "The native product is associated to a target product");
+    masterValueMeaningMap.put(lPVD.identifier, lPVD);
+
+    lPVD = new PermValueDefn(
+        "pds:Product_SPICE_Kernel/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.data_to_target",
+        "data_to_target", "The SPICE kernel product is associated to a target product");
+    masterValueMeaningMap.put(lPVD.identifier, lPVD);
+
+    lPVD = new PermValueDefn(
+        "pds:Product_XML_Schema/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.schema_to_target",
+        "schema_to_target", "The XML schema product is associated to a target product");
+    masterValueMeaningMap.put(lPVD.identifier, lPVD);
+
 
     return;
   }

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Mon Jun 24 20:07:52 EDT 2024
+; Wed Aug 07 20:30:28 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -1582,6 +1582,31 @@
 		"ancillary_to_document"
 		"ancillary_to_browse"))
 
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004864] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "pds")
+	(attrTitle "reference_type")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004864.101])
+	(identifier "pds:Product_Browse/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "pds:Product_Browse/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004864.101] of  Schematron_Assert
+
+	(assertMsg " must be set to one of the following values ")
+	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = (' browse_to_target')")
+	(assertType "EVERY")
+	(attrTitle "reference_type")
+	(identifier "reference_type")
+	(specMesg "TBD")
+	(testValArr " browse_to_target"))
+
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AIdentification_Area%2Fpds%3ALicense_Information%2Fpds%3AInternal_Reference.100002548] of  Schematron_Rule
 
 	(alwaysInclude "false")
@@ -1837,6 +1862,31 @@
 	(specMesg "TBD")
 	(testValArr "bundle_to_investigation"))
 
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Bundle%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004862] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "pds")
+	(attrTitle "reference_type")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Bundle%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004862.101])
+	(identifier "pds:Product_Bundle/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "pds:Product_Bundle/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Bundle%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004862.101] of  Schematron_Assert
+
+	(assertMsg " must be set to one of the following values ")
+	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('bundle_to_target')")
+	(assertType "EVERY")
+	(attrTitle "reference_type")
+	(identifier "reference_type")
+	(specMesg "TBD")
+	(testValArr "bundle_to_target"))
+
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Bundle%2Fpds%3AIdentification_Area.100002531] of  Schematron_Rule
 
 	(alwaysInclude "true")
@@ -2085,6 +2135,31 @@
 	(identifier "reference_type")
 	(specMesg "TBD")
 	(testValArr "collection_to_investigation"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Collection%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004863] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "pds")
+	(attrTitle "reference_type")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Collection%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004863.101])
+	(identifier "pds:Product_Collection/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "pds:Product_Collection/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Collection%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004863.101] of  Schematron_Assert
+
+	(assertMsg " must be set to one of the following values ")
+	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('collection_to_target')")
+	(assertType "EVERY")
+	(attrTitle "reference_type")
+	(identifier "reference_type")
+	(specMesg "TBD")
+	(testValArr "collection_to_target"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Collection%2Fpds%3AIdentification_Area.100002535] of  Schematron_Rule
 
@@ -2480,6 +2555,31 @@
 		"document_to_target"
 		"document_to_data"))
 
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_External%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004865] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "pds")
+	(attrTitle "reference_type")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_External%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004865.101])
+	(identifier "pds:Product_External/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "pds:Product_External/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_External%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004865.101] of  Schematron_Assert
+
+	(assertMsg " must be set to one of the following values ")
+	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('external_to_target')")
+	(assertType "EVERY")
+	(attrTitle "reference_type")
+	(identifier "reference_type")
+	(specMesg "TBD")
+	(testValArr "external_to_target"))
+
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_External%2Fpds%3AIdentification_Area%2Fpds%3ALicense_Information%2Fpds%3AInternal_Reference.100002548] of  Schematron_Rule
 
 	(alwaysInclude "false")
@@ -2578,6 +2678,31 @@
 	(identifier "reference_type")
 	(specMesg "TBD")
 	(testValArr "product_to_license"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Native%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004866] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "pds")
+	(attrTitle "reference_type")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Native%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004866.101])
+	(identifier "pds:Product_Native/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "pds:Product_Native/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Native%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004866.101] of  Schematron_Assert
+
+	(assertMsg " must be set to one of the following values ")
+	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('native_to_target')")
+	(assertType "EVERY")
+	(attrTitle "reference_type")
+	(identifier "reference_type")
+	(specMesg "TBD")
+	(testValArr "native_to_target"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Native%2Fpds%3AIdentification_Area%2Fpds%3ALicense_Information%2Fpds%3AInternal_Reference.100002548] of  Schematron_Rule
 
@@ -2827,6 +2952,31 @@
 	(specMesg "TBD")
 	(testValArr "data_to_target"))
 
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Observational%2Fpds%3AObservation_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004861] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "pds")
+	(attrTitle "reference_type")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Observational%2Fpds%3AObservation_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004861.101])
+	(identifier "pds:Product_Observational/pds:Observation_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "pds:Product_Observational/pds:Observation_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Observational%2Fpds%3AObservation_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004861.101] of  Schematron_Assert
+
+	(assertMsg " must be set to one of the following values ")
+	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('data_to_target')")
+	(assertType "EVERY")
+	(attrTitle "reference_type")
+	(identifier "reference_type")
+	(specMesg "TBD")
+	(testValArr "data_to_target"))
+
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Observational%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100002553] of  Schematron_Rule
 
 	(alwaysInclude "false")
@@ -2944,6 +3094,31 @@
 	(identifier "x")
 	(specMesg "In Product_SPICE_Kernel the Time_Coordinates, Investigation_Area, Target_Identification, and Observing_System classes must be present"))
 
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_SPICE_Kernel%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004867] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "pds")
+	(attrTitle "reference_type")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_SPICE_Kernel%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004867.101])
+	(identifier "pds:Product_SPICE_Kernel/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "pds:Product_SPICE_Kernel/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_SPICE_Kernel%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004867.101] of  Schematron_Assert
+
+	(assertMsg " must be set to one of the following values ")
+	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('data_to_target')")
+	(assertType "EVERY")
+	(attrTitle "reference_type")
+	(identifier "reference_type")
+	(specMesg "TBD")
+	(testValArr "data_to_target"))
+
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Thumbnail%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100002529] of  Schematron_Rule
 
 	(alwaysInclude "false")
@@ -2996,6 +3171,31 @@
 	(identifier "reference_type")
 	(specMesg "TBD")
 	(testValArr "update_to_collection"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_XML_Schema%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004868] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "pds")
+	(attrTitle "reference_type")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_XML_Schema%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004868.101])
+	(identifier "pds:Product_XML_Schema/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "pds:Product_XML_Schema/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_XML_Schema%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004868.101] of  Schematron_Assert
+
+	(assertMsg " must be set to one of the following values ")
+	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('schema_to_target')")
+	(assertType "EVERY")
+	(attrTitle "reference_type")
+	(identifier "reference_type")
+	(specMesg "TBD")
+	(testValArr "schema_to_target"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Zipped%2Fpds%3AInternal_Reference.100002558] of  Schematron_Rule
 
@@ -3961,6 +4161,9 @@
 )
 
 ([upper_110812b_Class0] of  %3APAL-CONSTRAINT
+)
+
+([UpperModel_bundle_to_target_Class16] of  Schematron_Assert
 )
 
 ([Waves] of  Group_Facet2

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Wed Aug 07 20:30:28 EDT 2024
+; Thu Aug 08 12:01:13 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -1600,12 +1600,12 @@
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004864.101] of  Schematron_Assert
 
 	(assertMsg " must be set to one of the following values ")
-	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = (' browse_to_target')")
+	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('browse_to_target')")
 	(assertType "EVERY")
 	(attrTitle "reference_type")
 	(identifier "reference_type")
 	(specMesg "TBD")
-	(testValArr " browse_to_target"))
+	(testValArr "browse_to_target"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AIdentification_Area%2Fpds%3ALicense_Information%2Fpds%3AInternal_Reference.100002548] of  Schematron_Rule
 

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Wed Aug 07 20:30:27 EDT 2024
+; Thu Aug 08 12:01:12 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Mon Jun 24 20:07:52 EDT 2024
+; Wed Aug 07 20:30:27 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Wed Aug 07 20:30:28 EDT 2024
+; Thu Aug 08 12:01:13 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -6,10 +6,10 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[UpperModel_ProjectKB_Class69]
-		[UpperModel_ProjectKB_Class70]
-		[UpperModel_ProjectKB_Class71]
-		[UpperModel_ProjectKB_Class72]))
+		[UpperModel_ProjectKB_Class10123]
+		[UpperModel_ProjectKB_Class10124]
+		[UpperModel_ProjectKB_Class10125]
+		[UpperModel_ProjectKB_Class10126]))
 
 ([CLSES_TAB] of  Widget
 
@@ -426,6 +426,9 @@
 ([KB_663782_Class0] of  Map
 )
 
+([KB_858554_Class0] of  Map
+)
+
 ([KB_887149_Instance_43] of  String
 
 	(name "factory_class_name")
@@ -547,9 +550,6 @@
 
 	(name "instances_file_name")
 	(string_value "UpperModel.pins"))
-
-([KB_896500_Class0] of  Map
-)
 
 ([PAL_FORM_WIDGET] of  Widget
 
@@ -832,328 +832,328 @@
 ([UpperModel_171209c_1910_ChangeLog_ProjectKB_Class82] of  Property_List
 )
 
-([UpperModel_bundle_to_target_ProjectKB_Class1] of  Widget
+([UpperModel_ProjectKB_Class1] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class2])
+	(property_list [UpperModel_ProjectKB_Class2])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.widget.OWLFormsTab"))
 
-([UpperModel_bundle_to_target_ProjectKB_Class10] of  Property_List
+([UpperModel_ProjectKB_Class10] of  Property_List
 )
 
-([UpperModel_bundle_to_target_ProjectKB_Class11] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class12])
-	(widget_class_name "edu.stanford.smi.protegex.owl.ui.cls.OWLClassesTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class12] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class13] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class14])
-	(widget_class_name "edu.stanford.smi.protegex.server_changes.prompt.UsersTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class14] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class15] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class16])
-	(widget_class_name "edu.stanford.smi.protege.query.LuceneQueryPlugin"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class16] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class17] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class18])
-	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.KnowledgeTreeTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class18] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class19] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class20])
-	(widget_class_name "edu.stanford.smi.protege.keywordsearch.StringSearch"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class2] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class20] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class21] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class22])
-	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalConstraintsTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class22] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class23] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class24])
-	(widget_class_name "edu.stanford.smi.protegex.owl.ui.metadatatab.OWLMetadataTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class24] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class25] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class26])
-	(widget_class_name "edu.stanford.smi.protegex.owl.swrl.ui.tab.SWRLTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class26] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class27] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class28])
-	(widget_class_name "edu.stanford.smi.protegex.owl.ui.individuals.OWLIndividualsTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class28] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class29] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class30])
-	(widget_class_name "uk.ac.man.cs.mig.coode.debugger.test.DebuggerTestTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class3] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class4])
-	(widget_class_name "org.protege.owl.mm.portability.protege3.MappingMasterTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class30] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class31] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class32])
-	(widget_class_name "ca.uvic.csr.shrimp.jambalaya.JambalayaTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class32] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class33] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class34])
-	(widget_class_name "edu.stanford.smi.protegex.changes.ChangesTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class34] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class35] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class36])
-	(widget_class_name "org.protege.owl.axiome.ui.AxiomeTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class36] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class37] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class38])
-	(widget_class_name "TGViztab.TGVizTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class38] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class39] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class40])
-	(widget_class_name "edu.stanford.smi.protegex.owl.ui.properties.OWLPropertiesTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class4] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class40] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class41] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class42])
-	(widget_class_name "uk.ac.man.ac.mig.coode.individuals.ui.OWLDLIndividualsTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class42] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class43] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class44])
-	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.InstanceTreeTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class44] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class45] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class46])
-	(widget_class_name "edu.stanford.smi.protegex.evaluation.MetaAnalysis"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class46] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class47] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class48])
-	(widget_class_name "edu.stanford.smi.protegex.changes.changesKBViewTab.ChangesKBViewTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class48] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class49] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class50])
-	(widget_class_name "se.liu.ida.JessTab.JessTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class5] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class6])
-	(widget_class_name "edu.stanford.smi.protege.widget.ProtegePropertiesTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class50] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class51] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class52])
-	(widget_class_name "edu.stanford.smi.protegex.changeanalysis.ChangeAnalysisTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class52] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class53] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class54])
-	(widget_class_name "uk.ac.man.cs.mig.coode.owlviz.ui.OWLVizTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class54] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class55] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class56])
-	(widget_class_name "edu.stanford.smi.protegex.changes.stats.ChangeStatisticsTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class56] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class57] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class58])
-	(widget_class_name "script.ProtegeScriptTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class58] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class59] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class60])
-	(widget_class_name "edu.stanford.smi.protegex.chatPlugin.ChatTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class6] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class60] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class61] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class62])
-	(widget_class_name "edu.stanford.smi.protegex.fctab.FacetConstraintsTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class62] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class63] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class64])
-	(widget_class_name "edu.stanford.smi.protegex.xml.tab.XMLTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class64] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class65] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class66])
-	(widget_class_name "edu.stanford.smi.protegex.datamaster.DataMasterTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class66] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class67] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class68])
-	(widget_class_name "ezpal.EZPalTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class68] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class7] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class8])
-	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalQueriesTab"))
-
-([UpperModel_bundle_to_target_ProjectKB_Class8] of  Property_List
-)
-
-([UpperModel_bundle_to_target_ProjectKB_Class9] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_bundle_to_target_ProjectKB_Class10])
-	(widget_class_name "dfki.protege.ontoviz_tab.OntovizTab"))
-
-([UpperModel_ProjectKB_Class69] of  String
+([UpperModel_ProjectKB_Class10123] of  String
 
 	(name "ChangeLog")
 	(string_value "date"))
 
-([UpperModel_ProjectKB_Class70] of  String
+([UpperModel_ProjectKB_Class10124] of  String
 
 	(name ":INSTANCE-ANNOTATION")
 	(string_value "%3AANNOTATION-TEXT"))
 
-([UpperModel_ProjectKB_Class71] of  String
+([UpperModel_ProjectKB_Class10125] of  String
 
 	(name ":PAL-CONSTRAINT")
 	(string_value "%3APAL-NAME"))
 
-([UpperModel_ProjectKB_Class72] of  String
+([UpperModel_ProjectKB_Class10126] of  String
 
 	(name ":META-CLASS")
 	(string_value "%3ANAME"))
+
+([UpperModel_ProjectKB_Class11] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class12])
+	(widget_class_name "edu.stanford.smi.protegex.owl.ui.cls.OWLClassesTab"))
+
+([UpperModel_ProjectKB_Class12] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class13] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class14])
+	(widget_class_name "edu.stanford.smi.protegex.server_changes.prompt.UsersTab"))
+
+([UpperModel_ProjectKB_Class14] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class15] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class16])
+	(widget_class_name "edu.stanford.smi.protege.query.LuceneQueryPlugin"))
+
+([UpperModel_ProjectKB_Class16] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class17] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class18])
+	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.KnowledgeTreeTab"))
+
+([UpperModel_ProjectKB_Class18] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class19] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class20])
+	(widget_class_name "edu.stanford.smi.protege.keywordsearch.StringSearch"))
+
+([UpperModel_ProjectKB_Class2] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class20] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class21] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class22])
+	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalConstraintsTab"))
+
+([UpperModel_ProjectKB_Class22] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class23] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class24])
+	(widget_class_name "edu.stanford.smi.protegex.owl.ui.metadatatab.OWLMetadataTab"))
+
+([UpperModel_ProjectKB_Class24] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class25] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class26])
+	(widget_class_name "edu.stanford.smi.protegex.owl.swrl.ui.tab.SWRLTab"))
+
+([UpperModel_ProjectKB_Class26] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class27] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class28])
+	(widget_class_name "edu.stanford.smi.protegex.owl.ui.individuals.OWLIndividualsTab"))
+
+([UpperModel_ProjectKB_Class28] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class29] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class30])
+	(widget_class_name "uk.ac.man.cs.mig.coode.debugger.test.DebuggerTestTab"))
+
+([UpperModel_ProjectKB_Class3] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class4])
+	(widget_class_name "org.protege.owl.mm.portability.protege3.MappingMasterTab"))
+
+([UpperModel_ProjectKB_Class30] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class31] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class32])
+	(widget_class_name "ca.uvic.csr.shrimp.jambalaya.JambalayaTab"))
+
+([UpperModel_ProjectKB_Class32] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class33] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class34])
+	(widget_class_name "edu.stanford.smi.protegex.changes.ChangesTab"))
+
+([UpperModel_ProjectKB_Class34] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class35] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class36])
+	(widget_class_name "org.protege.owl.axiome.ui.AxiomeTab"))
+
+([UpperModel_ProjectKB_Class36] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class37] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class38])
+	(widget_class_name "TGViztab.TGVizTab"))
+
+([UpperModel_ProjectKB_Class38] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class39] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class40])
+	(widget_class_name "edu.stanford.smi.protegex.owl.ui.properties.OWLPropertiesTab"))
+
+([UpperModel_ProjectKB_Class4] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class40] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class41] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class42])
+	(widget_class_name "uk.ac.man.ac.mig.coode.individuals.ui.OWLDLIndividualsTab"))
+
+([UpperModel_ProjectKB_Class42] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class43] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class44])
+	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.InstanceTreeTab"))
+
+([UpperModel_ProjectKB_Class44] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class45] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class46])
+	(widget_class_name "edu.stanford.smi.protegex.evaluation.MetaAnalysis"))
+
+([UpperModel_ProjectKB_Class46] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class47] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class48])
+	(widget_class_name "edu.stanford.smi.protegex.changes.changesKBViewTab.ChangesKBViewTab"))
+
+([UpperModel_ProjectKB_Class48] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class49] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class50])
+	(widget_class_name "se.liu.ida.JessTab.JessTab"))
+
+([UpperModel_ProjectKB_Class5] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class6])
+	(widget_class_name "edu.stanford.smi.protege.widget.ProtegePropertiesTab"))
+
+([UpperModel_ProjectKB_Class50] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class51] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class52])
+	(widget_class_name "edu.stanford.smi.protegex.changeanalysis.ChangeAnalysisTab"))
+
+([UpperModel_ProjectKB_Class52] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class53] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class54])
+	(widget_class_name "uk.ac.man.cs.mig.coode.owlviz.ui.OWLVizTab"))
+
+([UpperModel_ProjectKB_Class54] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class55] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class56])
+	(widget_class_name "edu.stanford.smi.protegex.changes.stats.ChangeStatisticsTab"))
+
+([UpperModel_ProjectKB_Class56] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class57] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class58])
+	(widget_class_name "script.ProtegeScriptTab"))
+
+([UpperModel_ProjectKB_Class58] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class59] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class60])
+	(widget_class_name "edu.stanford.smi.protegex.chatPlugin.ChatTab"))
+
+([UpperModel_ProjectKB_Class6] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class60] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class61] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class62])
+	(widget_class_name "edu.stanford.smi.protegex.fctab.FacetConstraintsTab"))
+
+([UpperModel_ProjectKB_Class62] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class63] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class64])
+	(widget_class_name "edu.stanford.smi.protegex.xml.tab.XMLTab"))
+
+([UpperModel_ProjectKB_Class64] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class65] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class66])
+	(widget_class_name "edu.stanford.smi.protegex.datamaster.DataMasterTab"))
+
+([UpperModel_ProjectKB_Class66] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class67] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class68])
+	(widget_class_name "ezpal.EZPalTab"))
+
+([UpperModel_ProjectKB_Class68] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class7] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class8])
+	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalQueriesTab"))
+
+([UpperModel_ProjectKB_Class8] of  Property_List
+)
+
+([UpperModel_ProjectKB_Class9] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_ProjectKB_Class10])
+	(widget_class_name "dfki.protege.ontoviz_tab.OntovizTab"))

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Mon Jun 24 20:07:52 EDT 2024
+; Wed Aug 07 20:30:28 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -6,10 +6,10 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[UpperModel_ProjectKB_Class73]
-		[UpperModel_ProjectKB_Class74]
-		[UpperModel_ProjectKB_Class75]
-		[UpperModel_ProjectKB_Class76]))
+		[UpperModel_ProjectKB_Class69]
+		[UpperModel_ProjectKB_Class70]
+		[UpperModel_ProjectKB_Class71]
+		[UpperModel_ProjectKB_Class72]))
 
 ([CLSES_TAB] of  Widget
 
@@ -426,9 +426,6 @@
 ([KB_663782_Class0] of  Map
 )
 
-([KB_703537_Class0] of  Map
-)
-
 ([KB_887149_Instance_43] of  String
 
 	(name "factory_class_name")
@@ -550,6 +547,9 @@
 
 	(name "instances_file_name")
 	(string_value "UpperModel.pins"))
+
+([KB_896500_Class0] of  Map
+)
 
 ([PAL_FORM_WIDGET] of  Widget
 
@@ -832,328 +832,328 @@
 ([UpperModel_171209c_1910_ChangeLog_ProjectKB_Class82] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class1] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class1] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class2])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class2])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.widget.OWLFormsTab"))
 
-([UpperModel_ProjectKB_Class10] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class10] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class11] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class11] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class12])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class12])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.cls.OWLClassesTab"))
 
-([UpperModel_ProjectKB_Class12] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class12] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class13] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class13] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class14])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class14])
 	(widget_class_name "edu.stanford.smi.protegex.server_changes.prompt.UsersTab"))
 
-([UpperModel_ProjectKB_Class14] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class14] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class15] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class15] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class16])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class16])
 	(widget_class_name "edu.stanford.smi.protege.query.LuceneQueryPlugin"))
 
-([UpperModel_ProjectKB_Class16] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class16] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class17] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class17] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class18])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class18])
 	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.KnowledgeTreeTab"))
 
-([UpperModel_ProjectKB_Class18] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class18] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class19] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class19] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class20])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class20])
 	(widget_class_name "edu.stanford.smi.protege.keywordsearch.StringSearch"))
 
-([UpperModel_ProjectKB_Class2] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class2] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class20] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class20] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class21] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class21] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class22])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class22])
 	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalConstraintsTab"))
 
-([UpperModel_ProjectKB_Class22] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class22] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class23] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class23] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class24])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class24])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.metadatatab.OWLMetadataTab"))
 
-([UpperModel_ProjectKB_Class24] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class24] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class25] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class25] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class26])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class26])
 	(widget_class_name "edu.stanford.smi.protegex.owl.swrl.ui.tab.SWRLTab"))
 
-([UpperModel_ProjectKB_Class26] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class26] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class27] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class27] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class28])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class28])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.individuals.OWLIndividualsTab"))
 
-([UpperModel_ProjectKB_Class28] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class28] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class29] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class29] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class30])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class30])
 	(widget_class_name "uk.ac.man.cs.mig.coode.debugger.test.DebuggerTestTab"))
 
-([UpperModel_ProjectKB_Class3] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class3] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class4])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class4])
 	(widget_class_name "org.protege.owl.mm.portability.protege3.MappingMasterTab"))
 
-([UpperModel_ProjectKB_Class30] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class30] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class31] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class31] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class32])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class32])
 	(widget_class_name "ca.uvic.csr.shrimp.jambalaya.JambalayaTab"))
 
-([UpperModel_ProjectKB_Class32] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class32] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class33] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class33] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class34])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class34])
 	(widget_class_name "edu.stanford.smi.protegex.changes.ChangesTab"))
 
-([UpperModel_ProjectKB_Class34] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class34] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class35] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class35] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class36])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class36])
 	(widget_class_name "org.protege.owl.axiome.ui.AxiomeTab"))
 
-([UpperModel_ProjectKB_Class36] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class36] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class37] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class37] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class38])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class38])
 	(widget_class_name "TGViztab.TGVizTab"))
 
-([UpperModel_ProjectKB_Class38] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class38] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class39] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class39] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class40])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class40])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.properties.OWLPropertiesTab"))
 
-([UpperModel_ProjectKB_Class4] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class4] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class40] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class40] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class41] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class41] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class42])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class42])
 	(widget_class_name "uk.ac.man.ac.mig.coode.individuals.ui.OWLDLIndividualsTab"))
 
-([UpperModel_ProjectKB_Class42] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class42] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class43] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class43] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class44])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class44])
 	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.InstanceTreeTab"))
 
-([UpperModel_ProjectKB_Class44] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class44] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class45] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class45] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class46])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class46])
 	(widget_class_name "edu.stanford.smi.protegex.evaluation.MetaAnalysis"))
 
-([UpperModel_ProjectKB_Class46] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class46] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class47] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class47] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class48])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class48])
 	(widget_class_name "edu.stanford.smi.protegex.changes.changesKBViewTab.ChangesKBViewTab"))
 
-([UpperModel_ProjectKB_Class48] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class48] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class49] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class49] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class50])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class50])
 	(widget_class_name "se.liu.ida.JessTab.JessTab"))
 
-([UpperModel_ProjectKB_Class5] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class5] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class6])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class6])
 	(widget_class_name "edu.stanford.smi.protege.widget.ProtegePropertiesTab"))
 
-([UpperModel_ProjectKB_Class50] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class50] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class51] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class51] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class52])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class52])
 	(widget_class_name "edu.stanford.smi.protegex.changeanalysis.ChangeAnalysisTab"))
 
-([UpperModel_ProjectKB_Class52] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class52] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class53] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class53] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class54])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class54])
 	(widget_class_name "uk.ac.man.cs.mig.coode.owlviz.ui.OWLVizTab"))
 
-([UpperModel_ProjectKB_Class54] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class54] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class55] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class55] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class56])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class56])
 	(widget_class_name "edu.stanford.smi.protegex.changes.stats.ChangeStatisticsTab"))
 
-([UpperModel_ProjectKB_Class56] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class56] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class57] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class57] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class58])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class58])
 	(widget_class_name "script.ProtegeScriptTab"))
 
-([UpperModel_ProjectKB_Class58] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class58] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class59] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class59] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class60])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class60])
 	(widget_class_name "edu.stanford.smi.protegex.chatPlugin.ChatTab"))
 
-([UpperModel_ProjectKB_Class6] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class6] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class60] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class60] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class61] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class61] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class62])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class62])
 	(widget_class_name "edu.stanford.smi.protegex.fctab.FacetConstraintsTab"))
 
-([UpperModel_ProjectKB_Class62] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class62] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class63] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class63] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class64])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class64])
 	(widget_class_name "edu.stanford.smi.protegex.xml.tab.XMLTab"))
 
-([UpperModel_ProjectKB_Class64] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class64] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class65] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class65] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class66])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class66])
 	(widget_class_name "edu.stanford.smi.protegex.datamaster.DataMasterTab"))
 
-([UpperModel_ProjectKB_Class66] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class66] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class67] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class67] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class68])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class68])
 	(widget_class_name "ezpal.EZPalTab"))
 
-([UpperModel_ProjectKB_Class68] of  Property_List
+([UpperModel_bundle_to_target_ProjectKB_Class68] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class7] of  Widget
+([UpperModel_bundle_to_target_ProjectKB_Class7] of  Widget
 
 	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class8])
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class8])
 	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalQueriesTab"))
 
-([UpperModel_ProjectKB_Class73] of  String
+([UpperModel_bundle_to_target_ProjectKB_Class8] of  Property_List
+)
+
+([UpperModel_bundle_to_target_ProjectKB_Class9] of  Widget
+
+	(is_hidden TRUE)
+	(property_list [UpperModel_bundle_to_target_ProjectKB_Class10])
+	(widget_class_name "dfki.protege.ontoviz_tab.OntovizTab"))
+
+([UpperModel_ProjectKB_Class69] of  String
 
 	(name "ChangeLog")
 	(string_value "date"))
 
-([UpperModel_ProjectKB_Class74] of  String
+([UpperModel_ProjectKB_Class70] of  String
 
 	(name ":INSTANCE-ANNOTATION")
 	(string_value "%3AANNOTATION-TEXT"))
 
-([UpperModel_ProjectKB_Class75] of  String
+([UpperModel_ProjectKB_Class71] of  String
 
 	(name ":PAL-CONSTRAINT")
 	(string_value "%3APAL-NAME"))
 
-([UpperModel_ProjectKB_Class76] of  String
+([UpperModel_ProjectKB_Class72] of  String
 
 	(name ":META-CLASS")
 	(string_value "%3ANAME"))
-
-([UpperModel_ProjectKB_Class8] of  Property_List
-)
-
-([UpperModel_ProjectKB_Class9] of  Widget
-
-	(is_hidden TRUE)
-	(property_list [UpperModel_ProjectKB_Class10])
-	(widget_class_name "dfki.protege.ontoviz_tab.OntovizTab"))


### PR DESCRIPTION
CCB#7  Missing schematron rule to check that Product_Bundle.Target_Identification.Internal_Reference.reference_type is bundle_to_target 

## 🗒️ Summary
Add the following standard values to allow a bundle to reference a target context product.
    Product_Bundle.Context_Area.Target_Identification.Internal_Reference.reference_type == bundle_to_target
    Product_Collection.Context_Area.Target_Identification.Internal_Reference.reference_type == collection_to_target
    Product_Observational.Observation_Area.Target_Identification.Internal_Reference.reference_type == data_to_target
    Product_Browse.Context_Area.Target_Identification.Internal_Reference.reference_type == browse_to_target
    Product_External.Context_Area.Target_Identification.Internal_Reference.reference_type == external_to_target
    Product_Native.Context_Area.Target_Identification.Internal_Reference.reference_type == native_to_target
    Product_SPICE_Kernel.Context_Area.Target_Identification.Internal_Reference.reference_type == data_to_target
    Product_XML_Schema.Context_Area.Target_Identification.Internal_Reference.reference_type == schema_to_target

## ⚙️ Test Data and/or Report
The attached Information Model Specification show that that these standard values and their value meanings have been added. 

## ♻️ Related Issues
Resolves #795
Refs https://github.com/NASA-PDS/PDS4-CCB/issues/7



[index_1N00.zip](https://github.com/user-attachments/files/16550842/index_1N00.zip)
