### PR TITLE
Added --include-all-namespaces option for JSON export

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -168,7 +168,7 @@ public class DMDocument extends Object {
 
   // import export file flags
   static boolean exportJSONFileFlag = false; // LDDTool, set by -J option
-  static boolean exportJSONFileAllFlag = false; // LDDTool, set by -6 option *** Not Currently Used - Deprecate? ***
+  static boolean includeAllNamespacesFlag = false; // LDDTool, set by --include-all-namespaces
   static boolean exportSpecFileFlag = false;
   static boolean exportDDFileFlag = false;
   static boolean exportTermMapFileFlag = false;
@@ -677,7 +677,7 @@ public class DMDocument extends Object {
 
 	  // import export file flags
 	  exportJSONFileFlag = false; // LDDTool, set by -J option
-	  exportJSONFileAllFlag = false; // LDDTool, set by -6 option *** Not Currently Used - Deprecate? ***
+	  includeAllNamespacesFlag = false; // LDDTool, set --include-all-namespaces
 	  exportSpecFileFlag = false;
 	  exportDDFileFlag = false;
 	  exportTermMapFileFlag = false;
@@ -1154,6 +1154,9 @@ public class DMDocument extends Object {
 
     parser.addArgument("-J", "--json").dest("J").type(Boolean.class).nargs(1)
         .action(Arguments.storeTrue()).help("Write the data dictionary to a JSON formatted file");
+    
+    parser.addArgument("-a", "--include-all-namespaces").dest("a").type(Boolean.class).nargs(1)
+    	.action(Arguments.storeTrue()).help("Include all namespaces in the JSON output (only valid with --json)");
 
     parser.addArgument("-m", "--merge").dest("m").type(Boolean.class).nargs(1)
         .action(Arguments.storeTrue())
@@ -1303,6 +1306,11 @@ public class DMDocument extends Object {
     if (JFlag) {
       dmProcessState.setexportJSONFileFlag();
       exportJSONFileFlag = true;
+    }
+    Boolean AFlag = ns.getBoolean("a");
+    if (AFlag) {
+      dmProcessState.setIncludeAllNamespacesFlag();
+      includeAllNamespacesFlag = true;
     }
     Boolean n1Flag = ns.getBoolean("1");
     if (n1Flag) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMProcessState.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMProcessState.java
@@ -244,13 +244,13 @@ public class DMProcessState {
     return false;
   }
   
-//  public Boolean getexportJSONFileAllFlag() {
-//    Integer lProcessOrder = processFlagMap.get("Export JSON File All Flag");
-//    if (lProcessOrder != null) {
-//      return true;
-//    }
-//    return false;
-//  }
+  public Boolean getIncludeAllNamespacesFlag() {
+    Integer lProcessOrder = processFlagMap.get("Include All Namespaces Flag");
+    if (lProcessOrder != null) {
+      return true;
+    }
+    return false;
+  }
 
   public Boolean getcheckFileNameFlag() {
     Integer lProcessOrder = processFlagMap.get("Check File Name Flag");
@@ -372,10 +372,10 @@ public class DMProcessState {
 	return;
   }
 
-//  public void setexportJSONFileAllFlag() {
-//    processFlagMap.put("Export JSON File All Flag", 1200);
-//    return;
-//  }
+  public void setIncludeAllNamespacesFlag() {
+    processFlagMap.put("Include All Namespaces Flag", 1200);
+    return;
+  }
 
   public void setcheckFileNameFlag() {
     processFlagMap.put("Check File Name Flag", 1210);

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFile.java
@@ -70,7 +70,7 @@ class WriteDOMDDJSONFile extends Object {
       PrintWriter prDDPins = new PrintWriter(
           new OutputStreamWriter(new FileOutputStream(new File(lFileName)), "UTF-8"));
       printPDDPHdr(DMDocument.masterLDDSchemaFileDefn, prDDPins);
-      if (!DMDocument.exportJSONFileAllFlag) {
+      if (!DMDocument.includeAllNamespacesFlag) {
         printPDDPBody(DMDocument.masterLDDSchemaFileDefn.nameSpaceIdNC, prDDPins);
       } else {
         printPDDPBody("all", prDDPins);

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFileLib.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFileLib.java
@@ -55,36 +55,44 @@ class WriteDOMDDJSONFileLib {
 	ArrayList <String> selectNamespaceArr = new ArrayList <> ();
 
 	public WriteDOMDDJSONFileLib() {
+		// start with the the Common (pds) namespace
 		selectNamespaceArr.add(DMDocument.masterPDSSchemaFileDefn.nameSpaceIdNC);
 		return;
 	}
   
 	// write the JSON file
 	public void writeJSONFile(SchemaFileDefn lSchemaFileDefn) throws java.io.IOException {
-		if (!DMDocument.LDDToolFlag) {	// write Common Dictionary to JSON file
-
+		if (!DMDocument.LDDToolFlag) {
+			// write Common Dictionary to JSON file
 			// get the level 0 JSON Object with name=null and value=empty JSON Array
 			JSONArray jsonArrayLevel0 = (JSONArray) getJSONArrayLevel1 (lSchemaFileDefn);
 			if (jsonArrayLevel0 != null) {
 
 				// write the JSON object
 				String lFileName = lSchemaFileDefn.relativeFileSpecDOMModelJSON;	
-//				lFileName = lFileName.replace(".JSON", "_NEW2.JSON");
 				writeJson(jsonArrayLevel0, lFileName);
 			}
 
 		} else {
-			// add all LDD namespaces for this run
-			selectNamespaceArr.addAll(DMDocument.LDDImportNameSpaceIdNCArr);
+			
+			// set file name for the JSON file - use LDD name
+			String lFileName = DMDocument.masterLDDSchemaFileDefn.relativeFileSpecDOMModelJSON;
+			
+			// check if all LDDs are to be included
+			if (DMDocument.includeAllNamespacesFlag) {
+				// add all LDD namespaces for this run
+				lFileName = lFileName.replace(".JSON", "_All.JSON");
+				selectNamespaceArr.addAll(DMDocument.LDDImportNameSpaceIdNCArr);
+			} else {
+				// add only the primary LDD in the run
+				selectNamespaceArr.add(DMDocument.masterLDDSchemaFileDefn.nameSpaceIdNC);
+			}
 
 			// get the level 0 JSON Object with name=null and value=empty JSON Array
 			JSONArray jsonArrayLevel0 = (JSONArray) getJSONArrayLevel1 (lSchemaFileDefn);
-			//  	  	System.out.println("debug writeJSONFile LDD - jsonArrayLevel0:" + jsonArrayLevel0);
 			if (jsonArrayLevel0 != null) {
 
 				// write the JSON file for the LDD
-				String lFileName = DMDocument.masterLDDSchemaFileDefn.relativeFileSpecDOMModelJSON;
-//				lFileName = lFileName.replace(".JSON", "_NEW3.JSON");
 				writeJson(jsonArrayLevel0, lFileName);
 			}
 		}


### PR DESCRIPTION
#723 lddtool json export seems to export the whole IM, not just the current dictionary

## 🗒️ Summary
The "-J" option (export to JSON formatted file) now has three possible outputs. The additional option --include-all-namespaces was added to indicate that all LDDs in the LDDTool run were to be exported to the JSON formatted file.

1. if LDDTool is run with the "-l -J" options, i.e. an LDD run, then only the primary LDD namespace is exported
2. if LDDTool is run with the "-l -J --include-all-namespaces" options, then all LDD namespaces in the run are exported
3. if LDDTool is run with the "-J" option, then only the Common namespace is exported to JSON

## ⚙️ Test Data and/or Report

1 - java"  -Ddata.home=.../Document/Data -jar "...\DMDocument.jar" -lpJD PDS4_CART_IngestLDD.xml PDS4_CTLI_IngestLDD.xml PDS4_DISP_IngestLDD.xml  PDS4_WAVE_IngestLDD.xml

   The output file included the class "Wave_Observation" consistent with the primary LDD being PDS4_WAVE_IngestLDD

2 - java"  -Ddata.home=.../Document/Data -jar "...\DMDocument.jar" -lpJD --include-all-namespaces PDS4_CART_IngestLDD.xml PDS4_CTLI_IngestLDD.xml PDS4_DISP_IngestLDD.xml  PDS4_WAVE_IngestLDD.xml

   The output file included the classes "Wave_Observation" and "Cartography", consistent with the inclusion of PDS4_CART_IngestLDD.

## ♻️ Related Issues
Resolves #723


