### PR TITLE
Support roundup-action#142 by ensuring we're using the latest gov.nasa.pds parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@ POSSIBILITY OF SUCH DAMAGE.
   <parent>
     <groupId>gov.nasa</groupId>
     <artifactId>pds</artifactId>
-    <version>1.17.0</version>
+    <version>1.18.0</version>
   </parent>
   
    <properties>


### PR DESCRIPTION
## 🗒️ Summary

This is just to ensure we're using the most recently blessed version of the `gov.nasa.pds` parent project object model (POM).

Note that the new `OSSRH_USERNAME` and `OSSRH_PASSWORD` really ought to be set in the organization—which as of 2024-11-17, they are.


## ⚙️ Test Data and/or Report

See the equivalent sandbox run at: https://github.com/nasa-pds-engineering-node/pds4-information-model/actions/runs/11881545051

## ♻️ Related Issues

- https://github.com/NASA-PDS/roundup-action/issues/142