### PR TITLE
Fix bug where `lddtool -v` creates/overwrites output directory and files

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -477,7 +477,7 @@ public class DMDocument extends Object {
 //	    	}
 //	    }
 
-	    // process second set of arguments; exit is return=false
+	    // process second set of arguments; exit if return=false
 	    if (! processArgumentParserNamespacePhase2(argparse4jNamespace))
 	    	return;
 
@@ -1238,6 +1238,7 @@ public class DMDocument extends Object {
     return namespace;
   }
 
+  // process -p, -l, and -V to determine IM Version to use
   static void processArgumentParserNamespacePhase1(Namespace ns) {
 
     // handle processing flags
@@ -1267,6 +1268,7 @@ public class DMDocument extends Object {
     return;
   }
 
+  // process remaining arguments, for -v (version) return false to exit application 
   static boolean processArgumentParserNamespacePhase2(Namespace ns) {
 
     // handle the request for version

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -477,8 +477,9 @@ public class DMDocument extends Object {
 //	    	}
 //	    }
 
-	    // process second set of arguments
-	    processArgumentParserNamespacePhase2(argparse4jNamespace);
+	    // process second set of arguments; exit is return=false
+	    if (! processArgumentParserNamespacePhase2(argparse4jNamespace))
+	    	return;
 
 	    // check the files
 	    checkRequiredFiles();
@@ -1266,7 +1267,7 @@ public class DMDocument extends Object {
     return;
   }
 
-  static void processArgumentParserNamespacePhase2(Namespace ns) {
+  static boolean processArgumentParserNamespacePhase2(Namespace ns) {
 
     // handle the request for version
     Boolean vFlag = ns.getBoolean("v");
@@ -1278,7 +1279,7 @@ public class DMDocument extends Object {
       System.out.println("Build Date: " + buildDate);
       System.out.println("Configured IM Versions: " + alternateIMVersionArr);
       System.out.println(" ");
-      return;
+      return false;
     }
 
     // validate the input arguments
@@ -1364,6 +1365,7 @@ public class DMDocument extends Object {
       LDDSchemaFileSortArr.add(lLDDSchemaFileDefn);
       masterLDDSchemaFileDefn = lLDDSchemaFileDefn; // the last Ingest_LDD named is the master.
     }
+    return true;
   }
 
   static void printErrorMessages() {


### PR DESCRIPTION
lddtool -v creates/overwrites output directory and files

## 🗒️ Summary
The -v option should only return the following four lines. The extraneous information is no longer being printed.

LDDTool Version: 
Built with IM Version: 
Build Date: 
Configured IM Versions:

## ⚙️ Test Data and/or Report
lddtool -v
-- output--
LDDTool Version: ${project.version}
Built with IM Version: 1.23.0.0
Build Date: ${buildNumber}
Configured IM Versions: [1N00, 1M00, 1L00, 1K00, 1J00, 1I00, 1H00, 1G00, 1F00, 1E00, 1D00, 1C00, 1B10, 1B00]
 

>>  INFO Exit(0)


## ♻️ Related Issues
Resolves #848

