### PR TITLE
`--V` flag option does not work when attempting to generate core IM

### DIFF
--- a/.github/workflows/secrets-detection.yaml
+++ b/.github/workflows/secrets-detection.yaml
@@ -45,7 +45,11 @@ jobs:
                     cp .secrets.baseline .secrets.new
 
                     # find the secrets in the repository
-                    bin/generate-detect-secrets.sh
+                    detect-secrets scan --disable-plugin AbsolutePathDetectorExperimental --baseline .secrets.new \
+                        --exclude-files '\.secrets..*' \
+                        --exclude-files '\.pre-commit-config\.yaml' \
+                        --exclude-files '\.git.*' \
+                        --exclude-files 'target'
                        
                     # if there is any difference between the known and newly detected secrets, break the build
                     # Function to compare secrets without listing them

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -125,18 +125,206 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "\\.secrets..*",
         "\\.git.*",
         "\\.pre-commit-config\\.yaml",
-        "target",
-        "docs/release/.*",
-        "model-ontology/src/ontology/Data/.*",
-        "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/.*",
-        "docs/namespace-registry/.*"
+        "\\.secrets..*",
+        "target"
       ]
     }
   ],
   "results": {
+    "docs/namespace-registry/pds-namespace-registry.csv": [
+      {
+        "type": "Email Address",
+        "filename": "docs/namespace-registry/pds-namespace-registry.csv",
+        "hashed_secret": "584c52cb2d7a3569c555109e76e7f28d732b41f5",
+        "is_verified": false,
+        "line_number": 20,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "docs/namespace-registry/pds-namespace-registry.csv",
+        "hashed_secret": "63bf7fcd75e3265429051c374aa23759a078f711",
+        "is_verified": false,
+        "line_number": 73,
+        "is_secret": false
+      }
+    ],
+    "docs/release/1K00/index_1K00.html": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/release/1K00/index_1K00.html",
+        "hashed_secret": "7454295ee524229373dfb3a7ec0d997a2d4ceee6",
+        "is_verified": false,
+        "line_number": 14811,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/release/1K00/index_1K00.html",
+        "hashed_secret": "bf3fea2cc8d317bc8abed3f65466183d83d70e11",
+        "is_verified": false,
+        "line_number": 16586,
+        "is_secret": false
+      }
+    ],
+    "docs/release/1K00/webhelp/common/license-3rd-party.txt": [
+      {
+        "type": "Email Address",
+        "filename": "docs/release/1K00/webhelp/common/license-3rd-party.txt",
+        "hashed_secret": "3f10470df93616dd046e20c74c4f57780a8c3291",
+        "is_verified": false,
+        "line_number": 99,
+        "is_secret": false
+      }
+    ],
+    "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/js/jquery.highlight-3.js": [
+      {
+        "type": "Email Address",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/js/jquery.highlight-3.js",
+        "hashed_secret": "c4f83cd12fb35f6b6ed090761689136e6181d414",
+        "is_verified": false,
+        "line_number": 13,
+        "is_secret": false
+      }
+    ],
+    "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/js/splitter.js": [
+      {
+        "type": "Email Address",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/js/splitter.js",
+        "hashed_secret": "4aa3f05c6a962885854678b6c22467d2bc4cf058",
+        "is_verified": false,
+        "line_number": 9,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/js/splitter.js",
+        "hashed_secret": "95e679cb828f461c6050029abaad5c31d3e58c9d",
+        "is_verified": false,
+        "line_number": 28,
+        "is_secret": false
+      }
+    ],
+    "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js",
+        "hashed_secret": "4d5967896006c8a626ecef45e6312f6fc7d5b52f",
+        "is_verified": false,
+        "line_number": 69,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js",
+        "hashed_secret": "4894cb39ee419a77b480060f3e4a6d0a4d0fa01f",
+        "is_verified": false,
+        "line_number": 91,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js",
+        "hashed_secret": "7ce98879cec564fb8c4702af747cde4e6bfe300e",
+        "is_verified": false,
+        "line_number": 92,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js",
+        "hashed_secret": "49289db43e663a3df5e2c70714722ecc54895565",
+        "is_verified": false,
+        "line_number": 93,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js",
+        "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
+        "is_verified": false,
+        "line_number": 120,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js",
+        "hashed_secret": "d3889a0728661a7de0c195be5e6a57e3dd214e43",
+        "is_verified": false,
+        "line_number": 121,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js",
+        "hashed_secret": "3fb75e3bfe4de94eb5198656fa9de95352dab915",
+        "is_verified": false,
+        "line_number": 122,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js",
+        "hashed_secret": "97ff6884d6ff311da211b0e940033ce43e5221b2",
+        "is_verified": false,
+        "line_number": 157,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js",
+        "hashed_secret": "08c327c028640360a8496436b0be694dcf07fd02",
+        "is_verified": false,
+        "line_number": 158,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js",
+        "hashed_secret": "3bfeb94233c88300d0726f43436e061caff65a2b",
+        "is_verified": false,
+        "line_number": 159,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js",
+        "hashed_secret": "427d99ef5ca789f51b448e6208a17e51a6923087",
+        "is_verified": false,
+        "line_number": 190,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/resources/localization/strings.js",
+        "hashed_secret": "093f941d92416f4d4f1f447ac09567a8c3b799ec",
+        "is_verified": false,
+        "line_number": 218,
+        "is_secret": false
+      }
+    ],
+    "docs/release/1K00/webhelp/common/oxygen-webhelp/search/index-1.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/search/index-1.js",
+        "hashed_secret": "307599426d747147ae704e3bdb6a2da13249f09e",
+        "is_verified": false,
+        "line_number": 359,
+        "is_secret": false
+      }
+    ],
+    "docs/release/1K00/webhelp/common/oxygen-webhelp/search/index-2.js": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/release/1K00/webhelp/common/oxygen-webhelp/search/index-2.js",
+        "hashed_secret": "97f2b71490b98b83b204f6a6c17554de4d394c3c",
+        "is_verified": false,
+        "line_number": 1422,
+        "is_secret": false
+      }
+    ],
     "model-dmdocument/src/changes/changes.xml": [
       {
         "type": "Email Address",
@@ -144,6 +332,114 @@
         "hashed_secret": "4b59e2ffa9a153c3e0c9aebbc172367f275b73cb",
         "is_verified": false,
         "line_number": 36,
+        "is_secret": false
+      }
+    ],
+    "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDDProductDOMAttrDefinitions.java": [
+      {
+        "type": "Email Address",
+        "filename": "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDDProductDOMAttrDefinitions.java",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 281,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDDProductDOMAttrDefinitions.java",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 287,
+        "is_secret": false
+      }
+    ],
+    "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFile.java": [
+      {
+        "type": "Email Address",
+        "filename": "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFile.java",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 516,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFile.java",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 522,
+        "is_secret": false
+      }
+    ],
+    "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFilePClass.java": [
+      {
+        "type": "Email Address",
+        "filename": "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFilePClass.java",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 528,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDPinsFilePClass.java",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 534,
+        "is_secret": false
+      }
+    ],
+    "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java": [
+      {
+        "type": "Email Address",
+        "filename": "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 1079,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1085,
+        "is_secret": false
+      }
+    ],
+    "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMRDFOWLFile.java": [
+      {
+        "type": "Email Address",
+        "filename": "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMRDFOWLFile.java",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 983,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMRDFOWLFile.java",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 989,
+        "is_secret": false
+      }
+    ],
+    "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteLODSKOSFileDOM.java": [
+      {
+        "type": "Email Address",
+        "filename": "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteLODSKOSFileDOM.java",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 598,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteLODSKOSFileDOM.java",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 604,
         "is_secret": false
       }
     ],
@@ -217,7 +513,7 @@
         "filename": "model-lddtool/src/site/xdoc/index.xml.vm",
         "hashed_secret": "4fb813c304003b3813b35a85f05b7cb0c3994cc1",
         "is_verified": false,
-        "line_number": 69,
+        "line_number": 68,
         "is_secret": false
       }
     ],
@@ -246,6 +542,308 @@
         "hashed_secret": "4b59e2ffa9a153c3e0c9aebbc172367f275b73cb",
         "is_verified": false,
         "line_number": 22,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1B00/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1B00/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1277,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1B00/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 58796,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1B10/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1B10/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1277,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1B10/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 58796,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1C00/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1C00/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1325,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1C00/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 61891,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1D00/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1D00/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1338,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1D00/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 62753,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1E00/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1E00/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1364,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1E00/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 64454,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1F00/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1F00/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1302,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1F00/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 60326,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1G00/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1G00/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1302,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1G00/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 60335,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1H00/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1H00/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1317,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1H00/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 61221,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1I00/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1I00/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1368,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1I00/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 64696,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1I00/pds-namespace-registry.csv": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1I00/pds-namespace-registry.csv",
+        "hashed_secret": "584c52cb2d7a3569c555109e76e7f28d732b41f5",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1J00/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1J00/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1317,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1J00/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 61221,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1K00/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1K00/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1323,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1K00/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 61738,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1K00/pds-namespace-registry.csv": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1K00/pds-namespace-registry.csv",
+        "hashed_secret": "584c52cb2d7a3569c555109e76e7f28d732b41f5",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1L00/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1L00/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1388,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1L00/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 66023,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1L00/pds-namespace-registry.csv": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1L00/pds-namespace-registry.csv",
+        "hashed_secret": "584c52cb2d7a3569c555109e76e7f28d732b41f5",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1M00/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1M00/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1404,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1M00/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 67013,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/1M00/pds-namespace-registry.csv": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/1M00/pds-namespace-registry.csv",
+        "hashed_secret": "584c52cb2d7a3569c555109e76e7f28d732b41f5",
+        "is_verified": false,
+        "line_number": 18,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/dd11179.pins": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/dd11179.pins",
+        "hashed_secret": "8807da39c4972c17a97b6b17ff4af586de259b96",
+        "is_verified": false,
+        "line_number": 1416,
+        "is_secret": false
+      },
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/dd11179.pins",
+        "hashed_secret": "8cd1c9679880dcebc59e4ffcf3a7747022997b5e",
+        "is_verified": false,
+        "line_number": 67781,
+        "is_secret": false
+      }
+    ],
+    "model-ontology/src/ontology/Data/pds-namespace-registry.csv": [
+      {
+        "type": "Email Address",
+        "filename": "model-ontology/src/ontology/Data/pds-namespace-registry.csv",
+        "hashed_secret": "584c52cb2d7a3569c555109e76e7f28d732b41f5",
+        "is_verified": false,
+        "line_number": 18,
         "is_secret": false
       }
     ],
@@ -370,5 +968,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-03T23:22:37Z"
+  "generated_at": "2025-02-05T21:27:50Z"
 }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -162,8 +162,7 @@ public class DMDocument extends Object {
                                          // DOMPermvalues
   // alternate IM Version
   // if no option "V" is provided on the command line, then the default is the current IM version.
-  static boolean alternateIMVersionFlag = false;
-  static String alternateIMVersion = buildIMVersionFolderId; // default
+  static String runIMVersion = buildIMVersionFolderId; // default
   // allowed alternate IM versions
   static ArrayList<String> alternateIMVersionArr;
 
@@ -367,11 +366,8 @@ public class DMDocument extends Object {
 	      dataDirPath = parentDir;
 	      nameSpaceDataDirPath = dataDirPath;
 	      // if this is an LDDTool run then an alternate path is allowed (option "V")
-	      // IMTool runs ignore the -V option
-	      if (LDDToolFlag && alternateIMVersionFlag) {
-	        if (alternateIMVersion.compareTo(buildIMVersionFolderId) != 0) {
-	            dataDirPath = parentDir + alternateIMVersion + "/";
-	        }
+	      if (runIMVersion.compareTo(buildIMVersionFolderId) != 0) {
+	          dataDirPath = parentDir + runIMVersion + "/";
 	      }
 	    } else {
 	      Utility.registerMessage("0>info - Property data.home is null");   
@@ -392,12 +388,9 @@ public class DMDocument extends Object {
 		      nameSpaceDataDirPath = dataDirPath;
 		  }
 	      // if this is an LDDTool run then an alternate path is allowed (option "V")
-	      // IMTool runs ignore the -V option
-	      if (LDDToolFlag && alternateIMVersionFlag) {
-	        if (alternateIMVersion.compareTo(buildIMVersionFolderId) != 0) {
-	          dataDirPath = parentDir + "/Data/" + alternateIMVersion + "/";
-	        }
-	       }
+	      if (runIMVersion.compareTo(buildIMVersionFolderId) != 0) {
+	    	  dataDirPath = parentDir + "/Data/" + runIMVersion + "/";
+	      }
 	    }
 	    Utility.registerMessage("0>info - Parent Directory:" + parentDir);
 	    Utility.registerMessage("0>info - IM Directory Path:" + dataDirPath);
@@ -680,8 +673,7 @@ public class DMDocument extends Object {
 	                                         // DOMPermvalues
 	  // alternate IM Version
 	  // if no option "V" is provided on the command line, then the default is the current IM version.
-	  alternateIMVersionFlag = false;
-	  alternateIMVersion = buildIMVersionFolderId; // default
+	  runIMVersion = buildIMVersionFolderId; // default
 
 	  // import export file flags
 	  exportJSONFileFlag = false; // LDDTool, set by -J option
@@ -1242,9 +1234,7 @@ public class DMDocument extends Object {
                                                              // IM
       if (alternateIMVersionArr.contains(altVersion)) { // is it an allowed prior version; was
                                                         // validated in argument parser
-        alternateIMVersion = altVersion;
-        dmProcessState.setalternateIMVersionFlag();
-        alternateIMVersionFlag = true;
+        runIMVersion = altVersion;
       }
     }
     return;
@@ -1422,7 +1412,7 @@ public class DMDocument extends Object {
     System.out.println("");
     System.out.println("Input:");
     System.out.println("");
-    System.out.println("     - IM Version: " + alternateIMVersion);
+    System.out.println("     - IM Version: " + runIMVersion);
 
     for (String processFlagName : dmProcessState.getSortedProcessFlagNameArr()) {
       System.out.println("     - " + processFlagName + ": true");

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -1235,6 +1235,7 @@ public class DMDocument extends Object {
       if (alternateIMVersionArr.contains(altVersion)) { // is it an allowed prior version; was
                                                         // validated in argument parser
         runIMVersion = altVersion;
+        dmProcessState.setalternateIMVersionFlag();
       }
     }
     return;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -1458,6 +1458,16 @@ public class DMDocument extends Object {
   public static String getOutputDirPath() {
     return outputDirPath;
   }
+  
+  public static SchemaFileDefn getMasterPDSSchemaFileDefn() {
+    return masterPDSSchemaFileDefn;
+  }
+  
+  public static String getMasterNameSpaceIdNCLC() {
+    return masterNameSpaceIdNCLC;
+  }
+  
+  // masterNameSpaceIdNCLC
 
   public static void setOutputDirPath(String outputDirPath) {
     DMDocument.outputDirPath = outputDirPath;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMProcessState.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMProcessState.java
@@ -128,14 +128,6 @@ public class DMProcessState {
     return false;
   }
 
-  public Boolean getalternateIMVersionFlag() {
-    Integer lProcessOrder = processFlagMap.get("IM Version");
-    if (lProcessOrder != null) {
-      return true;
-    }
-    return false;
-  }
-
   public Boolean getmapToolFlag() {
     Integer lProcessOrder = processFlagMap.get("Map Tool Flag");
     if (lProcessOrder != null) {
@@ -297,11 +289,6 @@ public class DMProcessState {
 
   public void sethelpFlag() {
     processFlagMap.put("Help Flag", 1030);
-    return;
-  }
-
-  public void setalternateIMVersionFlag() {
-    processFlagMap.put("IM Version", 1040);
     return;
   }
 

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMProcessState.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMProcessState.java
@@ -292,6 +292,11 @@ public class DMProcessState {
     return;
   }
 
+  public void setalternateIMVersionFlag() {
+    processFlagMap.put("IM Version", 1040);
+    return;
+  }
+
   public void setmapToolFlag() {
     processFlagMap.put("Map Tool Flag", 1050);
     return;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
@@ -54,8 +54,8 @@ class WriteDOMDocBook extends Object {
   ArrayList<AttrClassificationDefnDOM> attrClassificationArr;
 
   // Miscellaneous
-  String writtenNamespaceIds = DMDocument.masterPDSSchemaFileDefn.identifier + " v"
-      + DMDocument.masterPDSSchemaFileDefn.versionId;
+  String writtenNamespaceIds = DMDocument.getMasterPDSSchemaFileDefn().identifier + " v"
+      + DMDocument.getMasterPDSSchemaFileDefn().versionId;
 
   // Insert zero-width space characters (&#x200B;) in text strings; form break points for the lines.
 
@@ -68,7 +68,7 @@ class WriteDOMDocBook extends Object {
     if (!DMDocument.LDDToolFlag) {
       // only the common dictionary (pds)
       lSchemaFileDefnToWriteArr = new ArrayList<>();
-      lSchemaFileDefnToWriteArr.add(DMDocument.masterPDSSchemaFileDefn);
+      lSchemaFileDefnToWriteArr.add(DMDocument.getMasterPDSSchemaFileDefn());
     } else {
       // intialize array to capture namespaces to be written
       ArrayList<String> lDDNamespaceArr = new ArrayList<>();
@@ -76,9 +76,9 @@ class WriteDOMDocBook extends Object {
 
       // first get the common dictionary
       ArrayList<SchemaFileDefn> tempSchemaFileDefnToWriteArr = new ArrayList<>();
-      tempSchemaFileDefnToWriteArr.add(DMDocument.masterPDSSchemaFileDefn);
-      lSchemaFileDefnToWriteArr.add(DMDocument.masterPDSSchemaFileDefn);
-      lDDNamespaceArr.add(DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC);
+      tempSchemaFileDefnToWriteArr.add(DMDocument.getMasterPDSSchemaFileDefn());
+      lSchemaFileDefnToWriteArr.add(DMDocument.getMasterPDSSchemaFileDefn());
+      lDDNamespaceArr.add(DMDocument.getMasterPDSSchemaFileDefn().nameSpaceIdNC);
 
       // now add all the LDDs that are stacked for this run
       tempSchemaFileDefnToWriteArr = new ArrayList<>(DMDocument.LDDSchemaFileSortMap.values());
@@ -91,8 +91,7 @@ class WriteDOMDocBook extends Object {
     }
 
     // System.out.println("");
-    for (Iterator<SchemaFileDefn> i = lSchemaFileDefnToWriteArr.iterator(); i.hasNext();) {
-      SchemaFileDefn lSchemaFileDefn = i.next();
+    for (SchemaFileDefn lSchemaFileDefn: lSchemaFileDefnToWriteArr) {
       classClassificationMap.put(lSchemaFileDefn.nameSpaceIdNC,
           new ClassClassificationDefnDOM(lSchemaFileDefn.nameSpaceIdNC));
       attrClassificationMap.put(lSchemaFileDefn.nameSpaceIdNC,
@@ -113,8 +112,7 @@ class WriteDOMDocBook extends Object {
 
     // classify attributes and classes
     // get the class classification maps
-    for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
-      DOMClass lClass = i.next();
+    for (DOMClass lClass: DOMInfoModel.getMasterDOMClassArr()) {
       if (lClass.isInactive) {
         continue;
       }
@@ -122,15 +120,13 @@ class WriteDOMDocBook extends Object {
     }
 
     // get the classification arrays
-    for (Iterator<ClassClassificationDefnDOM> i = classClassificationArr.iterator(); i.hasNext();) {
-      ClassClassificationDefnDOM lClassClassificationDefn = i.next();
+    for (ClassClassificationDefnDOM lClassClassificationDefn: classClassificationArr) {
       lClassClassificationDefn.classArr =
           new ArrayList<>(lClassClassificationDefn.classMap.values());
     }
 
     // get the attribute classification maps
-    for (Iterator<DOMAttr> i = DOMInfoModel.masterDOMAttrArr.iterator(); i.hasNext();) {
-      DOMAttr lAttr = i.next();
+    for (DOMAttr lAttr: DOMInfoModel.getMasterDOMAttrArr()) {
       if (lAttr.isInactive) {
         continue;
       }
@@ -138,8 +134,7 @@ class WriteDOMDocBook extends Object {
     }
 
     // get the classification arrays
-    for (Iterator<AttrClassificationDefnDOM> i = attrClassificationArr.iterator(); i.hasNext();) {
-      AttrClassificationDefnDOM lAttrClassificationDefn = i.next();
+    for (AttrClassificationDefnDOM lAttrClassificationDefn: attrClassificationArr) {
       lAttrClassificationDefn.attrArr = new ArrayList<>(lAttrClassificationDefn.attrMap.values());
     }
 
@@ -154,7 +149,7 @@ class WriteDOMDocBook extends Object {
         Utility.registerMessage("0>info " + " - namespace: " + lId + "   size: "
             + lClassClassificationDefnDOM.classArr.size());
         if (lClassClassificationDefnDOM.classArr.size() > 0) {
-          if (!(lId.compareTo(DMDocument.masterNameSpaceIdNCLC) == 0
+          if (!(lId.compareTo(DMDocument.getMasterNameSpaceIdNCLC()) == 0
               || lId.compareTo("pds.product") == 0 || lId.compareTo("pds.ops") == 0
               || lId.compareTo("pds.support") == 0 || lId.compareTo("pds.other") == 0
               || lId.compareTo("other") == 0)) {
@@ -191,7 +186,7 @@ class WriteDOMDocBook extends Object {
     ClassClassificationDefnDOM lClassClassificationDefn =
         classClassificationMap.get(lClass.nameSpaceIdNC);
     if (lClassClassificationDefn != null) {
-      if (lClass.nameSpaceIdNC.compareTo(DMDocument.masterNameSpaceIdNCLC) == 0) {
+      if (lClass.nameSpaceIdNC.compareTo(DMDocument.getMasterNameSpaceIdNCLC()) == 0) {
         // i.e., the Common directory, pds
         if (lClass.steward.compareTo("ops") == 0) {
           lClassClassificationDefn = classClassificationMap.get("pds.ops");
@@ -236,7 +231,7 @@ class WriteDOMDocBook extends Object {
   // print DocBook File
   public void writeDocBook(SchemaFileDefn lSchemaFileDefn) throws java.io.IOException {
     String lFileName = lSchemaFileDefn.relativeFileSpecDDDocXML;
-    String lLabelVersionId = "_" + DMDocument.masterPDSSchemaFileDefn.lab_version_id;
+    String lLabelVersionId = "_" + DMDocument.getMasterPDSSchemaFileDefn().lab_version_id;
     String lDOMLabelVersionId = lLabelVersionId;
     lFileName = DMDocument.replaceString(lFileName, lLabelVersionId, lDOMLabelVersionId);
     PrintWriter prDocBook =
@@ -244,13 +239,12 @@ class WriteDOMDocBook extends Object {
     writeHeader(prDocBook);
 
     // write the Common dictionary
-    writeClassSection(DMDocument.masterNameSpaceIdNCLC, prDocBook);
-    writeAttrSection(DMDocument.masterNameSpaceIdNCLC, prDocBook);
+    writeClassSection(DMDocument.getMasterNameSpaceIdNCLC(), prDocBook);
+    writeAttrSection(DMDocument.getMasterNameSpaceIdNCLC(), prDocBook);
 
     // write the LDDs
-    for (Iterator<SchemaFileDefn> i = lSchemaFileDefnToWriteArr.iterator(); i.hasNext();) {
-      SchemaFileDefn lSchemaFileDefnToWrite = i.next();
-      if (lSchemaFileDefnToWrite.nameSpaceIdNCLC.compareTo(DMDocument.masterNameSpaceIdNCLC) == 0) {
+    for (SchemaFileDefn lSchemaFileDefnToWrite: lSchemaFileDefnToWriteArr) {
+      if (lSchemaFileDefnToWrite.nameSpaceIdNCLC.compareTo(DMDocument.getMasterNameSpaceIdNCLC()) == 0) {
         continue; // skip master namespace
       }
       ClassClassificationDefnDOM lClassClassificationDefn =
@@ -270,8 +264,8 @@ class WriteDOMDocBook extends Object {
     }
 
     // write the Data Types and Units
-    writeDataTypeSection(DMDocument.masterNameSpaceIdNCLC, prDocBook);
-    writeUnitsSection(DMDocument.masterNameSpaceIdNCLC, prDocBook);
+    writeDataTypeSection(DMDocument.getMasterNameSpaceIdNCLC(), prDocBook);
+    writeUnitsSection(DMDocument.getMasterNameSpaceIdNCLC(), prDocBook);
     writeFooter(prDocBook);
     prDocBook.close();
     return;
@@ -287,8 +281,7 @@ class WriteDOMDocBook extends Object {
       prDocBook.println("        <chapter>");
       prDocBook.println("           <title>Product Classes in the common namespace.</title>");
       prDocBook.println("           <para>These classes define the products.</para>");
-      for (Iterator<DOMClass> j = lClassClassificationDefn.classArr.iterator(); j.hasNext();) {
-        DOMClass lClass = j.next();
+      for (DOMClass lClass: lClassClassificationDefn.classArr) {
         writeClass(lClass, prDocBook);
       }
       prDocBook.println("        </chapter>");
@@ -301,8 +294,7 @@ class WriteDOMDocBook extends Object {
       prDocBook.println("           <title>Support classes in the common namespace.</title>");
       prDocBook.println(
           "           <para>The classes in this section are used by the product classes.</para>");
-      for (Iterator<DOMClass> j = lClassClassificationDefn.classArr.iterator(); j.hasNext();) {
-        DOMClass lClass = j.next();
+      for (DOMClass lClass: lClassClassificationDefn.classArr) {
         writeClass(lClass, prDocBook);
       }
       prDocBook.println("        </chapter>");
@@ -316,8 +308,7 @@ class WriteDOMDocBook extends Object {
         prDocBook.println("        <chapter>");
         prDocBook.println("           <title>OPS catalog classes in the common namespace.</title>");
         prDocBook.println("           <para>These classes support operations. </para>");
-        for (Iterator<DOMClass> j = lClassClassificationDefn.classArr.iterator(); j.hasNext();) {
-          DOMClass lClass = j.next();
+        for (DOMClass lClass: lClassClassificationDefn.classArr) {
           writeClass(lClass, prDocBook);
         }
         prDocBook.println("        </chapter>");
@@ -340,8 +331,7 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("           <title>Classes in the " + lClassClassificationDefn.namespaceId
         + " namespace.</title>");
     prDocBook.println("           <para>These classes comprise the namespace.</para>");
-    for (Iterator<DOMClass> j = lClassClassificationDefn.classArr.iterator(); j.hasNext();) {
-      DOMClass lClass = j.next();
+    for (DOMClass lClass: lClassClassificationDefn.classArr) {
       writeClass(lClass, prDocBook);
     }
     prDocBook.println("        </chapter>");
@@ -364,8 +354,7 @@ class WriteDOMDocBook extends Object {
         + " namespace.</title>");
     prDocBook.println("           <para>These attributes are used by the classes in the "
         + lAttrClassificationDefn.namespaceId + " namespace. </para>");
-    for (Iterator<DOMAttr> j = lAttrClassificationDefn.attrArr.iterator(); j.hasNext();) {
-      DOMAttr lAttr = j.next();
+    for (DOMAttr lAttr: lAttrClassificationDefn.attrArr) {
       writeAttr(lAttr, prDocBook);
     }
     prDocBook.println("        </chapter>");
@@ -427,8 +416,7 @@ class WriteDOMDocBook extends Object {
     lClassArr.add(lClass);
     lValueString = "";
     lValueDel = "";
-    for (Iterator<DOMClass> i = lClassArr.iterator(); i.hasNext();) {
-      DOMClass lHierClass = i.next();
+    for (DOMClass lHierClass: lClassArr) {
       lValueString += lValueDel + getClassLink(lHierClass);
       lValueDel = " :: ";
     }
@@ -440,8 +428,7 @@ class WriteDOMDocBook extends Object {
     // determine the type and number of class members (attributes and classes)
     int attrCount = 0, assocCount = 0;
     if (lClass.allAttrAssocArr != null) {
-      for (Iterator<DOMProp> i = lClass.allAttrAssocArr.iterator(); i.hasNext();) {
-        DOMProp lProp = i.next();
+      for (DOMProp lProp: lClass.allAttrAssocArr) {
         if (lProp.isAttribute) {
           attrCount++;
         } else {
@@ -465,8 +452,7 @@ class WriteDOMDocBook extends Object {
       prDocBook.println("                    <entry>" + getPrompt("Value") + "</entry>");
       prDocBook.println("                </row>");
 
-      for (Iterator<DOMProp> j = lClass.allAttrAssocArr.iterator(); j.hasNext();) {
-        DOMProp lProp = j.next();
+      for (DOMProp lProp: lClass.allAttrAssocArr) {
         if (!lProp.isAttribute) {
           continue;
         }
@@ -475,8 +461,7 @@ class WriteDOMDocBook extends Object {
         lValueDel = "";
         if (!(lAttr.domPermValueArr == null || lAttr.domPermValueArr.size() == 0)) {
           lValueString = "";
-          for (Iterator<DOMProp> k = lAttr.domPermValueArr.iterator(); k.hasNext();) {
-            DOMProp lDOMProp = k.next();
+          for (DOMProp lDOMProp: lAttr.domPermValueArr) {
             if (!(lDOMProp.hasDOMObject instanceof DOMPermValDefn)) {
               continue;
             }
@@ -518,8 +503,7 @@ class WriteDOMDocBook extends Object {
       TreeMap<String, TreeMap<String, DOMClass>> lPropMemberClassMap = new TreeMap<>();
 
       int lSeqNumI = 1000;
-      for (Iterator<DOMProp> j = lClass.allAttrAssocArr.iterator(); j.hasNext();) {
-        DOMProp lDOMProp = j.next();
+      for (DOMProp lDOMProp: lClass.allAttrAssocArr) {
         if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMClass) {
           DOMClass lMemberDOMClass = (DOMClass) lDOMProp.hasDOMObject;
           TreeMap<String, DOMClass> lMemberClassMap = lPropMemberClassMap.get(lDOMProp.title);
@@ -540,16 +524,14 @@ class WriteDOMDocBook extends Object {
 
       // write the member classes
       ArrayList<String> lPropOrderArr = new ArrayList<>(lPropOrderMap.values());
-      for (Iterator<String> j = lPropOrderArr.iterator(); j.hasNext();) {
-        String lDOMPropTitle = j.next();
+      for (String lDOMPropTitle: lPropOrderArr) {
         TreeMap<String, DOMClass> lMemberClassMap = lPropMemberClassMap.get(lDOMPropTitle);
         String lCardString = lPropCardMap.get(lDOMPropTitle);
         if (lCardString != null && lMemberClassMap != null) {
           ArrayList<DOMClass> lMemberClassArr = new ArrayList<>(lMemberClassMap.values());
           lValueString = "";
           lValueDel = "";
-          for (Iterator<DOMClass> k = lMemberClassArr.iterator(); k.hasNext();) {
-            DOMClass lMemberClass = k.next();
+          for (DOMClass lMemberClass: lMemberClassArr) {
             lValueString += lValueDel + getClassLink(lMemberClass);
             lValueDel = ", ";
           }
@@ -569,8 +551,7 @@ class WriteDOMDocBook extends Object {
     lValueString = "";
     lValueDel = "";
     if (!(lRefClassArr == null || lRefClassArr.isEmpty())) {
-      for (Iterator<DOMClass> i = lRefClassArr.iterator(); i.hasNext();) {
-        DOMClass lRefClass = i.next();
+      for (DOMClass lRefClass: lRefClassArr) {
         lValueString += lValueDel + getClassLink(lRefClass);
         lValueDel = ", ";
       }
@@ -597,14 +578,13 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("");
 
     AttrClassificationDefnDOM lAttrClassificationDefn =
-        attrClassificationMap.get(DMDocument.masterNameSpaceIdNCLC);
+        attrClassificationMap.get(DMDocument.getMasterNameSpaceIdNCLC());
     if (lAttrClassificationDefn != null) {
       prDocBook.println("        <chapter>");
       prDocBook.println("           <title>Attributes in the common namespace.</title>");
       prDocBook.println(
           "           <para>These attributes are used by the classes in the common namespace. </para>");
-      for (Iterator<DOMAttr> j = lAttrClassificationDefn.attrArr.iterator(); j.hasNext();) {
-        DOMAttr lAttr = j.next();
+      for (DOMAttr lAttr: lAttrClassificationDefn.attrArr) {
         writeAttr(lAttr, prDocBook);
       }
       prDocBook.println("        </chapter>");
@@ -729,8 +709,7 @@ class WriteDOMDocBook extends Object {
           + getPrompt("Value Meaning") + "</entry>");
       prDocBook.println("                </row>");
 
-      for (Iterator<DOMProp> j = lAttr.domPermValueArr.iterator(); j.hasNext();) {
-        DOMProp lProp = j.next();
+      for (DOMProp lProp: lAttr.domPermValueArr) {
         if (!(lProp.hasDOMObject instanceof DOMPermValDefn)) {
           continue;
         }
@@ -772,8 +751,7 @@ class WriteDOMDocBook extends Object {
     }
     if (!(lAttr.permValueExtArr == null || lAttr.permValueExtArr.isEmpty())) {
 
-      for (Iterator<PermValueExtDefn> i = lAttr.permValueExtArr.iterator(); i.hasNext();) {
-        PermValueExtDefn lPermValueExt = i.next();
+      for (PermValueExtDefn lPermValueExt: lAttr.permValueExtArr) {
         if (lPermValueExt.permValueExtArr == null || lPermValueExt.permValueExtArr.isEmpty()) {
           continue;
         }
@@ -786,8 +764,7 @@ class WriteDOMDocBook extends Object {
             + getPrompt("Value Meaning") + "</entry>");
         prDocBook.println("                </row>");
 
-        for (Iterator<PermValueDefn> j = lPermValueExt.permValueExtArr.iterator(); j.hasNext();) {
-          PermValueDefn lPermValueDefn = j.next();
+        for (PermValueDefn lPermValueDefn: lPermValueExt.permValueExtArr) {
           prDocBook.println("                <row>");
           prDocBook.println("                    <entry></entry>");
           prDocBook.println(
@@ -822,8 +799,7 @@ class WriteDOMDocBook extends Object {
 
     // Sort the data types
     TreeMap<String, DOMClass> sortDataTypeMap = new TreeMap<>();
-    for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
-      DOMClass lClass = i.next();
+    for (DOMClass lClass: DOMInfoModel.getMasterDOMClassArr()) {
       if (lClass.isInactive || (lNameSpaceIdNC.compareTo(lClass.nameSpaceIdNC) != 0)
           || !lClass.isDataType) {
         continue;
@@ -845,9 +821,7 @@ class WriteDOMDocBook extends Object {
     // Write the data types
     String lSchemaBaseType = "None", lMinChar = "None", lMaxChar = "None", lMinVal = "None",
         lMaxVal = "None";
-    for (Iterator<DOMClass> i = sortDataTypeArr.iterator(); i.hasNext();) {
-      DOMClass lClass = i.next();
-
+    for (DOMClass lClass: sortDataTypeArr) {
       lSchemaBaseType = "None";
       lMinChar = "None";
       lMaxChar = "None";
@@ -897,8 +871,7 @@ class WriteDOMDocBook extends Object {
           String lVal = DOMInfoModel.getSingletonAttrValue(lAttr.valArr);
           if (lVal != null) {
             // if not null there there are one or more patterns
-            for (Iterator<String> k = lAttr.valArr.iterator(); k.hasNext();) {
-              String lPattern = k.next();
+            for (String lPattern: lAttr.valArr) {
               lPatternArr.add(lPattern);
             }
           }
@@ -961,8 +934,7 @@ class WriteDOMDocBook extends Object {
         prDocBook.println("                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\">"
             + getPrompt("Pattern") + "</entry>");
         prDocBook.println("                </row>");
-        for (Iterator<String> k = lPatternArr.iterator(); k.hasNext();) {
-          String lPattern = k.next();
+        for (String lPattern: lPatternArr) {
           prDocBook.println("                <row>");
           prDocBook.println("                    <entry>" + "</entry>");
           prDocBook
@@ -998,8 +970,7 @@ class WriteDOMDocBook extends Object {
     // get the units
     ArrayList<DOMProp> lDOMPermValueArr;
     TreeMap<String, DOMClass> sortUnitsMap = new TreeMap<>();
-    for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
-      DOMClass lClass = i.next();
+    for (DOMClass lClass: DOMInfoModel.getMasterDOMClassArr()) {
       if (lClass.isInactive || (lNameSpaceIdNC.compareTo(lClass.nameSpaceIdNC) != 0)
           || !lClass.isUnitOfMeasure) {
         continue;
@@ -1017,8 +988,7 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("       <title>Units of Measure in the common namespace.</title>");
     prDocBook.println("       <para>These classes define the units of measure. </para>");
 
-    for (Iterator<DOMClass> i = sortUnitsArr.iterator(); i.hasNext();) {
-      DOMClass lClass = i.next();
+    for (DOMClass lClass: sortUnitsArr) {
       lDOMPermValueArr = new ArrayList<>();
       for (DOMProp lProp : lClass.allAttrAssocArr) {
         DOMAttr lDOMAttr = (DOMAttr) lProp.hasDOMObject;
@@ -1062,8 +1032,7 @@ class WriteDOMDocBook extends Object {
       prDocBook.println("                </row>");
 
       if (!lDOMPermValueArr.isEmpty()) {
-        for (Iterator<DOMProp> k = lDOMPermValueArr.iterator(); k.hasNext();) {
-          DOMProp lDOMProp = k.next();
+        for (DOMProp lDOMProp: lDOMPermValueArr) {
           if (lDOMProp.hasDOMObject != null && lDOMProp.hasDOMObject instanceof DOMPermValDefn) {
             DOMPermValDefn lDOMPermValDefn = (DOMPermValDefn) lDOMProp.hasDOMObject;
             prDocBook.println("                <row>");
@@ -1113,12 +1082,12 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("    <info>");
     prDocBook.println("        <title>" + DMDocument.ddDocTitle + "</title>");
     prDocBook.println("        <subtitle>Abridged - Version "
-        + DMDocument.masterPDSSchemaFileDefn.ont_version_id + "</subtitle>");
+        + DMDocument.getMasterPDSSchemaFileDefn().ont_version_id + "</subtitle>");
     prDocBook.println("        <author>");
     prDocBook.println("            <orgname>" + DMDocument.ddDocTeam + "</orgname>");
     prDocBook.println("        </author>");
     prDocBook.println("        <releaseinfo>Generated from Information Model Version "
-        + DMDocument.masterPDSSchemaFileDefn.ont_version_id + " on " + DMDocument.sTodaysDate
+        + DMDocument.getMasterPDSSchemaFileDefn().ont_version_id + " on " + DMDocument.sTodaysDate
         + "</releaseinfo>");
     prDocBook.println(
         "        <releaseinfo>Contains namespace ids: " + writtenNamespaceIds + "</releaseinfo>");
@@ -1365,7 +1334,7 @@ class WriteDOMDocBook extends Object {
 
   private String getDataTypeLink(String lDataType) {
     String lLink = DMDocument.registrationAuthorityIdentifierValue + "."
-        + DMDocument.masterNameSpaceIdNCLC + "." + lDataType;
+        + DMDocument.getMasterNameSpaceIdNCLC() + "." + lDataType;
     int lLinkI = lLink.hashCode();
     lLink = "N" + Integer.toString(lLinkI);
     // String lDataTypeWrap = DMDocument.replaceString(lDataType, "_", "_&#x200B;");
@@ -1377,7 +1346,7 @@ class WriteDOMDocBook extends Object {
       return "None";
     }
     String lLink = DMDocument.registrationAuthorityIdentifierValue + "."
-        + DMDocument.masterNameSpaceIdNCLC + "." + lUnitId;
+        + DMDocument.getMasterNameSpaceIdNCLC() + "." + lUnitId;
     int lLinkI = lLink.hashCode();
     lLink = "N" + Integer.toString(lLinkI);
     return "<link linkend=\"" + lLink + "\">" + lUnitId + "</link>";
@@ -1386,17 +1355,16 @@ class WriteDOMDocBook extends Object {
   private String getCardinality(int lCardMin, int lCardMax) {
     String pCardMax = "Unbounded";
     if (lCardMax != 9999999) {
-      pCardMax = (new Integer(lCardMax)).toString();
+      pCardMax = Integer.toString(lCardMax);
     }
-    String pCardMin = (new Integer(lCardMin)).toString();
+    String pCardMin = Integer.toString(lCardMin);
     return pCardMin + ".." + pCardMax;
   }
 
   // return all classes that reference this class
   private ArrayList<DOMClass> getClassReferences(DOMClass lTargetClass) {
     ArrayList<DOMClass> refClassArr = new ArrayList<>();
-    for (Iterator<DOMClass> i = DOMInfoModel.masterDOMClassArr.iterator(); i.hasNext();) {
-      DOMClass lClass = i.next();
+    for (DOMClass lClass: DOMInfoModel.getMasterDOMClassArr()) {
       if (lClass.isInactive) {
         continue;
       }


### PR DESCRIPTION
The -V flag does not work when attempting to generate core IM.

## 🗒️ Summary
The -V flag for specifying that LDDTool should use a prior version of the IM did not work when generating the Core schemas. The code was changed to allow the -V option for Core and LDD processing.

The WriteDOMDocBook.java was also modified. References to static variables were removed and replaced with get method calls. There was also significant cleanup of dated code.

## ⚙️ Test Data and/or Report
The regressions tests for comparing current and prior results from LDDTool process will test some of the current changes. A subsequent PR is planned to add additional tests.

## ♻️ Related Issues
Resolves #859


