### PR TITLE
Add tests back that use LDDs

### DIFF
--- a/model-lddtool/src/test/resources/features/validate.feature
+++ b/model-lddtool/src/test/resources/features/validate.feature
@@ -13,20 +13,19 @@ Feature: pds4_information_model_validate_integration
     # NOTE: The following flags are prepended to the execution by default: --disable-context-mismatch-warnings --report-style json --skip-content-validation --report-file {reportDir}/
     
     @v15.2.x
-#note: 'mvn test' choks if problem enum is blank or "" even if 0 messages
     Examples: 
 | testId                               | testName                        | testDir     | messageCount         | problemEnum        | commandArgs                                             | ingestLDDFileName         | pds4Version |
 | NASA-PDS/pds4-information-model#753  | "new Current units nA microA"   | "github753"  |           0  | "totalErrors" | "-t {resourceDir}/github753/pc__d139.xml" | "PDS4_MARS2020_IngestLDD.xml" | "" |
 | NASA-PDS/pds4-information-model#784a | "Encoded_Video for Product_Ancillary" | "github784a" |           0 | "totalErrors" | "-t {resourceDir}/github784/FUV2017032anc.xml" | "" | "" |
 | NASA-PDS/pds4-information-model#784b | "Encoded_Video for Product_Browse" | "github784b" |           0  | "totalErrors" | "-t {resourceDir}/github784/FUV2017032brw.xml" | "" | "" |
-#| NASA-PDS/pds4-information-model#794  | "new namespace vikinglander"    | "github794"  |           0  | "totalErrors" | "-t {resourceDir}/github794/ORB_35_STAR_SCANNER.xml" | "PDS4_VIKINGLANDER_IngestLDD.xml" | "" |
+| NASA-PDS/pds4-information-model#794  | "new namespace vikinglander"    | "github794"  |           0  | "totalErrors" | "-t {resourceDir}/github794/ORB_35_STAR_SCANNER.xml" | "PDS4_VIKINGLANDER_IngestLDD.xml" | "" |
 | NASA-PDS/pds4-information-model#795a | "reference_type Failures for all Data Types"             | "github795"  |          10  | "SCHEMATRON_ERROR,INTERNAL_ERROR" | "-R pds4.bundle -t {resourceDir}/github795" | "" | "" |
 | NASA-PDS/pds4-information-model#795b | "reference_type Failures for Product_External"             | "github795b" |           2  | "SCHEMATRON_ERROR" | "-t {resourceDir}/github795b/occultation_prediction_som_manifest.xml" | "" | "" |
-#| NASA-PDS/pds4-information-model#797  | "test schematron for kernel_type checks"             | "github797"  |           3  | "SCHEMATRON_ERROR" | "-t {resourceDir}/github797/test_label1_FAIL.xml {resourceDir}/github797/u5.xml" | "PDS4_GEOM_IngestLDD.xml" | "" |
-#| NASA-PDS/pds4-information-model#829  | "new unit mrad/pixels"          | "github829"  |           0 |  "totalErrors" | "-t {resourceDir}/github829/ORB_35_STAR_SCANNER.xml" | "PDS4_HST_IngestLDD.xml" | "" |
+| NASA-PDS/pds4-information-model#797  | "test schematron for kernel_type checks"             | "github797"  |           3  | "SCHEMATRON_ERROR" | "-t {resourceDir}/github797/test_label1_FAIL.xml {resourceDir}/github797/u5.xml" | "PDS4_GEOM_IngestLDD.xml" | "" |
+| NASA-PDS/pds4-information-model#829  | "new unit mrad/pixels"          | "github829"  |           0 |  "totalErrors" | "-t {resourceDir}/github829/ORB_35_STAR_SCANNER.xml" | "PDS4_HST_IngestLDD.xml" | "" |
 | NASA-PDS/pds4-information-model#831  | "add Array_1D_Spectrum"         | "github831"  |           0 |  "totalErrors" | "-t {resourceDir}/github831/" | "" | "" |
 
 # Primary check is that LDDTool executes successfully, which it did not before
-#| NASA-PDS/pds4-information-model#852a  | "bug generating LDDs for 1C00"   | "github852"  |           2  | "totalErrors" | "-t {resourceDir}/github852/lcross_nir2_cal_20090622162743896.xml" | "PDS4_LCROSS_IngestLDD_1000.xml" | "1C00" |
-#| NASA-PDS/pds4-information-model#852b  | "bug generating LDDs for 1D00"   | "github852"  |           2  | "totalErrors" | "-t {resourceDir}/github852/lcross_nir2_cal_20090622162743896.xml" | "PDS4_LCROSS_IngestLDD_1000.xml" | "1C00" |
-#| NASA-PDS/pds4-information-model#852c  | "bug generating LDDs for 1E00"   | "github852"  |           2  | "totalErrors" | "-t {resourceDir}/github852/lcross_nir2_cal_20090622162743896.xml" | "PDS4_LCROSS_IngestLDD_1000.xml" | "1C00" |
+# | NASA-PDS/pds4-information-model#852a  | "bug generating LDDs for 1C00"   | "github852"  |           0  | "totalErrors" | "-t {resourceDir}/github852/lcross_nir2_cal_20090622162743896.xml" | "PDS4_LCROSS_IngestLDD_1000.xml" | "1C00" |
+#| NASA-PDS/pds4-information-model#852b  | "bug generating LDDs for 1D00"   | "github852"  |           2  | "totalErrors" | "-t {resourceDir}/github852/lcross_nir2_cal_20090622162743896b.xml" | "PDS4_LCROSS_IngestLDD_1000.xml" | "1C00" |
+#| NASA-PDS/pds4-information-model#852c  | "bug generating LDDs for 1E00"   | "github852"  |           2  | "totalErrors" | "-t {resourceDir}/github852/lcross_nir2_cal_20090622162743896c.xml" | "PDS4_LCROSS_IngestLDD_1000.xml" | "1C00" |


### PR DESCRIPTION


<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Numerous tests were commented out because validate had a bug where it could not handle running after it loaded LDDs. [with that being fixed here](https://github.com/NASA-PDS/validate/issues/1105), we can add these tests back.

## ⚙️ Test Data and/or Report
See test run

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Fixes #866

