### PR TITLE
CCB-47: Add permissible value to units of spectral radiance

### DIFF
--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Fri Nov 08 17:54:28 EST 2024
+; Wed Nov 13 14:47:11 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Fri Nov 08 17:54:28 EST 2024
+; Wed Nov 13 14:47:11 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -12079,7 +12079,7 @@
 	(single-slot unit_id
 ;+		(comment "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
 		(type STRING)
-;+		(value "W*m**-2*sr**-1*Hz**-1" "W*m**-2*sr**-1*nm**-1" "W*m**-2*sr**-1*um**-1" "W*m**-3*sr**-1" "uW*cm**-2*sr**-1*um**-1" "W/m**2/sr/Hz" "W/m**2/sr/nm" "W/m**2/sr/μm" "W/m**3/sr" "μW/cm**2/sr/μm")
+;+		(value "W*m**-2*sr**-1*Hz**-1" "W*m**-2*sr**-1*nm**-1" "W*m**-2*sr**-1*um**-1" "W*m**-3*sr**-1" "uW*cm**-2*sr**-1*um**-1" "W/m**2/sr/Hz" "W/m**2/sr/nm" "W/m**2/sr/μm" "W/m**3/sr" "μW/cm**2/sr/μm" "W/cm**2/sr/μm")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Fri Nov 08 17:54:28 EST 2024
+; Wed Nov 13 14:47:11 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -6,10 +6,10 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[UpperModel_ProjectKB_Class127]
-		[UpperModel_ProjectKB_Class128]
-		[UpperModel_ProjectKB_Class129]
-		[UpperModel_ProjectKB_Class130]))
+		[UpperModel_ProjectKB_Class73]
+		[UpperModel_ProjectKB_Class74]
+		[UpperModel_ProjectKB_Class75]
+		[UpperModel_ProjectKB_Class76]))
 
 ([CLSES_TAB] of  Widget
 
@@ -423,7 +423,7 @@
 	(x 0)
 	(y 120))
 
-([KB_656901_Class0] of  Map
+([KB_206517_Class0] of  Map
 )
 
 ([KB_663782_Class0] of  Map
@@ -850,31 +850,11 @@
 ([UpperModel_ProjectKB_Class12] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class127] of  String
-
-	(name "ChangeLog")
-	(string_value "date"))
-
-([UpperModel_ProjectKB_Class128] of  String
-
-	(name ":INSTANCE-ANNOTATION")
-	(string_value "%3AANNOTATION-TEXT"))
-
-([UpperModel_ProjectKB_Class129] of  String
-
-	(name ":PAL-CONSTRAINT")
-	(string_value "%3APAL-NAME"))
-
 ([UpperModel_ProjectKB_Class13] of  Widget
 
 	(is_hidden TRUE)
 	(property_list [UpperModel_ProjectKB_Class14])
 	(widget_class_name "edu.stanford.smi.protegex.server_changes.prompt.UsersTab"))
-
-([UpperModel_ProjectKB_Class130] of  String
-
-	(name ":META-CLASS")
-	(string_value "%3ANAME"))
 
 ([UpperModel_ProjectKB_Class14] of  Property_List
 )
@@ -1148,6 +1128,26 @@
 	(is_hidden TRUE)
 	(property_list [UpperModel_ProjectKB_Class8])
 	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalQueriesTab"))
+
+([UpperModel_ProjectKB_Class73] of  String
+
+	(name "ChangeLog")
+	(string_value "date"))
+
+([UpperModel_ProjectKB_Class74] of  String
+
+	(name ":INSTANCE-ANNOTATION")
+	(string_value "%3AANNOTATION-TEXT"))
+
+([UpperModel_ProjectKB_Class75] of  String
+
+	(name ":PAL-CONSTRAINT")
+	(string_value "%3APAL-NAME"))
+
+([UpperModel_ProjectKB_Class76] of  String
+
+	(name ":META-CLASS")
+	(string_value "%3ANAME"))
 
 ([UpperModel_ProjectKB_Class8] of  Property_List
 )

--- a/model-ontology/src/ontology/Data/dd11179.pont
+++ b/model-ontology/src/ontology/Data/dd11179.pont
@@ -1,4 +1,4 @@
-; Fri Nov 08 18:27:06 EST 2024
+; Wed Nov 13 15:28:44 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/dd11179.pprj
+++ b/model-ontology/src/ontology/Data/dd11179.pprj
@@ -1,4 +1,4 @@
-; Fri Nov 08 18:27:07 EST 2024
+; Wed Nov 13 15:28:44 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -20,9 +20,9 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[dd11179_ProjectKB_Class210]
-		[dd11179_ProjectKB_Class211]
-		[dd11179_ProjectKB_Class212]))
+		[dd11179_ProjectKB_Class204]
+		[dd11179_ProjectKB_Class205]
+		[dd11179_ProjectKB_Class206]))
 
 ([CLSES_TAB] of  Widget
 
@@ -93,26 +93,26 @@
 ([dd11179_ProjectKB_Class20] of  Property_List
 )
 
+([dd11179_ProjectKB_Class204] of  String
+
+	(name ":INSTANCE-ANNOTATION")
+	(string_value "%3AANNOTATION-TEXT"))
+
+([dd11179_ProjectKB_Class205] of  String
+
+	(name ":PAL-CONSTRAINT")
+	(string_value "%3APAL-NAME"))
+
+([dd11179_ProjectKB_Class206] of  String
+
+	(name ":META-CLASS")
+	(string_value "%3ANAME"))
+
 ([dd11179_ProjectKB_Class21] of  Widget
 
 	(is_hidden TRUE)
 	(property_list [dd11179_ProjectKB_Class22])
 	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.KnowledgeTreeTab"))
-
-([dd11179_ProjectKB_Class210] of  String
-
-	(name ":INSTANCE-ANNOTATION")
-	(string_value "%3AANNOTATION-TEXT"))
-
-([dd11179_ProjectKB_Class211] of  String
-
-	(name ":PAL-CONSTRAINT")
-	(string_value "%3APAL-NAME"))
-
-([dd11179_ProjectKB_Class212] of  String
-
-	(name ":META-CLASS")
-	(string_value "%3ANAME"))
 
 ([dd11179_ProjectKB_Class22] of  Property_List
 )
@@ -522,7 +522,7 @@
 	(name "instances_file_name")
 	(string_value "dd11179.pins"))
 
-([KB_483221_Class0] of  Map
+([KB_849941_Class0] of  Map
 )
 
 ([KB_860773_Class0] of  Map


### PR DESCRIPTION
## 🗒️ Summary
Added the following value with its definition to the enumerated list:
  W/cm**2/sr/μm
  W/cm**2/sr/μm is an abbreviation for watts per square centimeter per steradian per micrometer, which is a unit of spectral radiance (power per unit area per unit solid angle per unit wavelength).


## ⚙️ Test Data and/or Report
Enclosure contains updates to the IM and a sample (HST) LDD to test the above Requested Changes:
-- updates to IM XSD
-- updates to HST XSD and SCH
-- both VALID and FAIL test cases.

[CCB-47_Units_of_Spectral_Radiance.zip](https://github.com/user-attachments/files/17248440/CCB-47_Units_of_Spectral_Radiance.zip)

## ♻️ Related Issues
Resolves Resolves https://github.com/NASA-PDS/pds4-information-model/issues/830
Refs https://github.com/NASA-PDS/PDS4-CCB/issues/47
