### PR TITLE
Generated LDD documentation does not handle xs:choice right

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
@@ -470,11 +470,13 @@ class WriteDOMDocBook extends Object {
             lValueDel = ", ";
           }
         }
+        String choiceIndicator = "";
+        if (lProp.isChoice) choiceIndicator = " - Choice";
         prDocBook.println("                <row>");
         prDocBook.println("                    <entry></entry>");
         prDocBook.println("                    <entry>" + getAttrLink(lAttr) + "</entry>");
         prDocBook.println("                    <entry>"
-            + getValue(getCardinality(lAttr.cardMinI, lAttr.cardMaxI)) + "</entry>");
+            + getValue(getCardinality(lAttr.cardMinI, lAttr.cardMaxI)) + choiceIndicator + "</entry>");
         prDocBook.println("                    <entry>" + lValueString + "</entry>");
         prDocBook.println("                </row>");
       }
@@ -516,8 +518,10 @@ class WriteDOMDocBook extends Object {
             lMemberClassMap = new TreeMap<>();
             lMemberClassMap.put(lMemberDOMClass.title, lMemberDOMClass);
             lPropMemberClassMap.put(lDOMProp.title, lMemberClassMap);
+            String choiceIndicator = "";
+            if (lDOMProp.isChoice) choiceIndicator = " - Choice";
             lPropCardMap.put(lDOMProp.title,
-                getValue(getCardinality(lDOMProp.cardMinI, lDOMProp.cardMaxI)));
+                getValue((getCardinality(lDOMProp.cardMinI, lDOMProp.cardMaxI)) + choiceIndicator));
           }
         }
       }
@@ -535,6 +539,7 @@ class WriteDOMDocBook extends Object {
             lValueString += lValueDel + getClassLink(lMemberClass);
             lValueDel = ", ";
           }
+
           prDocBook.println("                <row>");
           prDocBook.println("                    <entry></entry>");
           prDocBook

--- a/model-lddtool/pom.xml
+++ b/model-lddtool/pom.xml
@@ -191,7 +191,7 @@
     <dependency>
         <groupId>gov.nasa.pds</groupId>
         <artifactId>validate</artifactId>
-        <version>3.7.0-SNAPSHOT</version>
+        <version>3.8.0-SNAPSHOT</version>
         <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Generated LDD documentation does not handle xs:choice right

## 🗒️ Summary
In the PDS4 Data Dictionary, the classes and attributes that are members of choice blocks were not indicated as members of a choice block. The choice blocks are now detected and a "Choice" indicator was added to the cardinality cell in the table.

## ⚙️ Test Data and/or Report
The following 19 classes and attributes, identified as being members of choice blocks, now have a "Choice" indicator in the associated cardinality cell of the dictionary document. 
    Bundle_Member_Entry
    Internal_Reference
    Product_Context
    Record_Binary
    Record_Character
    Record_Delimited
    Citation_Information
    Document
    File_Area_Ancillary
    File_Area_Browse
    File_Area_Metadata
    File_Area_Native
    File_Area_Observational
    File_Area_Observational_Supplemental
    Group_Field_Binary
    Group_Field_Character
    Group_Field_Delimited
    DD_Class
    File_Area_Update *Deprecated*

[See comment below for additional context for testing](https://github.com/NASA-PDS/pds4-information-model/pull/925#issuecomment-2905894112)

## ♻️ Related Issues
Resolves #916


