### PR TITLE
Add Array_1D_Spectrum to File_Area_Ancillary, File_Area_Browse, and File_Area_Observational_Supplemental

### DIFF
--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Mon Aug 26 19:35:40 EDT 2024
+; Wed Aug 28 09:43:08 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Mon Aug 26 12:54:11 EDT 2024
+; Mon Aug 26 19:35:40 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Wed Aug 14 12:29:19 EDT 2024
+; Mon Aug 26 12:54:11 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Mon Aug 26 12:54:11 EDT 2024
+; Mon Aug 26 19:35:40 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -10181,7 +10181,7 @@
 	(multislot has_tagged_data_object
 ;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
 		(type INSTANCE)
-;+		(allowed-classes Array_2D_Map Array_2D_Image Stream_Text Array_2D_Spectrum Array_3D_Image Table_Binary Array_3D_Movie Array_3D_Spectrum Table_Character Header Table_Delimited Encoded_Header Array_3D Array_2D XSChoice%23 Array_1D Array Encoded_Audio Encoded_Video)
+;+		(allowed-classes Array_2D_Map Array_2D_Image Stream_Text Array_2D_Spectrum Array_3D_Image Table_Binary Array_3D_Movie Array_3D_Spectrum Table_Character Header Table_Delimited Encoded_Header Array_3D Array_2D XSChoice%23 Array_1D Array Encoded_Audio Encoded_Video Array_1D_Spectrum)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
 	(single-slot has_composite_structure

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Mon Aug 26 19:35:40 EDT 2024
+; Wed Aug 28 09:43:08 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -10219,7 +10219,7 @@
 	(multislot has_tagged_data_object
 ;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
 		(type INSTANCE)
-;+		(allowed-classes Array_2D_Map Array_2D_Image Stream_Text Array_2D_Spectrum Array_3D_Image Table_Binary Array_3D_Movie Array_3D_Spectrum Encoded_Image Table_Character Header Encoded_Header Table_Delimited Array_2D Array_3D XSChoice%23 Array_1D Array Encoded_Audio Encoded_Video)
+;+		(allowed-classes Array_2D_Map Array_2D_Image Stream_Text Array_2D_Spectrum Array_3D_Image Table_Binary Array_3D_Movie Array_3D_Spectrum Encoded_Image Table_Character Header Encoded_Header Table_Delimited Array_2D Array_3D XSChoice%23 Array_1D Array Encoded_Audio Encoded_Video Array_1D_Spectrum)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
 	(single-slot has_File
@@ -10298,7 +10298,7 @@
 	(multislot has_tagged_data_object
 ;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
 		(type INSTANCE)
-;+		(allowed-classes Parsable_Byte_Stream Encoded_Byte_Stream Array_3D_Movie Array_2D_Spectrum Array_2D Array_3D Array_2D_Image Array_2D_Map Array_3D_Image Array_3D_Spectrum Stream_Text Table_Delimited Header Table_Binary Table_Character Encoded_Header Encoded_Image Encoded_Binary XSChoice%23 Array_1D Array Table_Delimited_Source_Product_Internal Table_Delimited_Source_Product_External Encoded_Audio Encoded_Video)
+;+		(allowed-classes Parsable_Byte_Stream Encoded_Byte_Stream Array_3D_Movie Array_2D_Spectrum Array_2D Array_3D Array_2D_Image Array_2D_Map Array_3D_Image Array_3D_Spectrum Stream_Text Table_Delimited Header Table_Binary Table_Character Encoded_Header Encoded_Image Encoded_Binary XSChoice%23 Array_1D Array Table_Delimited_Source_Product_Internal Table_Delimited_Source_Product_External Encoded_Audio Encoded_Video Array_1D_Spectrum)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
 	(single-slot has_composite_structure
@@ -10390,7 +10390,7 @@
 	(multislot has_tagged_data_object
 ;+		(comment "The has_tagged_data_object association is a relationship to any tagged_digital_object or tagged_nondigital_object.")
 		(type INSTANCE)
-;+		(allowed-classes Table_Binary Table_Delimited Table_Character XSChoice%23 Array_3D_Movie Array_2D_Spectrum Array_2D Array_3D Array Array_2D_Image Array_2D_Map Array_3D_Image Array_3D_Spectrum Stream_Text Encoded_Image Header Encoded_Header Checksum_Manifest Array_1D Encoded_Audio Encoded_Video)
+;+		(allowed-classes Table_Binary Table_Delimited Table_Character XSChoice%23 Array_3D_Movie Array_2D_Spectrum Array_2D Array_3D Array Array_2D_Image Array_2D_Map Array_3D_Image Array_3D_Spectrum Stream_Text Encoded_Image Header Encoded_Header Checksum_Manifest Array_1D Encoded_Audio Encoded_Video Array_1D_Spectrum)
 		(cardinality 1 ?VARIABLE)
 		(create-accessor read-write))
 	(single-slot has_File

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Wed Aug 14 12:29:18 EDT 2024
+; Mon Aug 26 12:54:11 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -5267,6 +5267,10 @@
 ;+		(allowed-classes Axis_Array)
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
+
+(defclass Array_1D_Spectrum "The Array 1D Spectrum class is an extension of the Array 1D class and defines a one dimensional spectrum."
+	(is-a Array_1D)
+	(role concrete))
 
 (defclass File "The File class consists of attributes that describe a file in a data store."
 	(is-a Tagged_Digital_Object)

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Mon Aug 26 19:35:40 EDT 2024
+; Wed Aug 28 09:43:08 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -423,7 +423,7 @@
 	(x 0)
 	(y 120))
 
-([KB_648079_Class0] of  Map
+([KB_307747_Class0] of  Map
 )
 
 ([KB_663782_Class0] of  Map

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Mon Aug 26 12:54:11 EDT 2024
+; Mon Aug 26 19:35:40 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -423,6 +423,9 @@
 	(x 0)
 	(y 120))
 
+([KB_648079_Class0] of  Map
+)
+
 ([KB_663782_Class0] of  Map
 )
 
@@ -547,9 +550,6 @@
 
 	(name "instances_file_name")
 	(string_value "UpperModel.pins"))
-
-([KB_967117_Class0] of  Map
-)
 
 ([PAL_FORM_WIDGET] of  Widget
 

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Wed Aug 14 12:29:19 EDT 2024
+; Mon Aug 26 12:54:11 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -6,10 +6,10 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[UpperModel_ProjectKB_Class123]
-		[UpperModel_ProjectKB_Class124]
-		[UpperModel_ProjectKB_Class125]
-		[UpperModel_ProjectKB_Class126]))
+		[UpperModel_ProjectKB_Class69]
+		[UpperModel_ProjectKB_Class70]
+		[UpperModel_ProjectKB_Class71]
+		[UpperModel_ProjectKB_Class72]))
 
 ([CLSES_TAB] of  Widget
 
@@ -423,9 +423,6 @@
 	(x 0)
 	(y 120))
 
-([KB_414268_Class0] of  Map
-)
-
 ([KB_663782_Class0] of  Map
 )
 
@@ -550,6 +547,9 @@
 
 	(name "instances_file_name")
 	(string_value "UpperModel.pins"))
+
+([KB_967117_Class0] of  Map
+)
 
 ([PAL_FORM_WIDGET] of  Widget
 
@@ -850,26 +850,6 @@
 ([UpperModel_ProjectKB_Class12] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class123] of  String
-
-	(name "ChangeLog")
-	(string_value "date"))
-
-([UpperModel_ProjectKB_Class124] of  String
-
-	(name ":INSTANCE-ANNOTATION")
-	(string_value "%3AANNOTATION-TEXT"))
-
-([UpperModel_ProjectKB_Class125] of  String
-
-	(name ":PAL-CONSTRAINT")
-	(string_value "%3APAL-NAME"))
-
-([UpperModel_ProjectKB_Class126] of  String
-
-	(name ":META-CLASS")
-	(string_value "%3ANAME"))
-
 ([UpperModel_ProjectKB_Class13] of  Widget
 
 	(is_hidden TRUE)
@@ -1143,11 +1123,31 @@
 ([UpperModel_ProjectKB_Class68] of  Property_List
 )
 
+([UpperModel_ProjectKB_Class69] of  String
+
+	(name "ChangeLog")
+	(string_value "date"))
+
 ([UpperModel_ProjectKB_Class7] of  Widget
 
 	(is_hidden TRUE)
 	(property_list [UpperModel_ProjectKB_Class8])
 	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalQueriesTab"))
+
+([UpperModel_ProjectKB_Class70] of  String
+
+	(name ":INSTANCE-ANNOTATION")
+	(string_value "%3AANNOTATION-TEXT"))
+
+([UpperModel_ProjectKB_Class71] of  String
+
+	(name ":PAL-CONSTRAINT")
+	(string_value "%3APAL-NAME"))
+
+([UpperModel_ProjectKB_Class72] of  String
+
+	(name ":META-CLASS")
+	(string_value "%3ANAME"))
 
 ([UpperModel_ProjectKB_Class8] of  Property_List
 )

--- a/model-ontology/src/ontology/Data/dd11179.pont
+++ b/model-ontology/src/ontology/Data/dd11179.pont
@@ -1,4 +1,4 @@
-; Mon Aug 26 13:23:12 EDT 2024
+; Mon Aug 26 19:49:30 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/dd11179.pont
+++ b/model-ontology/src/ontology/Data/dd11179.pont
@@ -1,4 +1,4 @@
-; Mon Jun 24 20:35:04 EDT 2024
+; Mon Aug 26 13:23:12 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/dd11179.pont
+++ b/model-ontology/src/ontology/Data/dd11179.pont
@@ -1,4 +1,4 @@
-; Mon Aug 26 19:49:30 EDT 2024
+; Wed Aug 28 09:56:34 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/dd11179.pprj
+++ b/model-ontology/src/ontology/Data/dd11179.pprj
@@ -1,4 +1,4 @@
-; Mon Jun 24 20:35:04 EDT 2024
+; Mon Aug 26 13:23:12 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -20,9 +20,9 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[dd11179_ProjectKB_Class193]
-		[dd11179_ProjectKB_Class194]
-		[dd11179_ProjectKB_Class195]))
+		[dd11179_ProjectKB_Class313]
+		[dd11179_ProjectKB_Class314]
+		[dd11179_ProjectKB_Class315]))
 
 ([CLSES_TAB] of  Widget
 
@@ -87,21 +87,6 @@
 	(property_list [dd11179_ProjectKB_Class20])
 	(widget_class_name "edu.stanford.smi.protege.widget.KAToolTab"))
 
-([dd11179_ProjectKB_Class193] of  String
-
-	(name ":INSTANCE-ANNOTATION")
-	(string_value "%3AANNOTATION-TEXT"))
-
-([dd11179_ProjectKB_Class194] of  String
-
-	(name ":PAL-CONSTRAINT")
-	(string_value "%3APAL-NAME"))
-
-([dd11179_ProjectKB_Class195] of  String
-
-	(name ":META-CLASS")
-	(string_value "%3ANAME"))
-
 ([dd11179_ProjectKB_Class2] of  Property_List
 )
 
@@ -164,6 +149,21 @@
 	(is_hidden TRUE)
 	(property_list [dd11179_ProjectKB_Class32])
 	(widget_class_name "edu.stanford.smi.protegex.owl.swrl.ui.tab.SWRLTab"))
+
+([dd11179_ProjectKB_Class313] of  String
+
+	(name ":INSTANCE-ANNOTATION")
+	(string_value "%3AANNOTATION-TEXT"))
+
+([dd11179_ProjectKB_Class314] of  String
+
+	(name ":PAL-CONSTRAINT")
+	(string_value "%3APAL-NAME"))
+
+([dd11179_ProjectKB_Class315] of  String
+
+	(name ":META-CLASS")
+	(string_value "%3ANAME"))
 
 ([dd11179_ProjectKB_Class32] of  Property_List
 )
@@ -522,7 +522,7 @@
 	(name "instances_file_name")
 	(string_value "dd11179.pins"))
 
-([KB_440487_Class0] of  Map
+([KB_304103_Class0] of  Map
 )
 
 ([KB_860773_Class0] of  Map

--- a/model-ontology/src/ontology/Data/dd11179.pprj
+++ b/model-ontology/src/ontology/Data/dd11179.pprj
@@ -1,4 +1,4 @@
-; Mon Aug 26 13:23:12 EDT 2024
+; Mon Aug 26 19:49:30 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -20,9 +20,9 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[dd11179_ProjectKB_Class313]
-		[dd11179_ProjectKB_Class314]
-		[dd11179_ProjectKB_Class315]))
+		[dd11179_ProjectKB_Class118]
+		[dd11179_ProjectKB_Class119]
+		[dd11179_ProjectKB_Class120]))
 
 ([CLSES_TAB] of  Widget
 
@@ -51,8 +51,23 @@
 	(property_list [dd11179_ProjectKB_Class12])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.cls.OWLClassesTab"))
 
+([dd11179_ProjectKB_Class118] of  String
+
+	(name ":INSTANCE-ANNOTATION")
+	(string_value "%3AANNOTATION-TEXT"))
+
+([dd11179_ProjectKB_Class119] of  String
+
+	(name ":PAL-CONSTRAINT")
+	(string_value "%3APAL-NAME"))
+
 ([dd11179_ProjectKB_Class12] of  Property_List
 )
+
+([dd11179_ProjectKB_Class120] of  String
+
+	(name ":META-CLASS")
+	(string_value "%3ANAME"))
 
 ([dd11179_ProjectKB_Class13] of  Widget
 
@@ -149,21 +164,6 @@
 	(is_hidden TRUE)
 	(property_list [dd11179_ProjectKB_Class32])
 	(widget_class_name "edu.stanford.smi.protegex.owl.swrl.ui.tab.SWRLTab"))
-
-([dd11179_ProjectKB_Class313] of  String
-
-	(name ":INSTANCE-ANNOTATION")
-	(string_value "%3AANNOTATION-TEXT"))
-
-([dd11179_ProjectKB_Class314] of  String
-
-	(name ":PAL-CONSTRAINT")
-	(string_value "%3APAL-NAME"))
-
-([dd11179_ProjectKB_Class315] of  String
-
-	(name ":META-CLASS")
-	(string_value "%3ANAME"))
 
 ([dd11179_ProjectKB_Class32] of  Property_List
 )
@@ -522,10 +522,10 @@
 	(name "instances_file_name")
 	(string_value "dd11179.pins"))
 
-([KB_304103_Class0] of  Map
+([KB_860773_Class0] of  Map
 )
 
-([KB_860773_Class0] of  Map
+([KB_958176_Class0] of  Map
 )
 
 ([LAYOUT_PROPERTIES] of  Property_List

--- a/model-ontology/src/ontology/Data/dd11179.pprj
+++ b/model-ontology/src/ontology/Data/dd11179.pprj
@@ -1,4 +1,4 @@
-; Mon Aug 26 19:49:30 EDT 2024
+; Wed Aug 28 09:56:34 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -522,10 +522,10 @@
 	(name "instances_file_name")
 	(string_value "dd11179.pins"))
 
-([KB_860773_Class0] of  Map
+([KB_699654_Class0] of  Map
 )
 
-([KB_958176_Class0] of  Map
+([KB_860773_Class0] of  Map
 )
 
 ([LAYOUT_PROPERTIES] of  Property_List


### PR DESCRIPTION
Update to #42 Create Array_1D_Spectrum

To complete #42,  the class Array_1D_Spectrum was added to File_Area_Ancillary, File_Area_Browse, and File_Area_Observational_Supplemental. In the original PR, Array_1D_Spectrum was only added to File_Area_Observational.

## ⚙️ Test Data and/or Report
Test data is available in the attached zip.

[TestingDistributionPackage.zip](https://github.com/user-attachments/files/16785204/TestingDistributionPackage.zip)

Resolves https://github.com/NASA-PDS/PDS4-CCB/issues/42

