### PR TITLE
Added mrad/pixel to Units_of_Pixel_Resolution_Angular

### DIFF
--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Wed Aug 28 09:43:08 EDT 2024
+; Wed Aug 28 11:13:39 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Wed Aug 28 09:43:08 EDT 2024
+; Wed Aug 28 11:13:39 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -12189,7 +12189,7 @@
 	(single-slot unit_id
 ;+		(comment "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
 		(type STRING)
-;+		(value "deg/pixel" "arcsec/pixel" "radian/pixel" "HA/pixel")
+;+		(value "deg/pixel" "arcsec/pixel" "radian/pixel" "HA/pixel" "mrad/pixel")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Wed Aug 28 09:43:08 EDT 2024
+; Wed Aug 28 11:13:39 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -6,10 +6,10 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[UpperModel_ProjectKB_Class69]
-		[UpperModel_ProjectKB_Class70]
-		[UpperModel_ProjectKB_Class71]
-		[UpperModel_ProjectKB_Class72]))
+		[UpperModel_ProjectKB_Class73]
+		[UpperModel_ProjectKB_Class74]
+		[UpperModel_ProjectKB_Class75]
+		[UpperModel_ProjectKB_Class76]))
 
 ([CLSES_TAB] of  Widget
 
@@ -423,7 +423,7 @@
 	(x 0)
 	(y 120))
 
-([KB_307747_Class0] of  Map
+([KB_115311_Class0] of  Map
 )
 
 ([KB_663782_Class0] of  Map
@@ -1123,28 +1123,28 @@
 ([UpperModel_ProjectKB_Class68] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class69] of  String
-
-	(name "ChangeLog")
-	(string_value "date"))
-
 ([UpperModel_ProjectKB_Class7] of  Widget
 
 	(is_hidden TRUE)
 	(property_list [UpperModel_ProjectKB_Class8])
 	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalQueriesTab"))
 
-([UpperModel_ProjectKB_Class70] of  String
+([UpperModel_ProjectKB_Class73] of  String
+
+	(name "ChangeLog")
+	(string_value "date"))
+
+([UpperModel_ProjectKB_Class74] of  String
 
 	(name ":INSTANCE-ANNOTATION")
 	(string_value "%3AANNOTATION-TEXT"))
 
-([UpperModel_ProjectKB_Class71] of  String
+([UpperModel_ProjectKB_Class75] of  String
 
 	(name ":PAL-CONSTRAINT")
 	(string_value "%3APAL-NAME"))
 
-([UpperModel_ProjectKB_Class72] of  String
+([UpperModel_ProjectKB_Class76] of  String
 
 	(name ":META-CLASS")
 	(string_value "%3ANAME"))

--- a/model-ontology/src/ontology/Data/dd11179.pont
+++ b/model-ontology/src/ontology/Data/dd11179.pont
@@ -1,4 +1,4 @@
-; Wed Aug 28 09:56:34 EDT 2024
+; Wed Aug 28 11:19:30 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/dd11179.pprj
+++ b/model-ontology/src/ontology/Data/dd11179.pprj
@@ -1,4 +1,4 @@
-; Wed Aug 28 09:56:34 EDT 2024
+; Wed Aug 28 11:19:31 EDT 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -20,9 +20,9 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[dd11179_ProjectKB_Class118]
-		[dd11179_ProjectKB_Class119]
-		[dd11179_ProjectKB_Class120]))
+		[dd11179_ProjectKB_Class10204]
+		[dd11179_ProjectKB_Class10205]
+		[dd11179_ProjectKB_Class10206]))
 
 ([CLSES_TAB] of  Widget
 
@@ -45,29 +45,29 @@
 ([dd11179_ProjectKB_Class10] of  Property_List
 )
 
+([dd11179_ProjectKB_Class10204] of  String
+
+	(name ":INSTANCE-ANNOTATION")
+	(string_value "%3AANNOTATION-TEXT"))
+
+([dd11179_ProjectKB_Class10205] of  String
+
+	(name ":PAL-CONSTRAINT")
+	(string_value "%3APAL-NAME"))
+
+([dd11179_ProjectKB_Class10206] of  String
+
+	(name ":META-CLASS")
+	(string_value "%3ANAME"))
+
 ([dd11179_ProjectKB_Class11] of  Widget
 
 	(is_hidden TRUE)
 	(property_list [dd11179_ProjectKB_Class12])
 	(widget_class_name "edu.stanford.smi.protegex.owl.ui.cls.OWLClassesTab"))
 
-([dd11179_ProjectKB_Class118] of  String
-
-	(name ":INSTANCE-ANNOTATION")
-	(string_value "%3AANNOTATION-TEXT"))
-
-([dd11179_ProjectKB_Class119] of  String
-
-	(name ":PAL-CONSTRAINT")
-	(string_value "%3APAL-NAME"))
-
 ([dd11179_ProjectKB_Class12] of  Property_List
 )
-
-([dd11179_ProjectKB_Class120] of  String
-
-	(name ":META-CLASS")
-	(string_value "%3ANAME"))
 
 ([dd11179_ProjectKB_Class13] of  Widget
 
@@ -522,7 +522,7 @@
 	(name "instances_file_name")
 	(string_value "dd11179.pins"))
 
-([KB_699654_Class0] of  Map
+([KB_116612_Class0] of  Map
 )
 
 ([KB_860773_Class0] of  Map


### PR DESCRIPTION
Add value mrad/pixel to Units_of_Pixel_Resolution_Angular

The list of units allowed under Units_of_Pixel_Resolution_Angular needs mrad/pixel for the delivery of data products in which the desired unit is mrad/pixel.
				
Resolves https://github.com/NASA-PDS/PDS4-CCB/issues/38

## ⚙️ Test Data and/or Report
A dummy product label and LDD are included in the attached zip file for testing.
[TestingDistributionPackage_38.zip](https://github.com/user-attachments/files/16808459/TestingDistributionPackage_38.zip)
