### PR TITLE
CCB-27: DOI requires at least an author or editor

### DIFF
--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Wed Nov 13 17:41:42 EST 2024
+; Thu Nov 14 08:20:46 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -308,6 +308,7 @@
 	(assertMsg "The presence of \"pds:doi\" requires at least one of either \"List_Author\" or \"List_Editor\" classes.")
 	(assertStmt "if (pds:doi) then (pds:author_list or pds:editor_list or pds:List_Author or pds:List_Editor) else true()")
 	(assertType "RAW")
+	(attrTitle "author_list")
 	(identifier "Citation_Information")
 	(specMesg "The presence of \"pds:doi\" requires at least one of either \"List_Author\" or \"List_Editor\" classes."))
 
@@ -316,6 +317,7 @@
 	(assertMsg "The pds:List_Author and pds:List_Editor classes should not be used in conjunction with the deprecated pds:author_list and pds:editor_list attributes.")
 	(assertStmt "\"if ((pds:author_list or pds:editor_list) and (pds:List_Author or pds:List_Editor)) then false() else true()")
 	(assertType "RAW")
+	(attrTitle "author_list")
 	(identifier "Citation_Information")
 	(specMesg "The pds:List_Author and pds:List_Editor classes should not be used in conjunction with the deprecated pds:author_list and pds:editor_list attributes."))
 

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Fri Nov 08 17:54:28 EST 2024
+; Wed Nov 13 14:47:11 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pins
+++ b/model-ontology/src/ontology/Data/UpperModel.pins
@@ -1,4 +1,4 @@
-; Wed Nov 13 14:47:11 EST 2024
+; Wed Nov 13 17:41:42 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -286,6 +286,39 @@
 	(identifier "sequence_number")
 	(specMesg "The sequence number of the second axis of an Array_2D_Image must be set to 2."))
 
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3ACitation_Information.100004635] of  Schematron_Rule
+
+	(alwaysInclude "false")
+	(attrNameSpaceNC "pds")
+	(attrTitle "description")
+	(classNameSpaceNC "pds")
+	(classSteward "pds")
+	(classTitle "Citation_Information")
+	(has_Schematron_Assert
+		[http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3ACitation_Information.100004635.101]
+		[http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3ACitation_Information.100004635.102])
+	(identifier "pds:Citation_Information")
+	(isMissionOnly "false")
+	(roleId "TBD_roleId")
+	(type "TBD_type")
+	(xpath "pds:Citation_Information"))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3ACitation_Information.100004635.101] of  Schematron_Assert
+
+	(assertMsg "The presence of \"pds:doi\" requires at least one of either \"List_Author\" or \"List_Editor\" classes.")
+	(assertStmt "if (pds:doi) then (pds:author_list or pds:editor_list or pds:List_Author or pds:List_Editor) else true()")
+	(assertType "RAW")
+	(identifier "Citation_Information")
+	(specMesg "The presence of \"pds:doi\" requires at least one of either \"List_Author\" or \"List_Editor\" classes."))
+
+([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3ACitation_Information.100004635.102] of  Schematron_Assert
+
+	(assertMsg "The pds:List_Author and pds:List_Editor classes should not be used in conjunction with the deprecated pds:author_list and pds:editor_list attributes.")
+	(assertStmt "\"if ((pds:author_list or pds:editor_list) and (pds:List_Author or pds:List_Editor)) then false() else true()")
+	(assertType "RAW")
+	(identifier "Citation_Information")
+	(specMesg "The pds:List_Author and pds:List_Editor classes should not be used in conjunction with the deprecated pds:author_list and pds:editor_list attributes."))
+
 ([http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3ACitation_Information%2Fpds%3Adescription.100002517] of  Schematron_Rule
 
 	(alwaysInclude "false")
@@ -318,7 +351,6 @@
 	(classNameSpaceNC "pds")
 	(classSteward "pds")
 	(classTitle "Internal_Reference")
-	(has_Schematron_Assert [http%3A%2F%2Fpds.nasa.gov%2Finfomodel%2Fpds%23.pds%3ADD_Attribute%2Fpds%3AInternal_Reference.100004572.101])
 	(identifier "pds:DD_Attribute/pds:Internal_Reference")
 	(isMissionOnly "false")
 	(roleId "TBD_roleId")
@@ -4095,9 +4127,6 @@
 )
 
 ([upper_110812b_Class0] of  %3APAL-CONSTRAINT
-)
-
-([UpperModel_bundle_to_target_Class16] of  Schematron_Assert
 )
 
 ([Waves] of  Group_Facet2

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Fri Nov 08 17:54:28 EST 2024
+; Wed Nov 13 14:47:11 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -12079,7 +12079,7 @@
 	(single-slot unit_id
 ;+		(comment "The unit_id attribute provides a character or character string which serves as an abbreviation for, or symbol representing, a unit of measure.")
 		(type STRING)
-;+		(value "W*m**-2*sr**-1*Hz**-1" "W*m**-2*sr**-1*nm**-1" "W*m**-2*sr**-1*um**-1" "W*m**-3*sr**-1" "uW*cm**-2*sr**-1*um**-1" "W/m**2/sr/Hz" "W/m**2/sr/nm" "W/m**2/sr/μm" "W/m**3/sr" "μW/cm**2/sr/μm")
+;+		(value "W*m**-2*sr**-1*Hz**-1" "W*m**-2*sr**-1*nm**-1" "W*m**-2*sr**-1*um**-1" "W*m**-3*sr**-1" "uW*cm**-2*sr**-1*um**-1" "W/m**2/sr/Hz" "W/m**2/sr/nm" "W/m**2/sr/μm" "W/m**3/sr" "μW/cm**2/sr/μm" "W/cm**2/sr/μm")
 ;+		(cardinality 1 1)
 		(create-accessor read-write)))
 

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Wed Nov 13 14:47:11 EST 2024
+; Wed Nov 13 17:41:42 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pont
+++ b/model-ontology/src/ontology/Data/UpperModel.pont
@@ -1,4 +1,4 @@
-; Wed Nov 13 17:41:42 EST 2024
+; Thu Nov 14 08:20:46 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Wed Nov 13 17:41:42 EST 2024
+; Thu Nov 14 08:20:46 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -6,10 +6,10 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[UpperModel_ProjectKB_Class10147]
-		[UpperModel_ProjectKB_Class10148]
-		[UpperModel_ProjectKB_Class10149]
-		[UpperModel_ProjectKB_Class10150]))
+		[UpperModel_ProjectKB_Class10151]
+		[UpperModel_ProjectKB_Class10152]
+		[UpperModel_ProjectKB_Class10153]
+		[UpperModel_ProjectKB_Class10154]))
 
 ([CLSES_TAB] of  Widget
 
@@ -841,22 +841,22 @@
 ([UpperModel_ProjectKB_Class10] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class10147] of  String
+([UpperModel_ProjectKB_Class10151] of  String
 
 	(name "ChangeLog")
 	(string_value "date"))
 
-([UpperModel_ProjectKB_Class10148] of  String
+([UpperModel_ProjectKB_Class10152] of  String
 
 	(name ":INSTANCE-ANNOTATION")
 	(string_value "%3AANNOTATION-TEXT"))
 
-([UpperModel_ProjectKB_Class10149] of  String
+([UpperModel_ProjectKB_Class10153] of  String
 
 	(name ":PAL-CONSTRAINT")
 	(string_value "%3APAL-NAME"))
 
-([UpperModel_ProjectKB_Class10150] of  String
+([UpperModel_ProjectKB_Class10154] of  String
 
 	(name ":META-CLASS")
 	(string_value "%3ANAME"))

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Wed Nov 13 14:47:11 EST 2024
+; Wed Nov 13 17:41:42 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -6,10 +6,10 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[UpperModel_ProjectKB_Class73]
-		[UpperModel_ProjectKB_Class74]
-		[UpperModel_ProjectKB_Class75]
-		[UpperModel_ProjectKB_Class76]))
+		[UpperModel_ProjectKB_Class10147]
+		[UpperModel_ProjectKB_Class10148]
+		[UpperModel_ProjectKB_Class10149]
+		[UpperModel_ProjectKB_Class10150]))
 
 ([CLSES_TAB] of  Widget
 
@@ -423,7 +423,7 @@
 	(x 0)
 	(y 120))
 
-([KB_206517_Class0] of  Map
+([KB_267879_Class0] of  Map
 )
 
 ([KB_663782_Class0] of  Map
@@ -841,6 +841,26 @@
 ([UpperModel_ProjectKB_Class10] of  Property_List
 )
 
+([UpperModel_ProjectKB_Class10147] of  String
+
+	(name "ChangeLog")
+	(string_value "date"))
+
+([UpperModel_ProjectKB_Class10148] of  String
+
+	(name ":INSTANCE-ANNOTATION")
+	(string_value "%3AANNOTATION-TEXT"))
+
+([UpperModel_ProjectKB_Class10149] of  String
+
+	(name ":PAL-CONSTRAINT")
+	(string_value "%3APAL-NAME"))
+
+([UpperModel_ProjectKB_Class10150] of  String
+
+	(name ":META-CLASS")
+	(string_value "%3ANAME"))
+
 ([UpperModel_ProjectKB_Class11] of  Widget
 
 	(is_hidden TRUE)
@@ -1128,26 +1148,6 @@
 	(is_hidden TRUE)
 	(property_list [UpperModel_ProjectKB_Class8])
 	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalQueriesTab"))
-
-([UpperModel_ProjectKB_Class73] of  String
-
-	(name "ChangeLog")
-	(string_value "date"))
-
-([UpperModel_ProjectKB_Class74] of  String
-
-	(name ":INSTANCE-ANNOTATION")
-	(string_value "%3AANNOTATION-TEXT"))
-
-([UpperModel_ProjectKB_Class75] of  String
-
-	(name ":PAL-CONSTRAINT")
-	(string_value "%3APAL-NAME"))
-
-([UpperModel_ProjectKB_Class76] of  String
-
-	(name ":META-CLASS")
-	(string_value "%3ANAME"))
 
 ([UpperModel_ProjectKB_Class8] of  Property_List
 )

--- a/model-ontology/src/ontology/Data/UpperModel.pprj
+++ b/model-ontology/src/ontology/Data/UpperModel.pprj
@@ -1,4 +1,4 @@
-; Fri Nov 08 17:54:28 EST 2024
+; Wed Nov 13 14:47:11 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -6,10 +6,10 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[UpperModel_ProjectKB_Class127]
-		[UpperModel_ProjectKB_Class128]
-		[UpperModel_ProjectKB_Class129]
-		[UpperModel_ProjectKB_Class130]))
+		[UpperModel_ProjectKB_Class73]
+		[UpperModel_ProjectKB_Class74]
+		[UpperModel_ProjectKB_Class75]
+		[UpperModel_ProjectKB_Class76]))
 
 ([CLSES_TAB] of  Widget
 
@@ -423,7 +423,7 @@
 	(x 0)
 	(y 120))
 
-([KB_656901_Class0] of  Map
+([KB_206517_Class0] of  Map
 )
 
 ([KB_663782_Class0] of  Map
@@ -850,31 +850,11 @@
 ([UpperModel_ProjectKB_Class12] of  Property_List
 )
 
-([UpperModel_ProjectKB_Class127] of  String
-
-	(name "ChangeLog")
-	(string_value "date"))
-
-([UpperModel_ProjectKB_Class128] of  String
-
-	(name ":INSTANCE-ANNOTATION")
-	(string_value "%3AANNOTATION-TEXT"))
-
-([UpperModel_ProjectKB_Class129] of  String
-
-	(name ":PAL-CONSTRAINT")
-	(string_value "%3APAL-NAME"))
-
 ([UpperModel_ProjectKB_Class13] of  Widget
 
 	(is_hidden TRUE)
 	(property_list [UpperModel_ProjectKB_Class14])
 	(widget_class_name "edu.stanford.smi.protegex.server_changes.prompt.UsersTab"))
-
-([UpperModel_ProjectKB_Class130] of  String
-
-	(name ":META-CLASS")
-	(string_value "%3ANAME"))
 
 ([UpperModel_ProjectKB_Class14] of  Property_List
 )
@@ -1148,6 +1128,26 @@
 	(is_hidden TRUE)
 	(property_list [UpperModel_ProjectKB_Class8])
 	(widget_class_name "edu.stanford.smi.protegex.widget.pal.PalQueriesTab"))
+
+([UpperModel_ProjectKB_Class73] of  String
+
+	(name "ChangeLog")
+	(string_value "date"))
+
+([UpperModel_ProjectKB_Class74] of  String
+
+	(name ":INSTANCE-ANNOTATION")
+	(string_value "%3AANNOTATION-TEXT"))
+
+([UpperModel_ProjectKB_Class75] of  String
+
+	(name ":PAL-CONSTRAINT")
+	(string_value "%3APAL-NAME"))
+
+([UpperModel_ProjectKB_Class76] of  String
+
+	(name ":META-CLASS")
+	(string_value "%3ANAME"))
 
 ([UpperModel_ProjectKB_Class8] of  Property_List
 )

--- a/model-ontology/src/ontology/Data/dd11179.pont
+++ b/model-ontology/src/ontology/Data/dd11179.pont
@@ -1,4 +1,4 @@
-; Fri Nov 08 18:27:06 EST 2024
+; Wed Nov 13 15:28:44 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")

--- a/model-ontology/src/ontology/Data/dd11179.pprj
+++ b/model-ontology/src/ontology/Data/dd11179.pprj
@@ -1,4 +1,4 @@
-; Fri Nov 08 18:27:07 EST 2024
+; Wed Nov 13 15:28:44 EST 2024
 ; 
 ;+ (version "3.5")
 ;+ (build "Build 663")
@@ -20,9 +20,9 @@
 ([BROWSER_SLOT_NAMES] of  Property_List
 
 	(properties
-		[dd11179_ProjectKB_Class210]
-		[dd11179_ProjectKB_Class211]
-		[dd11179_ProjectKB_Class212]))
+		[dd11179_ProjectKB_Class204]
+		[dd11179_ProjectKB_Class205]
+		[dd11179_ProjectKB_Class206]))
 
 ([CLSES_TAB] of  Widget
 
@@ -93,26 +93,26 @@
 ([dd11179_ProjectKB_Class20] of  Property_List
 )
 
+([dd11179_ProjectKB_Class204] of  String
+
+	(name ":INSTANCE-ANNOTATION")
+	(string_value "%3AANNOTATION-TEXT"))
+
+([dd11179_ProjectKB_Class205] of  String
+
+	(name ":PAL-CONSTRAINT")
+	(string_value "%3APAL-NAME"))
+
+([dd11179_ProjectKB_Class206] of  String
+
+	(name ":META-CLASS")
+	(string_value "%3ANAME"))
+
 ([dd11179_ProjectKB_Class21] of  Widget
 
 	(is_hidden TRUE)
 	(property_list [dd11179_ProjectKB_Class22])
 	(widget_class_name "edu.stanford.smi.protege.widget.instance_tree.KnowledgeTreeTab"))
-
-([dd11179_ProjectKB_Class210] of  String
-
-	(name ":INSTANCE-ANNOTATION")
-	(string_value "%3AANNOTATION-TEXT"))
-
-([dd11179_ProjectKB_Class211] of  String
-
-	(name ":PAL-CONSTRAINT")
-	(string_value "%3APAL-NAME"))
-
-([dd11179_ProjectKB_Class212] of  String
-
-	(name ":META-CLASS")
-	(string_value "%3ANAME"))
 
 ([dd11179_ProjectKB_Class22] of  Property_List
 )
@@ -522,7 +522,7 @@
 	(name "instances_file_name")
 	(string_value "dd11179.pins"))
 
-([KB_483221_Class0] of  Map
+([KB_849941_Class0] of  Map
 )
 
 ([KB_860773_Class0] of  Map


### PR DESCRIPTION
#823 CCB-27: DOI requires at least an author or editor

## 🗒️ Summary
Added new schematron rule to validate:
 The presence of "pds:doi" requires at least one of either "List_Author" or "List_Editor" classes.
 pds:List_Author and pds:List_Editor classes should not be used in conjunction with the deprecated pds:author_list and pds:editor_list attributes.

## ⚙️ Test Data and/or Report
The enclosure contains both VALID and FAIL test cases:
[aaaTest_cases_final_20240912.zip](https://github.com/user-attachments/files/16982862/aaaTest_cases_final_20240912.zip)

## ♻️ Related Issues
Resolves https://github.com/NASA-PDS/pds4-information-model/issues/823
Refs https://github.com/NASA-PDS/PDS4-CCB/issues/27


