### PR TITLE
Fix regression in schematron improvements for references 

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetValueMeanings.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/GetValueMeanings.java
@@ -757,65 +757,10 @@ class GetValueMeanings extends Object {
         "The format of the digital object must be described one or more referenced documents");
     masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
-    /*
-     * lPVD = new PermValueDefn
-     * ("pds:Product_Operational/pds:Reference_List/pds:Internal_Reference.reference_type.operational_to_resource",
-     * "operational_to_resource", "The operational product is associated to a resource");
-     * masterValueMeaningMap.put(lPVD.identifier, lPVD); lPVD = new PermValueDefn
-     * ("pds:Product_Operational/pds:Reference_List/pds:Internal_Reference.reference_type.operational_to_associate",
-     * "operational_to_associate", "The operational product is associated to a product");
-     * masterValueMeaningMap.put(lPVD.identifier, lPVD); lPVD = new PermValueDefn
-     * ("pds:Product_Operational/pds:Reference_List/pds:Internal_Reference.reference_type.operational_to_document",
-     * "operational_to_document", "The operational product is associated to a document");
-     * masterValueMeaningMap.put(lPVD.identifier, lPVD);
-     */
-
-    // lPVD = new PermValueDefn
-    // ("pds:Target_Identification/pds:Internal_Reference.reference_type.data_to_target",
-    // "data_to_target", "The data product is associated to a target");
-    // masterValueMeaningMap.put(lPVD.identifier, lPVD);
-    // lPVD = new PermValueDefn
-    // ("pds:Target_Identification/pds:Internal_Reference.reference_type.collection_to_target",
-    // "collection_to_target", "The collection is associated to a target");
-    // masterValueMeaningMap.put(lPVD.identifier, lPVD);
-    // lPVD = new PermValueDefn
-    // ("pds:Target_Identification/pds:Internal_Reference.reference_type.bundle_to_target",
-    // "bundle_to_target", "The bundle is associated to a target");
-    // masterValueMeaningMap.put(lPVD.identifier, lPVD);
-    // lPVD = new PermValueDefn
-    // ("pds:Target_Identification/pds:Internal_Reference.reference_type.document_to_target",
-    // "document_to_target", "The document is associated to a target");
-    // masterValueMeaningMap.put(lPVD.identifier, lPVD);
-
     lPVD = new PermValueDefn(
         "pds:Product_Observational/pds:Observation_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.data_to_target",
         "data_to_target", "The data product is associated to a target");
     masterValueMeaningMap.put(lPVD.identifier, lPVD);
-    // lPVD = new PermValueDefn
-    // ("pds:Product_Observational/pds:Observation_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.collection_to_target",
-    // "collection_to_target", "The collection is associated to a target");
-    // masterValueMeaningMap.put(lPVD.identifier, lPVD);
-    // lPVD = new PermValueDefn
-    // ("pds:Product_Observational/pds:Observation_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.bundle_to_target",
-    // "bundle_to_target", "The bundle is associated to a target");
-    // masterValueMeaningMap.put(lPVD.identifier, lPVD);
-    // lPVD = new PermValueDefn
-    // ("pds:Product_Observational/pds:Observation_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.document_to_target",
-    // "document_to_target", "The document is associated to a target");
-    // masterValueMeaningMap.put(lPVD.identifier, lPVD);
-
-    // lPVD = new PermValueDefn
-    // ("pds:Update_Entry/pds:Internal_Reference.reference_type.data_to_update", "data_to_update",
-    // "The data product is associated to an update product");
-    // masterValueMeaningMap.put(lPVD.identifier, lPVD);
-    // lPVD = new PermValueDefn
-    // ("pds:Update_Entry/pds:Internal_Reference.reference_type.collection_to_update",
-    // "collection_to_update", "The collection is associated to an update product");
-    // masterValueMeaningMap.put(lPVD.identifier, lPVD);
-    // lPVD = new PermValueDefn
-    // ("pds:Update_Entry/pds:Internal_Reference.reference_type.bundle_to_update",
-    // "bundle_to_update", "The bundle is associated to an update product");
-    // masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
     lPVD = new PermValueDefn(
         "pds:Product_Update/pds:Reference_List/pds:Internal_Reference.reference_type.update_to_collection",
@@ -952,42 +897,42 @@ class GetValueMeanings extends Object {
     
 
     lPVD = new PermValueDefn(
-        "pds:Product_Observational/pds:Observation_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.data_to_target",
+        "pds:Product_Observational/pds:Observation_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.data_to_target",
         "data_to_target", "The observational product is associated to a target product");
     masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
     lPVD = new PermValueDefn(
-        "pds:Product_Bundle/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.bundle_to_target",
+        "pds:Product_Bundle/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.bundle_to_target",
         "bundle_to_target", "The bundle product is associated to a target product");
     masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
     lPVD = new PermValueDefn(
-        "pds:Product_Collection/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.collection_to_target",
+        "pds:Product_Collection/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.collection_to_target",
         "collection_to_target", "The collection product is associated to a target product");
     masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
     lPVD = new PermValueDefn(
-        "pds:Product_Browse/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.browse_to_target",
+        "pds:Product_Browse/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.browse_to_target",
         "browse_to_target", "The browse product is associated to a target product");
     masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
     lPVD = new PermValueDefn(
-        "pds:Product_External/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.external_to_target",
+        "pds:Product_External/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.external_to_target",
         "external_to_target", "The external product is associated to a target product");
     masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
     lPVD = new PermValueDefn(
-        "pds:Product_Native/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.native_to_target",
+        "pds:Product_Native/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.native_to_target",
         "native_to_target", "The native product is associated to a target product");
     masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
     lPVD = new PermValueDefn(
-        "pds:Product_SPICE_Kernel/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.data_to_target",
+        "pds:Product_SPICE_Kernel/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.data_to_target",
         "data_to_target", "The SPICE kernel product is associated to a target product");
     masterValueMeaningMap.put(lPVD.identifier, lPVD);
 
     lPVD = new PermValueDefn(
-        "pds:Product_XML_Schema/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference.reference_type.schema_to_target",
+        "pds:Product_XML_Schema/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference.reference_type.schema_to_target",
         "schema_to_target", "The XML schema product is associated to a target product");
     masterValueMeaningMap.put(lPVD.identifier, lPVD);
 

--- a/model-lddtool/src/test/resources/features/validate.feature
+++ b/model-lddtool/src/test/resources/features/validate.feature
@@ -16,11 +16,11 @@ Feature: Running integration tests for validate module
     Examples: 
       | testName | testDir     | messageCount | messageText         | problemEnum        | commandArgs                                             | ingestLDDFileName         |
       # NOTE: as of 10/18/2024, this fails
-      | "NASA-PDS/pds4-information-model#795 Test Schematron 1"  | "github795" |           10 | "10 errors expected" | "SCHEMATRON_ERROR" | "--rule pds4.bundle --target {resourceDir}/github795/" | "" |
+      | "NASA-PDS/pds4-information-model#795 Test Schematron 1"  | "github795" |           9 | "9 errors expected" | "SCHEMATRON_ERROR" | "--rule pds4.bundle --target {resourceDir}/github795/" | "" |
 
-      | "NASA-PDS/pds4-information-model#795 Test Schematron 2"  | "github795b" |           1 | "1 errors expected" | "SCHEMATRON_ERROR" | "--target {resourceDir}/github795/" | "" |
+      | "NASA-PDS/pds4-information-model#795 Test Schematron 2"  | "github795b" |           1 | "1 errors expected" | "SCHEMATRON_ERROR" | "--target {resourceDir}/github795b/" | "" |
       
-      | "NASA-PDS/pds4-information-model#797 Test Schematron 1"  | "github797" |            3 | "3 errors expected" | "SCHEMATRON_ERROR" | "--target {resourceDir}/github797/test_label1_FAIL.xml {resourceDir}/github797/u5.xml" | "PDS4_GEOM_IngestLDD.xml" |
+      #| "NASA-PDS/pds4-information-model#797 Test Schematron 1"  | "github797" |            3 | "3 errors expected" | "SCHEMATRON_ERROR" | "--target {resourceDir}/github797/test_label1_FAIL.xml {resourceDir}/github797/u5.xml" | "PDS4_GEOM_IngestLDD.xml" |
       
       
 

--- a/model-lddtool/src/test/resources/github795/bundle.xml
+++ b/model-lddtool/src/test/resources/github795/bundle.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1M00.sch" 
+<?xml-model href="file:///Users/jpadams/proj/pds/pdsen/workspace/pds4-information-model/export/PDS4_PDS_1N00.sch" 
     schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Bundle
     xmlns="http://pds.nasa.gov/pds4/pds/v1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="
     http://pds.nasa.gov/pds4/pds/v1
-    https://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1M00.xsd">
+    file:///Users/jpadams/proj/pds/pdsen/workspace/pds4-information-model/export/PDS4_PDS_1N00.xsd">
     <Identification_Area>
         <logical_identifier>urn:nasa:pds:im795</logical_identifier>
         <version_id>1.0</version_id>

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Tue Sep 03 20:58:20 EDT 2024
+; Tue Nov 05 15:41:23 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -1605,7 +1605,7 @@
 		"ancillary_to_document"
 		"ancillary_to_browse"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004864] of  Schematron_Rule
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004864] of  Schematron_Rule
 
 	(alwaysInclude "false")
 	(attrNameSpaceNC "pds")
@@ -1613,14 +1613,14 @@
 	(classNameSpaceNC "pds")
 	(classSteward "pds")
 	(classTitle "Internal_Reference")
-	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004864.101])
-	(identifier "pds:Product_Browse/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004864.101])
+	(identifier "pds:Product_Browse/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference")
 	(isMissionOnly "false")
 	(roleId "TBD_roleId")
 	(type "TBD_type")
-	(xpath "pds:Product_Browse/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+	(xpath "pds:Product_Browse/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004864.101] of  Schematron_Assert
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Browse%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004864.101] of  Schematron_Assert
 
 	(assertMsg " must be set to one of the following values ")
 	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('browse_to_target')")
@@ -1885,7 +1885,7 @@
 	(specMesg "TBD")
 	(testValArr "bundle_to_investigation"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Bundle%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004862] of  Schematron_Rule
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Bundle%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004862] of  Schematron_Rule
 
 	(alwaysInclude "false")
 	(attrNameSpaceNC "pds")
@@ -1893,14 +1893,14 @@
 	(classNameSpaceNC "pds")
 	(classSteward "pds")
 	(classTitle "Internal_Reference")
-	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Bundle%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004862.101])
-	(identifier "pds:Product_Bundle/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Bundle%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004862.101])
+	(identifier "pds:Product_Bundle/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference")
 	(isMissionOnly "false")
 	(roleId "TBD_roleId")
 	(type "TBD_type")
-	(xpath "pds:Product_Bundle/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+	(xpath "pds:Product_Bundle/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Bundle%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004862.101] of  Schematron_Assert
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Bundle%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004862.101] of  Schematron_Assert
 
 	(assertMsg " must be set to one of the following values ")
 	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('bundle_to_target')")
@@ -2159,7 +2159,7 @@
 	(specMesg "TBD")
 	(testValArr "collection_to_investigation"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Collection%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004863] of  Schematron_Rule
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Collection%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004863] of  Schematron_Rule
 
 	(alwaysInclude "false")
 	(attrNameSpaceNC "pds")
@@ -2167,14 +2167,14 @@
 	(classNameSpaceNC "pds")
 	(classSteward "pds")
 	(classTitle "Internal_Reference")
-	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Collection%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004863.101])
-	(identifier "pds:Product_Collection/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Collection%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004863.101])
+	(identifier "pds:Product_Collection/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference")
 	(isMissionOnly "false")
 	(roleId "TBD_roleId")
 	(type "TBD_type")
-	(xpath "pds:Product_Collection/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+	(xpath "pds:Product_Collection/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Collection%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004863.101] of  Schematron_Assert
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Collection%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004863.101] of  Schematron_Assert
 
 	(assertMsg " must be set to one of the following values ")
 	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('collection_to_target')")
@@ -2578,7 +2578,7 @@
 		"document_to_target"
 		"document_to_data"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_External%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004865] of  Schematron_Rule
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_External%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004865] of  Schematron_Rule
 
 	(alwaysInclude "false")
 	(attrNameSpaceNC "pds")
@@ -2586,14 +2586,14 @@
 	(classNameSpaceNC "pds")
 	(classSteward "pds")
 	(classTitle "Internal_Reference")
-	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_External%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004865.101])
-	(identifier "pds:Product_External/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_External%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004865.101])
+	(identifier "pds:Product_External/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference")
 	(isMissionOnly "false")
 	(roleId "TBD_roleId")
 	(type "TBD_type")
-	(xpath "pds:Product_External/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+	(xpath "pds:Product_External/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_External%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004865.101] of  Schematron_Assert
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_External%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004865.101] of  Schematron_Assert
 
 	(assertMsg " must be set to one of the following values ")
 	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('external_to_target')")
@@ -2702,7 +2702,7 @@
 	(specMesg "TBD")
 	(testValArr "product_to_license"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Native%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004866] of  Schematron_Rule
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Native%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004866] of  Schematron_Rule
 
 	(alwaysInclude "false")
 	(attrNameSpaceNC "pds")
@@ -2710,14 +2710,14 @@
 	(classNameSpaceNC "pds")
 	(classSteward "pds")
 	(classTitle "Internal_Reference")
-	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Native%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004866.101])
-	(identifier "pds:Product_Native/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Native%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004866.101])
+	(identifier "pds:Product_Native/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference")
 	(isMissionOnly "false")
 	(roleId "TBD_roleId")
 	(type "TBD_type")
-	(xpath "pds:Product_Native/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+	(xpath "pds:Product_Native/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Native%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004866.101] of  Schematron_Assert
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Native%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004866.101] of  Schematron_Assert
 
 	(assertMsg " must be set to one of the following values ")
 	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('native_to_target')")
@@ -2975,21 +2975,6 @@
 	(specMesg "TBD")
 	(testValArr "data_to_target"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Observational%2Fpds%3AObservation_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004861] of  Schematron_Rule
-
-	(alwaysInclude "false")
-	(attrNameSpaceNC "pds")
-	(attrTitle "reference_type")
-	(classNameSpaceNC "pds")
-	(classSteward "pds")
-	(classTitle "Internal_Reference")
-	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Observational%2Fpds%3AObservation_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004861.101])
-	(identifier "pds:Product_Observational/pds:Observation_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
-	(isMissionOnly "false")
-	(roleId "TBD_roleId")
-	(type "TBD_type")
-	(xpath "pds:Product_Observational/pds:Observation_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
-
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_Observational%2Fpds%3AObservation_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004861.101] of  Schematron_Assert
 
 	(assertMsg " must be set to one of the following values ")
@@ -3117,7 +3102,7 @@
 	(identifier "x")
 	(specMesg "In Product_SPICE_Kernel the Time_Coordinates, Investigation_Area, Target_Identification, and Observing_System classes must be present"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_SPICE_Kernel%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004867] of  Schematron_Rule
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_SPICE_Kernel%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004867] of  Schematron_Rule
 
 	(alwaysInclude "false")
 	(attrNameSpaceNC "pds")
@@ -3125,14 +3110,14 @@
 	(classNameSpaceNC "pds")
 	(classSteward "pds")
 	(classTitle "Internal_Reference")
-	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_SPICE_Kernel%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004867.101])
-	(identifier "pds:Product_SPICE_Kernel/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_SPICE_Kernel%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004867.101])
+	(identifier "pds:Product_SPICE_Kernel/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference")
 	(isMissionOnly "false")
 	(roleId "TBD_roleId")
 	(type "TBD_type")
-	(xpath "pds:Product_SPICE_Kernel/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+	(xpath "pds:Product_SPICE_Kernel/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_SPICE_Kernel%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004867.101] of  Schematron_Assert
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_SPICE_Kernel%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004867.101] of  Schematron_Assert
 
 	(assertMsg " must be set to one of the following values ")
 	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('data_to_target')")
@@ -3195,7 +3180,7 @@
 	(specMesg "TBD")
 	(testValArr "update_to_collection"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_XML_Schema%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004868] of  Schematron_Rule
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_XML_Schema%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004868] of  Schematron_Rule
 
 	(alwaysInclude "false")
 	(attrNameSpaceNC "pds")
@@ -3203,14 +3188,14 @@
 	(classNameSpaceNC "pds")
 	(classSteward "pds")
 	(classTitle "Internal_Reference")
-	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_XML_Schema%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004868.101])
-	(identifier "pds:Product_XML_Schema/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference")
+	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_XML_Schema%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004868.101])
+	(identifier "pds:Product_XML_Schema/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference")
 	(isMissionOnly "false")
 	(roleId "TBD_roleId")
 	(type "TBD_type")
-	(xpath "pds:Product_XML_Schema/pds:Context_Area/pds:Target_Identification/pds:Reference_List/pds:Internal_Reference"))
+	(xpath "pds:Product_XML_Schema/pds:Context_Area/pds:Target_Identification/pds:Internal_Reference"))
 
-([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_XML_Schema%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AReference_List%2Fpds%3AInternal_Reference.100004868.101] of  Schematron_Assert
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3AProduct_XML_Schema%2Fpds%3AContext_Area%2Fpds%3ATarget_Identification%2Fpds%3AInternal_Reference.100004868.101] of  Schematron_Assert
 
 	(assertMsg " must be set to one of the following values ")
 	(assertStmt "every $ref in (pds:reference_type) satisfies $ref = ('schema_to_target')")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Tue Sep 03 20:58:20 EDT 2024
+; Tue Nov 05 15:41:23 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Tue Sep 03 20:58:20 EDT 2024
+; Tue Nov 05 15:41:23 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -6,10 +6,10 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[UpperModel_ProjectKB_Class81]
-		[UpperModel_ProjectKB_Class82]
-		[UpperModel_ProjectKB_Class83]
-		[UpperModel_ProjectKB_Class84]))
+		[UpperModel_ProjectKB_Class131]
+		[UpperModel_ProjectKB_Class132]
+		[UpperModel_ProjectKB_Class133]
+		[UpperModel_ProjectKB_Class134]))
 
 ([CLSES_TAB] of  Widget
 
@@ -423,10 +423,10 @@
 	(x 0)
 	(y 120))
 
-([KB_250697_Class0] of  Map
+([KB_663782_Class0] of  Map
 )
 
-([KB_663782_Class0] of  Map
+([KB_715051_Class0] of  Map
 )
 
 ([KB_887149_Instance_43] of  String
@@ -856,6 +856,26 @@
 	(property_list [UpperModel_ProjectKB_Class14])
 	(widget_class_name "edu.stanford.smi.protegex.server_changes.prompt.UsersTab"))
 
+([UpperModel_ProjectKB_Class131] of  String
+
+	(name "ChangeLog")
+	(string_value "date"))
+
+([UpperModel_ProjectKB_Class132] of  String
+
+	(name ":INSTANCE-ANNOTATION")
+	(string_value "%3AANNOTATION-TEXT"))
+
+([UpperModel_ProjectKB_Class133] of  String
+
+	(name ":PAL-CONSTRAINT")
+	(string_value "%3APAL-NAME"))
+
+([UpperModel_ProjectKB_Class134] of  String
+
+	(name ":META-CLASS")
+	(string_value "%3ANAME"))
+
 ([UpperModel_ProjectKB_Class14] of  Property_List
 )
 
@@ -1131,26 +1151,6 @@
 
 ([UpperModel_ProjectKB_Class8] of  Property_List
 )
-
-([UpperModel_ProjectKB_Class81] of  String
-
-	(name "ChangeLog")
-	(string_value "date"))
-
-([UpperModel_ProjectKB_Class82] of  String
-
-	(name ":INSTANCE-ANNOTATION")
-	(string_value "%3AANNOTATION-TEXT"))
-
-([UpperModel_ProjectKB_Class83] of  String
-
-	(name ":PAL-CONSTRAINT")
-	(string_value "%3APAL-NAME"))
-
-([UpperModel_ProjectKB_Class84] of  String
-
-	(name ":META-CLASS")
-	(string_value "%3ANAME"))
 
 ([UpperModel_ProjectKB_Class9] of  Widget
 

--- a/model-ontology/src/ontology/Data/dd11179.pont
+++ b/model-ontology/src/ontology/Data/dd11179.pont
@@ -1,4 +1,4 @@
-; Mon Sep 30 13:10:22 EDT 2024
+; Tue Nov 05 15:26:20 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/dd11179.pprj
+++ b/model-ontology/src/ontology/Data/dd11179.pprj
@@ -1,4 +1,4 @@
-; Mon Sep 30 13:10:23 EDT 2024
+; Tue Nov 05 15:26:21 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -20,9 +20,9 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[dd11179_ProjectKB_Class226]
-		[dd11179_ProjectKB_Class227]
-		[dd11179_ProjectKB_Class228]))
+		[dd11179_ProjectKB_Class78]
+		[dd11179_ProjectKB_Class79]
+		[dd11179_ProjectKB_Class80]))
 
 ([CLSES_TAB] of  Widget
 
@@ -101,21 +101,6 @@
 
 ([dd11179_ProjectKB_Class22] of  Property_List
 )
-
-([dd11179_ProjectKB_Class226] of  String
-
-	(name ":INSTANCE-ANNOTATION")
-	(string_value "%3AANNOTATION-TEXT"))
-
-([dd11179_ProjectKB_Class227] of  String
-
-	(name ":PAL-CONSTRAINT")
-	(string_value "%3APAL-NAME"))
-
-([dd11179_ProjectKB_Class228] of  String
-
-	(name ":META-CLASS")
-	(string_value "%3ANAME"))
 
 ([dd11179_ProjectKB_Class23] of  Widget
 
@@ -375,8 +360,23 @@
 ([dd11179_ProjectKB_Class74] of  Property_List
 )
 
+([dd11179_ProjectKB_Class78] of  String
+
+	(name ":INSTANCE-ANNOTATION")
+	(string_value "%3AANNOTATION-TEXT"))
+
+([dd11179_ProjectKB_Class79] of  String
+
+	(name ":PAL-CONSTRAINT")
+	(string_value "%3APAL-NAME"))
+
 ([dd11179_ProjectKB_Class8] of  Property_List
 )
+
+([dd11179_ProjectKB_Class80] of  String
+
+	(name ":META-CLASS")
+	(string_value "%3ANAME"))
 
 ([dd11179_ProjectKB_Class9] of  Widget
 
@@ -522,7 +522,7 @@
 	(name "instances_file_name")
 	(string_value "dd11179.pins"))
 
-([KB_479305_Class0] of  Map
+([KB_387226_Class0] of  Map
 )
 
 ([KB_860773_Class0] of  Map


### PR DESCRIPTION
## 🗒️ Summary
Found and fixed errors in xpath for eight rules.
  "Target_Identification/pds:Reference_List/pds:Internal_Reference -> pds:Target_Identification/pds:Internal_Reference

#819  Regression in schematron improvements for references
Fixed problem with schematron rules

#795  CCB-7: Missing schematron rule - bundle_to_targets 

NASA-PDS/PDS4-CCB#7 Missing schematron rule to check that Product_Bundle.Target_Identification.Internal_Reference.reference_type is bundle_to_target

## ⚙️ Test Data and/or Report
The build test was not successful. However each label in the test suite was loaded into Oxygen. For each <!--RChen should fail-->" an error was thrown as expected.

## ♻️ Related Issues
Resolves #819
Resolves #795
Refs NASA-PDS/PDS4-CCB#7

