### PR TITLE
Added geom:kernel_type validation rule

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -838,7 +838,8 @@ public class DMDocument extends Object {
 	    setexposedElementFlag();
 	    
 	    // set exposed attributes
-	    setexposedAttributeFlag();
+	    // 555 commented out until DDWG approves the impact of the fix
+//	    setexposedAttributeFlag();
   }
   
   static private void reset() {
@@ -1099,6 +1100,10 @@ public class DMDocument extends Object {
     exposedElementArr.add("0001_NASA_PDS_1.pds.Internal_Reference");
     exposedElementArr.add("0001_NASA_PDS_1.pds.Local_Internal_Reference");
     exposedElementArr.add("0001_NASA_PDS_1.pds.External_Reference");
+    
+    // 555 added back in until DDWG approves impact of the fix
+    exposedElementArr.add("0001_NASA_PDS_1.pds.DD_Class.pds.local_identifier");
+    exposedElementArr.add("0001_NASA_PDS_1.pds.Identification_Area.pds.logical_identifier");
   }
   
   static void setexposedAttributeFlag() {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -838,8 +838,7 @@ public class DMDocument extends Object {
 	    setexposedElementFlag();
 	    
 	    // set exposed attributes
-	    // 555 commented out until DDWG approves the impact of the fix
-//	    setexposedAttributeFlag();
+	    setexposedAttributeFlag();
   }
   
   static private void reset() {
@@ -1100,21 +1099,18 @@ public class DMDocument extends Object {
     exposedElementArr.add("0001_NASA_PDS_1.pds.Internal_Reference");
     exposedElementArr.add("0001_NASA_PDS_1.pds.Local_Internal_Reference");
     exposedElementArr.add("0001_NASA_PDS_1.pds.External_Reference");
-    
-    // 555 added back in until DDWG approves impact of the fix
-    exposedElementArr.add("0001_NASA_PDS_1.pds.DD_Class.pds.local_identifier");
-    exposedElementArr.add("0001_NASA_PDS_1.pds.Identification_Area.pds.logical_identifier");
   }
   
   static void setexposedAttributeFlag() {
     // the set of attributes that will be externalized (defined as xs:Element)
     exposedAttributeArr = new ArrayList<>();
-    exposedAttributeArr.add("0001_NASA_PDS_1.all.USER.pds.comment");
-    exposedAttributeArr.add("0001_NASA_PDS_1.all.USER.pds.description");
+// 555 commented out until DDWG addresses impact of using ref:
+//    exposedAttributeArr.add("0001_NASA_PDS_1.all.USER.pds.comment");
+//    exposedAttributeArr.add("0001_NASA_PDS_1.all.USER.pds.description");
     exposedAttributeArr.add("0001_NASA_PDS_1.all.USER.pds.local_identifier");
     exposedAttributeArr.add("0001_NASA_PDS_1.all.USER.pds.logical_identifier");
-    exposedAttributeArr.add("0001_NASA_PDS_1.all.USER.pds.name");
-    exposedAttributeArr.add("0001_NASA_PDS_1.all.USER.pds.kernel_type");
+//    exposedAttributeArr.add("0001_NASA_PDS_1.all.USER.pds.name");
+//    exposedAttributeArr.add("0001_NASA_PDS_1.all.USER.pds.kernel_type");
   }
 
   static void setRegistryAttrFlag() {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -1808,13 +1808,14 @@ public class LDDDOMParser extends Object {
     }
     
     // validate that referenced attribute is exposed
-    if (lDOMAttr.nameSpaceIdNC.compareTo("pds") == 0 && ! lDOMAttr.isExposed) {
-    	if (lDOMAttr.isEnumerated) {
-            DMDocument.registerMessage("2>error Attribute: " + " - The referenced enumerated attribute " + lLocalIdentifier + " must be exposed.");
-    	} else {
-    		DMDocument.registerMessage("2>warning Attribute: " + " - The referenced attribute " + lLocalIdentifier + " is not exposed.");
-    	}
-    }
+	// 555 commented out until DDWG approves impact of the fix
+//    if (lDOMAttr.nameSpaceIdNC.compareTo("pds") == 0 && ! lDOMAttr.isExposed) {
+//    	if (lDOMAttr.isEnumerated) {
+//            DMDocument.registerMessage("2>warning Attribute: " + " - The referenced enumerated attribute " + lLocalIdentifier + " is not exposed.");
+//    	} else {
+//    		DMDocument.registerMessage("2>warning Attribute: " + " - The referenced attribute " + lLocalIdentifier + " is not exposed.");
+//    	}
+//    }
 
     // clone the USER or LDD attribute for use as a Resolved attribute
     // returns rdfIdentifier = "TBD_rdfIdentifier"

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
@@ -142,8 +142,8 @@ class MasterDOMInfoModel extends DOMInfoModel {
               DOMInfoModel.getAttrIdentifier(DMDocument.masterUserClassNamespaceIdNC,
                   DMDocument.masterUserClassName, lDOMAttr.nameSpaceIdNC, lDOMAttr.title);
           
-          // 555
-          if (DMDocument.exposedAttributeArr.contains(lUserAttrIdentifier)) lDOMAttr.isExposed = true;
+          	// 555 commented out until DDWG approves impact of the fix
+//          if (DMDocument.exposedAttributeArr.contains(lUserAttrIdentifier)) lDOMAttr.isExposed = true;
 
           DOMInfoModel.userDOMClassAttrIdMap.put(lUserAttrIdentifier, lDOMAttr);
         }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/MasterDOMInfoModel.java
@@ -142,8 +142,8 @@ class MasterDOMInfoModel extends DOMInfoModel {
               DOMInfoModel.getAttrIdentifier(DMDocument.masterUserClassNamespaceIdNC,
                   DMDocument.masterUserClassName, lDOMAttr.nameSpaceIdNC, lDOMAttr.title);
           
-          	// 555 commented out until DDWG approves impact of the fix
-//          if (DMDocument.exposedAttributeArr.contains(lUserAttrIdentifier)) lDOMAttr.isExposed = true;
+          // set selected attributes to exposed
+          if (DMDocument.exposedAttributeArr.contains(lUserAttrIdentifier)) lDOMAttr.isExposed = true;
 
           DOMInfoModel.userDOMClassAttrIdMap.put(lUserAttrIdentifier, lDOMAttr);
         }

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Thu Aug 08 12:01:13 EDT 2024
+; Wed Aug 14 12:29:19 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -144,6 +144,29 @@
 	(attrTitle "nilReason")
 	(identifier "nilReason")
 	(specMesg "The 'nilReason' attribute must be used in conjunction with xsi:nil=\"true\""))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.geom%3ASPICE_Kernel_Identification%2Fgeom%3Akernel_type.100004870] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "geom")
+	(attrTitle "kernel_type")
+	(classNameSpaceNC "geom")
+	(classSteward "geom")
+	(classTitle "SPICE_Kernel_Identification")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.geom%3ASPICE_Kernel_Identification%2Fgeom%3Akernel_type.100004870.101])
+	(identifier "geom:SPICE_Kernel_Identification/geom:kernel_type")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "geom:SPICE_Kernel_Identification/geom:kernel_type"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.geom%3ASPICE_Kernel_Identification%2Fgeom%3Akernel_type.100004870.101] of  Schematron_Assert
+
+	(assertMsg "The attribute geom:SPICE_Kernel_Identification/geom:kernel_type must be equal to one of the following values 'CK', 'DBK', 'DSK', 'EK', 'FK', 'IK', 'LSK', 'MK', 'PCK', 'SCLK', 'SPK'.")
+	(assertStmt ". = ('CK', 'DBK', 'DSK', 'EK', 'FK', 'IK', 'LSK', 'MK', 'PCK', 'SCLK', 'SPK')")
+	(assertType "RAW")
+	(attrTitle "kernel_type")
+	(identifier "kernel_type"))
 
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3A%2FProduct_Observational%2Fpds%3AIdentification_Area%2Fpds%3Alogical_identifier.100002512] of  Schematron_Rule
 

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Thu Aug 08 12:01:12 EDT 2024
+; Wed Aug 14 12:29:18 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Thu Aug 08 12:01:13 EDT 2024
+; Wed Aug 14 12:29:19 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -6,10 +6,10 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[UpperModel_ProjectKB_Class10123]
-		[UpperModel_ProjectKB_Class10124]
-		[UpperModel_ProjectKB_Class10125]
-		[UpperModel_ProjectKB_Class10126]))
+		[UpperModel_ProjectKB_Class123]
+		[UpperModel_ProjectKB_Class124]
+		[UpperModel_ProjectKB_Class125]
+		[UpperModel_ProjectKB_Class126]))
 
 ([CLSES_TAB] of  Widget
 
@@ -423,10 +423,10 @@
 	(x 0)
 	(y 120))
 
-([KB_663782_Class0] of  Map
+([KB_414268_Class0] of  Map
 )
 
-([KB_858554_Class0] of  Map
+([KB_663782_Class0] of  Map
 )
 
 ([KB_887149_Instance_43] of  String
@@ -841,26 +841,6 @@
 ([UpperModel_ProjectKB_Class10] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class10123] of  String
-
-	(name "ChangeLog")
-	(string_value "date"))
-
-([UpperModel_ProjectKB_Class10124] of  String
-
-	(name ":INSTANCE-ANNOTATION")
-	(string_value "%3AANNOTATION-TEXT"))
-
-([UpperModel_ProjectKB_Class10125] of  String
-
-	(name ":PAL-CONSTRAINT")
-	(string_value "%3APAL-NAME"))
-
-([UpperModel_ProjectKB_Class10126] of  String
-
-	(name ":META-CLASS")
-	(string_value "%3ANAME"))
-
 ([UpperModel_ProjectKB_Class11] of  Widget
 
 	(is_hidden TRUE)
@@ -869,6 +849,26 @@
 
 ([UpperModel_ProjectKB_Class12] of  Property_List
 )
+
+([UpperModel_ProjectKB_Class123] of  String
+
+	(name "ChangeLog")
+	(string_value "date"))
+
+([UpperModel_ProjectKB_Class124] of  String
+
+	(name ":INSTANCE-ANNOTATION")
+	(string_value "%3AANNOTATION-TEXT"))
+
+([UpperModel_ProjectKB_Class125] of  String
+
+	(name ":PAL-CONSTRAINT")
+	(string_value "%3APAL-NAME"))
+
+([UpperModel_ProjectKB_Class126] of  String
+
+	(name ":META-CLASS")
+	(string_value "%3ANAME"))
 
 ([UpperModel_ProjectKB_Class13] of  Widget
 


### PR DESCRIPTION
Added a validation rule for geom:kernel_type as a fix for the issue: GEOM LDD schematron rules are not executing as expected <kernel_type> validation #797

## 🗒️ Summary

Added the geom:kernel_type validation rule to the common dictionary so that it is available for writing to the geom schematron file during LDDTool processing of the Geo Ingest_LDD. The rule is:
				
   <sch:pattern>
      <sch:rule context="geom:SPICE_Kernel_Identification/geom:kernel_type">
         <sch:assert test=". = ('CK', 'DBK', 'DSK', 'EK', 'FK', 'IK', 'LSK', 'MK', 'PCK', 'SCLK', 'SPK')">
         <title>geom:SPICE_Kernel_Identification/geom:kernel_type/kernel_type</title>
         The attribute geom:SPICE_Kernel_Identification/geom:kernel_type must be equal to one of the following values 'CK', 'DBK', 'DSK', 'EK', 'FK', 'IK', 'LSK', 'MK', 'PCK', 'SCLK', 'SPK'.</sch:assert>
      </sch:rule>
   </sch:pattern>
  				
This issue was caused by a failure to expose attributes in the Common schema that are referenced in Ingest_LDD files. The references are formulated like pds.<name>, for example pds:kernel_type, pds:name, pds:comment, etc. The attribute pds:kernel_type is the only attribute that is enumerated.
  			 
There are several fixes to the problem, each with its own impact.
  			
1) Simply add the rule to check the geom:kernel_type. This only solves the problem for kernel_type.
  			
2) Expose the referenced attributes in the common schema. This was the original intent from V1.0 were it was suggested to expose all common attributes. The DDWG voted not to expose all the attributes but to request them as needed.
    The expected result is that the geom schema references the attributes in the common schema using "ref:" instead of defining them locally.
    The current impact is a significant set of "cosmetic" differences in the geom schema file, for example:
  			   
  			         <xs:element ref="pds:comment" minOccurs="0" maxOccurs="1"> </xs:element>
  			         		-versus-
  			         <xs:element name="comment" type="pds:comment" minOccurs="0" maxOccurs="1"> </xs:element>
  			         
  			  This occurs over 20 times in the current geom LDD.
  			  
3) Add a validation routine to check that all referenced pds: attributes are exposed. 
    The impact here is that if the common attributes are not exposed then warning messages are written to the log file. Again, over 20 messages would be written.
  			   
As a path forward and to minimize surprise, this pull request only implements option 1. The plan is to submit an SCR for DDWG discussion to determine whether option 2 and/or 3 should be considered. It seems reasonable to at least implement option 3.


## ⚙️ Test Data and/or Report
The test files are attached below. The schema locations will need to be updated for the testing environment. The previous versions of the .xsd and .sch files are provided for diff checking. 

Resolves #797 #799


[Try3_Option_1.zip](https://github.com/user-attachments/files/16628978/Try3_Option_1.zip)
