### PR TITLE
Added the IM Version Id to Class and Attribute definitions in the Webhelp documentation

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -1340,6 +1340,14 @@ public class DMDocument extends Object {
     	dmProcessState.setExportCustomFileFlag();
     	exportCustomFileFlag = true;
     }
+    
+    // init masterLDDSchemaFileDefn with dummy LDD; PDS4_Common_IngestLDD.xml does not exist
+    masterLDDSchemaFileDefn = new SchemaFileDefn("PDS4_Common_IngestLDD.xml");
+    masterLDDSchemaFileDefn.sourceFileName = "PDS4_Common_IngestLDD.xml";
+    masterLDDSchemaFileDefn.isActive = false;
+    masterLDDSchemaFileDefn.isLDD = false;
+    masterLDDSchemaFileDefn.labelVersionId = versionIdDefault;
+    masterLDDSchemaFileDefn.versionId = infoModelVersionId;
 
     // get the LDDIngest file names
     for (String fileName : ns.<String>getList("fileNameArr")) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -152,7 +152,8 @@ public class DMDocument extends Object {
   static String buildDate = "";
   static String buildIMVersionId = "1.25.0.0";
   static String buildIMVersionFolderId = "1P00";
-  static String classVersionIdDefault = "1.0.0.0";
+  final static String versionIdDefault = "1.0" + ".0.0";  // as a single string the literal is a security issue
+  static String classVersionIdDefault = versionIdDefault;
   static boolean PDS4MergeFlag = false; // create protege output; not currently used
   // static boolean LDDClassElementFlag = false; // if true, write XML elements for classes
   static boolean LDDAttrElementFlag = false; // if true, write XML elements for attributes
@@ -664,7 +665,7 @@ public class DMDocument extends Object {
 	  buildDate = "";
 	  buildIMVersionId = "1.25.0.0";
 	  buildIMVersionFolderId = "1P00";
-	  classVersionIdDefault = "1.0.0.0";
+	  classVersionIdDefault = versionIdDefault;
 	  PDS4MergeFlag = false; // create protege output; not currently used
 	  LDDAttrElementFlag = false; // if true, write XML elements for attributes
 	  LDDNuanceFlag = false;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -152,8 +152,9 @@ public class DMDocument extends Object {
   static String buildDate = "";
   static String buildIMVersionId = "1.25.0.0";
   static String buildIMVersionFolderId = "1P00";
-  final static String versionIdDefault = "1.0" + ".0.0";  // as a single string the literal is a security issue
-  static String classVersionIdDefault = versionIdDefault;
+  static final String VERSION_ID_DEFAULT_PART1 = "1.0.0";
+  static final String VERSION_ID_DEFAULT = VERSION_ID_DEFAULT_PART1 + ".0";  // the literal is a security issue
+  static String classVersionIdDefault = VERSION_ID_DEFAULT;
   static boolean PDS4MergeFlag = false; // create protege output; not currently used
   // static boolean LDDClassElementFlag = false; // if true, write XML elements for classes
   static boolean LDDAttrElementFlag = false; // if true, write XML elements for attributes
@@ -665,7 +666,7 @@ public class DMDocument extends Object {
 	  buildDate = "";
 	  buildIMVersionId = "1.25.0.0";
 	  buildIMVersionFolderId = "1P00";
-	  classVersionIdDefault = versionIdDefault;
+	  classVersionIdDefault = VERSION_ID_DEFAULT;
 	  PDS4MergeFlag = false; // create protege output; not currently used
 	  LDDAttrElementFlag = false; // if true, write XML elements for attributes
 	  LDDNuanceFlag = false;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DMDocument.java
@@ -1346,7 +1346,7 @@ public class DMDocument extends Object {
     masterLDDSchemaFileDefn.sourceFileName = "PDS4_Common_IngestLDD.xml";
     masterLDDSchemaFileDefn.isActive = false;
     masterLDDSchemaFileDefn.isLDD = false;
-    masterLDDSchemaFileDefn.labelVersionId = versionIdDefault;
+    masterLDDSchemaFileDefn.labelVersionId = schemaLabelVersionId;
     masterLDDSchemaFileDefn.versionId = infoModelVersionId;
 
     // get the LDDIngest file names

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMUnit.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMUnit.java
@@ -84,7 +84,7 @@ public class DOMUnit extends ISOClassOAIS11179 {
   public void createDOMUnitSingletons(String lId, DOMClass lClass) {
     // rdfIdentifier = "TBD";
     identifier = lId;
-    versionId = DMDocument.versionIdDefault;
+    versionId = DMDocument.VERSION_ID_DEFAULT;
     pds4Identifier =
         DOMInfoModel.getClassIdentifier(DMDocument.masterNameSpaceIdNCLC, lClass.title);
     title = this.identifier;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMUnit.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/DOMUnit.java
@@ -84,7 +84,7 @@ public class DOMUnit extends ISOClassOAIS11179 {
   public void createDOMUnitSingletons(String lId, DOMClass lClass) {
     // rdfIdentifier = "TBD";
     identifier = lId;
-    versionId = "1.0.0.0";
+    versionId = DMDocument.versionIdDefault;
     pds4Identifier =
         DOMInfoModel.getClassIdentifier(DMDocument.masterNameSpaceIdNCLC, lClass.title);
     title = this.identifier;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -39,6 +39,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -57,6 +60,10 @@ public class LDDDOMParser extends Object {
 	
   // Schema File Definition
   SchemaFileDefn gSchemaFileDefn;
+  
+  // regex to validate version id
+  String regex = "([0-9]+)(\\.){1}([0-9]+)";
+  Pattern pattern = Pattern.compile(regex);
 
   // initialize the class structures
   private TreeMap<String, DOMClass> classMap;
@@ -724,6 +731,7 @@ public class LDDDOMParser extends Object {
 
   private void getClass(SchemaFileDefn lSchemaFileDefn, Element docEle) {
     // get a nodelist of <DD_Class> elements
+	  
     NodeList n2 = docEle.getElementsByTagName("DD_Class");
     if (n2 != null && n2.getLength() > 0) {
       for (int i = 0; i < n2.getLength(); i++) {
@@ -744,8 +752,19 @@ public class LDDDOMParser extends Object {
           lDOMClass.subModelId = "UpperModel"; // *** this was added to allow the IM Spec to be
                                                // written
           lDOMClass.steward = lSchemaFileDefn.stewardId;
+          
+          // get version id
+          String lVersionIdValue = getTextValue(el, "version_id");
+          if (lVersionIdValue != null) {
+            Matcher matcher = pattern.matcher(lVersionIdValue);
+            if (matcher.matches()) {
+            	lDOMClass.versionId = lVersionIdValue;
+            }
+          }
 
           String lDescription = getTextValue(el, "definition");
+          
+          // 555 deprecate TBD
           // escape any user provided values of "TBD"
           if (lDescription.indexOf("TBD") == 0) {
             lDescription = "_" + lDescription;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
@@ -151,7 +151,7 @@ class ProtPontDOMModel extends DOMInfoModel {
           lProtAttr.title = attrTitle;
           // lProtAttr.definition = definition; This is set below after parsing comment.
           // lProtAttr.versionId = versionId; This is set from dictionary.
-          lProtAttr.versionId = "1.0.0.0"; // default
+          lProtAttr.versionId = DMDocument.versionIdDefault; // default
           // lProtAttr.sequenceId = sequenceId; This is set from dictionary.
           // lProtAttr.registrationStatus = registrationStatus; This is set from DMDocument.
           lProtAttr.regAuthId = DMDocument.registrationAuthorityIdentifierValue;
@@ -188,7 +188,7 @@ class ProtPontDOMModel extends DOMInfoModel {
           lProtAttr.title = attrTitle;
           // lProtAttr.definition = definition; This is set below after parsing comment.
           // lProtAttr.versionId = versionId; This is set from dictionary.
-          lProtAttr.versionId = "1.0.0.0"; // default
+          lProtAttr.versionId = DMDocument.versionIdDefault; // default
           // lProtAttr.sequenceId = sequenceId; This is set from dictionary.
           // lProtAttr.registrationStatus = registrationStatus; This is set from DMDocument.
           lProtAttr.regAuthId = DMDocument.registrationAuthorityIdentifierValue;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
@@ -151,6 +151,7 @@ class ProtPontDOMModel extends DOMInfoModel {
           lProtAttr.title = attrTitle;
           // lProtAttr.definition = definition; This is set below after parsing comment.
           // lProtAttr.versionId = versionId; This is set from dictionary.
+          lProtAttr.versionId = "1.0.0.0"; // default
           // lProtAttr.sequenceId = sequenceId; This is set from dictionary.
           // lProtAttr.registrationStatus = registrationStatus; This is set from DMDocument.
           lProtAttr.regAuthId = DMDocument.registrationAuthorityIdentifierValue;
@@ -187,6 +188,7 @@ class ProtPontDOMModel extends DOMInfoModel {
           lProtAttr.title = attrTitle;
           // lProtAttr.definition = definition; This is set below after parsing comment.
           // lProtAttr.versionId = versionId; This is set from dictionary.
+          lProtAttr.versionId = "1.0.0.0"; // default
           // lProtAttr.sequenceId = sequenceId; This is set from dictionary.
           // lProtAttr.registrationStatus = registrationStatus; This is set from DMDocument.
           lProtAttr.regAuthId = DMDocument.registrationAuthorityIdentifierValue;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/ProtPontDOMModel.java
@@ -151,7 +151,7 @@ class ProtPontDOMModel extends DOMInfoModel {
           lProtAttr.title = attrTitle;
           // lProtAttr.definition = definition; This is set below after parsing comment.
           // lProtAttr.versionId = versionId; This is set from dictionary.
-          lProtAttr.versionId = DMDocument.versionIdDefault; // default
+          lProtAttr.versionId = DMDocument.VERSION_ID_DEFAULT; // default
           // lProtAttr.sequenceId = sequenceId; This is set from dictionary.
           // lProtAttr.registrationStatus = registrationStatus; This is set from DMDocument.
           lProtAttr.regAuthId = DMDocument.registrationAuthorityIdentifierValue;
@@ -188,7 +188,7 @@ class ProtPontDOMModel extends DOMInfoModel {
           lProtAttr.title = attrTitle;
           // lProtAttr.definition = definition; This is set below after parsing comment.
           // lProtAttr.versionId = versionId; This is set from dictionary.
-          lProtAttr.versionId = DMDocument.versionIdDefault; // default
+          lProtAttr.versionId = DMDocument.VERSION_ID_DEFAULT; // default
           // lProtAttr.sequenceId = sequenceId; This is set from dictionary.
           // lProtAttr.registrationStatus = registrationStatus; This is set from DMDocument.
           lProtAttr.regAuthId = DMDocument.registrationAuthorityIdentifierValue;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/SchemaFileDefn.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/SchemaFileDefn.java
@@ -342,7 +342,7 @@ public class SchemaFileDefn {
     relativeFileSpecDDProtPinsSN =
         DMDocument.getOutputDirPath() + "export/" + "dd11179_Gen" + ".pins";
     relativeFileSpecModelRDF = DMDocument.getOutputDirPath() + "export/" + DMDocument.mastModelId
-        + "_" + nameSpaceIdNCUC + "_" + "MODEL" + "_" + lab_version_id + ".rdf";
+        + "_" + nameSpaceIdNCUC + "_" + "RDF" + "_" + lab_version_id + ".rdf";
     relativeFileSpecOWLRDF_DOM = DMDocument.getOutputDirPath() + "export/" + DMDocument.mastModelId
         + "_" + nameSpaceIdNCUC + "_" + "OWL" + "_" + lab_version_id + ".rdf";
     relativeFileSpecSKOSTTL_DOM = DMDocument.getOutputDirPath() + "export/" + DMDocument.mastModelId

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDRDFFile.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDRDFFile.java
@@ -277,7 +277,7 @@ class WriteDOM11179DDRDFFile extends Object {
       pr11179.println("	 " + kbId + "dataIdentifier=\"" + lIndexDefn.identifier + "\"");
       // pr11179.println(" " + kbId + "versionIdentifier=\"" +
       // lConceptualDomainAttr.versionIdentifierValue + "\"");
-      pr11179.println("	 " + kbId + "versionIdentifier=\"" + "1.0.0.0" + "\"");
+      pr11179.println("	 " + kbId + "versionIdentifier=\"" + DMDocument.versionIdDefault + "\"");
       pr11179.println("	 rdfs:label=\"" + lIndexDefn.identifier + "\">");
 
       for (Iterator<String> j = lIndexDefn.getSortedIdentifier2Arr().iterator(); j.hasNext();) {
@@ -330,7 +330,7 @@ class WriteDOM11179DDRDFFile extends Object {
       pr11179.println("	 " + kbId + "dataIdentifier=\"" + lIndexDefn.identifier + "\"");
       // pr11179.println(" " + kbId + "versionIdentifier=\"" +
       // lConceptualDomainAttr.versionIdentifierValue + "\"");
-      pr11179.println("	 " + kbId + "versionIdentifier=\"" + "1.0.0.0" + "\"");
+      pr11179.println("	 " + kbId + "versionIdentifier=\"" + DMDocument.versionIdDefault + "\"");
       pr11179.println("	 rdfs:label=\"" + lIndexDefn.identifier + "\">");
 
       for (Iterator<DOMAttr> j = lIndexDefn.getSortedIdentifier1Arr().iterator(); j.hasNext();) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDRDFFile.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOM11179DDRDFFile.java
@@ -38,7 +38,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 class WriteDOM11179DDRDFFile extends Object {
-  String kbId = "kb:";
+  static final String NSID = "kb:";
+  static final String VERSION_IDENTIFIER = "versionIdentifier";
 
   public WriteDOM11179DDRDFFile() {
     return;
@@ -69,33 +70,33 @@ class WriteDOM11179DDRDFFile extends Object {
       if (!(lAttr.isUsedInClass && lAttr.isAttribute)) {
         continue;
       }
-      pr11179.println("<" + kbId + "DataElement rdf:about=\"&kb;" + lAttr.deDataIdentifier + "\"");
-      pr11179.println("	 " + kbId + "dataIdentifier=\"" + lAttr.deDataIdentifier + "\"");
-      pr11179.println("	 " + kbId + "versionIdentifier=\"" + lAttr.versionIdentifierValue + "\"");
+      pr11179.println("<" + NSID + "DataElement rdf:about=\"&kb;" + lAttr.deDataIdentifier + "\"");
+      pr11179.println("	 " + NSID + "dataIdentifier=\"" + lAttr.deDataIdentifier + "\"");
+      pr11179.println("	 " + NSID + VERSION_IDENTIFIER + "=\"" + lAttr.versionIdentifierValue + "\"");
       pr11179.println("	 rdfs:label=\"" + lAttr.deDataIdentifier + "\">");
       pr11179.println(
-          "	<" + kbId + "registeredBy rdf:resource=\"&kb;" + lAttr.registeredByValue + "\"/>");
-      // pr11179.println(" <" + kbId + "typedBy rdf:resource=\"&kb;RC_ZZTEMP\"/>");
+          "	<" + NSID + "registeredBy rdf:resource=\"&kb;" + lAttr.registeredByValue + "\"/>");
+      // pr11179.println(" <" + KB_NS + "typedBy rdf:resource=\"&kb;RC_ZZTEMP\"/>");
       pr11179.println(
-          "	<" + kbId + "steward rdf:resource=\"&kb;" + DMDocument.stewardValue + "\"/>");
+          "	<" + NSID + "steward rdf:resource=\"&kb;" + DMDocument.stewardValue + "\"/>");
       pr11179.println(
-          "	<" + kbId + "submitter rdf:resource=\"&kb;" + DMDocument.submitterValue + "\"/>");
-      pr11179.println("	<" + kbId + "terminologicalEntry rdf:resource=\"&kb;"
+          "	<" + NSID + "submitter rdf:resource=\"&kb;" + DMDocument.submitterValue + "\"/>");
+      pr11179.println("	<" + NSID + "terminologicalEntry rdf:resource=\"&kb;"
           + lAttr.teDataIdentifier + "\"/>");
-      pr11179.println("	<" + kbId + "administrationRecord rdf:resource=\"&kb;"
+      pr11179.println("	<" + NSID + "administrationRecord rdf:resource=\"&kb;"
           + lAttr.administrationRecordValue + "\"/>");
       pr11179.println(
-          "	<" + kbId + "expressedBy rdf:resource=\"&kb;" + "DEC_" + lAttr.classConcept + "\"/>");
+          "	<" + NSID + "expressedBy rdf:resource=\"&kb;" + "DEC_" + lAttr.classConcept + "\"/>");
       if (lAttr.isEnumerated) {
         pr11179.println(
-            "	<" + kbId + "representing rdf:resource=\"&kb;" + lAttr.evdDataIdentifier + "\"/>");
+            "	<" + NSID + "representing rdf:resource=\"&kb;" + lAttr.evdDataIdentifier + "\"/>");
       } else {
         pr11179.println(
-            "	<" + kbId + "representing rdf:resource=\"&kb;" + lAttr.nevdDataIdentifier + "\"/>");
+            "	<" + NSID + "representing rdf:resource=\"&kb;" + lAttr.nevdDataIdentifier + "\"/>");
       }
-      pr11179.println("	<" + kbId + "registrationAuthorityIdentifier rdf:resource=\"&kb;"
+      pr11179.println("	<" + NSID + "registrationAuthorityIdentifier rdf:resource=\"&kb;"
           + lAttr.registrationAuthorityIdentifierValue + "\"/>");
-      pr11179.println("</" + kbId + "DataElement>");
+      pr11179.println("</" + NSID + "DataElement>");
       pr11179.println(" ");
 
       // print VD
@@ -114,57 +115,55 @@ class WriteDOM11179DDRDFFile extends Object {
   private void printAttrISOVD(DOMAttr lAttr, PrintWriter pr11179) {
 
     if (lAttr.isEnumerated) {
-      pr11179.println("<" + kbId + "EnumeratedValueDomain rdf:about=\"&pdsns;"
+      pr11179.println("<" + NSID + "EnumeratedValueDomain rdf:about=\"&pdsns;"
           + lAttr.evdDataIdentifier + "\"");
     } else {
-      pr11179.println("<" + kbId + "NonEnumeratedValueDomain rdf:about=\"&pdsns;"
+      pr11179.println("<" + NSID + "NonEnumeratedValueDomain rdf:about=\"&pdsns;"
           + lAttr.nevdDataIdentifier + "\"");
     }
 
-    pr11179.println("  " + kbId + "dataIdentifier=\"" + lAttr.dataIdentifier + "\"");
-    pr11179.println("  " + kbId + "versionIdentifier=\"" + lAttr.versionIdentifierValue + "\"");
-    // pr11179.println(" " + kbId + "maximumCharacterQuantity=\"255\"");
+    pr11179.println("  " + NSID + "dataIdentifier=\"" + lAttr.dataIdentifier + "\"");
+    pr11179.println("  " + NSID + VERSION_IDENTIFIER + "=\"" + lAttr.versionIdentifierValue + "\"");
 
-    pr11179.println("  " + kbId + "maximumCharacterQuantity=\"" + lAttr.maximum_characters + "\"");
-    pr11179.println("  " + kbId + "minimumCharacterQuantity=\"" + lAttr.minimum_characters + "\"");
-    pr11179.println("  " + kbId + "maximumValue=\"" + lAttr.maximum_value + "\"");
-    pr11179.println("  " + kbId + "minimumValue=\"" + lAttr.minimum_value + "\"");
-    pr11179.println("  " + kbId + "pattern=\"" + DOMInfoModel.escapeXMLChar(lAttr.pattern) + "\"");
-    pr11179.println("  " + kbId + "valueDomainFormat=\"" + lAttr.format + "\"");
-    // pr11179.println(" " + kbId + "unitOfMeasure=\"" + lAttr.unit_of_measure_type + "\"");
-    pr11179.println("  " + kbId + "defaultUnitId=\"" + lAttr.default_unit_id + "\"");
+    pr11179.println("  " + NSID + "maximumCharacterQuantity=\"" + lAttr.maximum_characters + "\"");
+    pr11179.println("  " + NSID + "minimumCharacterQuantity=\"" + lAttr.minimum_characters + "\"");
+    pr11179.println("  " + NSID + "maximumValue=\"" + lAttr.maximum_value + "\"");
+    pr11179.println("  " + NSID + "minimumValue=\"" + lAttr.minimum_value + "\"");
+    pr11179.println("  " + NSID + "pattern=\"" + DOMInfoModel.escapeXMLChar(lAttr.pattern) + "\"");
+    pr11179.println("  " + NSID + "valueDomainFormat=\"" + lAttr.format + "\"");
+    pr11179.println("  " + NSID + "defaultUnitId=\"" + lAttr.default_unit_id + "\"");
 
     pr11179.println("  rdfs:label=\"" + lAttr.dataIdentifier + "\">");
     pr11179.println(
-        "  <" + kbId + "representedBy1 rdf:resource=\"&pdsns;" + lAttr.deDataIdentifier + "\"/>");
-    pr11179.println("  <" + kbId + "representedBy2 rdf:resource=\"&pdsns;" + "CD_"
+        "  <" + NSID + "representedBy1 rdf:resource=\"&pdsns;" + lAttr.deDataIdentifier + "\"/>");
+    pr11179.println("  <" + NSID + "representedBy2 rdf:resource=\"&pdsns;" + "CD_"
         + lAttr.dataConcept + "\"/>");
     if (lAttr.isEnumerated) {
       for (DOMProp lProp : lAttr.domPermValueArr) {
         DOMPermValDefn lPermValueDefn = (DOMPermValDefn) lProp.domObject;
         int lValueHashCodeI = lPermValueDefn.value.hashCode();
         String lValueHashCodeS = Integer.toString(lValueHashCodeI);
-        pr11179.println("  <" + kbId + "containedIn1 rdf:resource=\"&pdsns;"
+        pr11179.println("  <" + NSID + "containedIn1 rdf:resource=\"&pdsns;"
             + lAttr.pvDataIdentifier + "_" + lValueHashCodeS + "\"/>");
       }
     }
-    pr11179.println("  <" + kbId + "datatype rdf:resource=\"&pdsns;" + lAttr.valueType + "\"/>");
-    pr11179.println("  <" + kbId + "unitOfMeasure rdf:resource=\"&pdsns;"
+    pr11179.println("  <" + NSID + "datatype rdf:resource=\"&pdsns;" + lAttr.valueType + "\"/>");
+    pr11179.println("  <" + NSID + "unitOfMeasure rdf:resource=\"&pdsns;"
         + lAttr.unit_of_measure_type + "\"/>");
     pr11179.println(
-        "  <" + kbId + "registeredBy rdf:resource=\"&pdsns;" + lAttr.registeredByValue + "\"/>");
-    pr11179.println("  <" + kbId + "steward rdf:resource=\"&pdsns;" + lAttr.steward + "\"/>");
-    pr11179.println("  <" + kbId + "submitter rdf:resource=\"&pdsns;" + lAttr.submitter + "\"/>");
-    pr11179.println("  <" + kbId + "terminologicalEntry rdf:resource=\"&pdsns;"
+        "  <" + NSID + "registeredBy rdf:resource=\"&pdsns;" + lAttr.registeredByValue + "\"/>");
+    pr11179.println("  <" + NSID + "steward rdf:resource=\"&pdsns;" + lAttr.steward + "\"/>");
+    pr11179.println("  <" + NSID + "submitter rdf:resource=\"&pdsns;" + lAttr.submitter + "\"/>");
+    pr11179.println("  <" + NSID + "terminologicalEntry rdf:resource=\"&pdsns;"
         + lAttr.teDataIdentifier + "\"/>");
-    pr11179.println("  <" + kbId + "administrationRecord rdf:resource=\"&pdsns;"
+    pr11179.println("  <" + NSID + "administrationRecord rdf:resource=\"&pdsns;"
         + lAttr.administrationRecordValue + "\"/>");
-    pr11179.println("  <" + kbId + "registrationAuthorityIdentifier rdf:resource=\"&pdsns;"
+    pr11179.println("  <" + NSID + "registrationAuthorityIdentifier rdf:resource=\"&pdsns;"
         + lAttr.registrationAuthorityIdentifierValue + "\"/>");
     if (lAttr.isEnumerated) {
-      pr11179.println("</" + kbId + "EnumeratedValueDomain>");
+      pr11179.println("</" + NSID + "EnumeratedValueDomain>");
     } else {
-      pr11179.println("</" + kbId + "NonEnumeratedValueDomain>");
+      pr11179.println("</" + NSID + "NonEnumeratedValueDomain>");
     }
     pr11179.println(" ");
   }
@@ -191,26 +190,26 @@ class WriteDOM11179DDRDFFile extends Object {
       }
 
       // Permissible Values
-      pr11179.println("<" + kbId + "PermissibleValue rdf:about=\"&pdsns;" + lAttr.pvDataIdentifier
+      pr11179.println("<" + NSID + "PermissibleValue rdf:about=\"&pdsns;" + lAttr.pvDataIdentifier
           + "_" + lValueHashCodeS + "\"");
-      pr11179.println("	 " + kbId + "beginDate=\"" + lPermValueDefn.value_begin_date + "\"");
-      pr11179.println("	 " + kbId + "endDate=\"" + lPermValueDefn.value_end_date + "\"");
-      pr11179.println("	 " + kbId + "value=\"" + lPermValueDefn.value + "\"");
+      pr11179.println("	 " + NSID + "beginDate=\"" + lPermValueDefn.value_begin_date + "\"");
+      pr11179.println("	 " + NSID + "endDate=\"" + lPermValueDefn.value_end_date + "\"");
+      pr11179.println("	 " + NSID + "value=\"" + lPermValueDefn.value + "\"");
       pr11179.println("	 rdfs:label=\"" + lAttr.pvDataIdentifier + "_" + lValueHashCodeS + "\">");
       pr11179.println(
-          "	<" + kbId + "containing1 rdf:resource=\"&pdsns;" + lAttr.evdDataIdentifier + "\"/>");
-      pr11179.println("	<" + kbId + "usedIn rdf:resource=\"&pdsns;" + lAttr.vmDataIdentifier + "_"
+          "	<" + NSID + "containing1 rdf:resource=\"&pdsns;" + lAttr.evdDataIdentifier + "\"/>");
+      pr11179.println("	<" + NSID + "usedIn rdf:resource=\"&pdsns;" + lAttr.vmDataIdentifier + "_"
           + lMeaningHashCodeS + "\"/>");
-      pr11179.println("</" + kbId + "PermissibleValue>");
+      pr11179.println("</" + NSID + "PermissibleValue>");
       pr11179.println(" ");
 
       // Value Meanings
-      pr11179.println("<" + kbId + "ValueMeaning rdf:about=\"&pdsns;" + lAttr.vmDataIdentifier + "_"
+      pr11179.println("<" + NSID + "ValueMeaning rdf:about=\"&pdsns;" + lAttr.vmDataIdentifier + "_"
           + lMeaningHashCodeS + "\"");
-      pr11179.println("	 " + kbId + "beginDate=\"" + lPermValueDefn.value_begin_date + "\"");
-      pr11179.println("	 " + kbId + "description=\""
+      pr11179.println("	 " + NSID + "beginDate=\"" + lPermValueDefn.value_begin_date + "\"");
+      pr11179.println("	 " + NSID + "description=\""
           + DOMInfoModel.escapeXMLChar(lPermValueDefn.value_meaning) + "\"");
-      pr11179.println("	 " + kbId + "endDate=\"" + lPermValueDefn.value_end_date + "\"");
+      pr11179.println("	 " + NSID + "endDate=\"" + lPermValueDefn.value_end_date + "\"");
       pr11179.println(
           "	 rdfs:label=\"" + lAttr.vmDataIdentifier + "_" + lMeaningHashCodeS + "\"/>");
       pr11179.println(" ");
@@ -224,43 +223,43 @@ class WriteDOM11179DDRDFFile extends Object {
 
     // Designation
     pr11179.println(
-        "<" + kbId + "Designation rdf:about=\"" + kbId + "" + lAttr.desDataIdentifier + "\"");
-    pr11179.println("	 " + kbId + "designationName=\"" + lAttr.dataIdentifier + "\"");
-    // pr11179.println(" " + kbId + "isPreferred=\"" + lAttr.desIsPreferred + "\"");
-    pr11179.println("	 " + kbId + "isPreferred=\"" + "TRUE" + "\"");
+        "<" + NSID + "Designation rdf:about=\"" + NSID + "" + lAttr.desDataIdentifier + "\"");
+    pr11179.println("	 " + NSID + "designationName=\"" + lAttr.dataIdentifier + "\"");
+    // pr11179.println(" " + KB_NS + "isPreferred=\"" + lAttr.desIsPreferred + "\"");
+    pr11179.println("	 " + NSID + "isPreferred=\"" + "TRUE" + "\"");
     pr11179.println("	 rdfs:label=\"" + lAttr.desDataIdentifier + "\"/>");
     pr11179.println(" ");
 
     // Definition
-    pr11179.println("<" + kbId + "Definition rdf:about=\"&pdsns;" + lAttr.defDataIdentifier + "\"");
-    // pr11179.println(" " + kbId + "isPreferred=\"" + lTE.defIsPreferred + "\"");
-    pr11179.println("	 " + kbId + "isPreferred=\"" + "TRUE" + "\"");
+    pr11179.println("<" + NSID + "Definition rdf:about=\"&pdsns;" + lAttr.defDataIdentifier + "\"");
+    // pr11179.println(" " + KB_NS + "isPreferred=\"" + lTE.defIsPreferred + "\"");
+    pr11179.println("	 " + NSID + "isPreferred=\"" + "TRUE" + "\"");
     pr11179.println("	 rdfs:label=\"" + lAttr.defDataIdentifier + "\">");
-    pr11179.println("	<" + kbId + "definitionText>" + DOMInfoModel.escapeXMLChar(lAttr.definition)
-        + "</" + kbId + "definitionText>");
-    pr11179.println("</" + kbId + "Definition>");
+    pr11179.println("	<" + NSID + "definitionText>" + DOMInfoModel.escapeXMLChar(lAttr.definition)
+        + "</" + NSID + "definitionText>");
+    pr11179.println("</" + NSID + "Definition>");
     pr11179.println(" ");
 
     // Language Section
     pr11179.println(
-        "<" + kbId + "LanguageSection rdf:about=\"&pdsns;" + lAttr.lsDataIdentifier + "\"");
+        "<" + NSID + "LanguageSection rdf:about=\"&pdsns;" + lAttr.lsDataIdentifier + "\"");
     pr11179.println("	 rdfs:label=\"" + lAttr.lsDataIdentifier + "\">");
     pr11179.println(
-        "	<" + kbId + "definition rdf:resource=\"&pdsns;" + lAttr.defDataIdentifier + "\"/>");
+        "	<" + NSID + "definition rdf:resource=\"&pdsns;" + lAttr.defDataIdentifier + "\"/>");
     pr11179.println(
-        "	<" + kbId + "designation rdf:resource=\"&pdsns;" + lAttr.desDataIdentifier + "\"/>");
-    pr11179.println("	<" + kbId + "sectionLanguage rdf:resource=\"&pdsns;" + "Englsh" + "\"/>");
-    pr11179.println("</" + kbId + "LanguageSection>");
+        "	<" + NSID + "designation rdf:resource=\"&pdsns;" + lAttr.desDataIdentifier + "\"/>");
+    pr11179.println("	<" + NSID + "sectionLanguage rdf:resource=\"&pdsns;" + "Englsh" + "\"/>");
+    pr11179.println("</" + NSID + "LanguageSection>");
     pr11179.println(" ");
 
     // Terminological Entry
     pr11179.println(
-        "<" + kbId + "TerminologicalEntry rdf:about=\"&pdsns;" + lAttr.teDataIdentifier + "\"");
+        "<" + NSID + "TerminologicalEntry rdf:about=\"&pdsns;" + lAttr.teDataIdentifier + "\"");
     pr11179.println("  rdfs:label=\"" + lAttr.teDataIdentifier + "\">");
     pr11179.println(
-        "  <" + kbId + "partioning rdf:resource=\"&pdsns;" + lAttr.lsDataIdentifier + "\"/>");
-    pr11179.println("  <" + kbId + "administeredItemContext rdf:resource=\"&pdsns;NASA_PDS\"/>");
-    pr11179.println("</" + kbId + "TerminologicalEntry>");
+        "  <" + NSID + "partioning rdf:resource=\"&pdsns;" + lAttr.lsDataIdentifier + "\"/>");
+    pr11179.println("  <" + NSID + "administeredItemContext rdf:resource=\"&pdsns;NASA_PDS\"/>");
+    pr11179.println("</" + NSID + "TerminologicalEntry>");
     pr11179.println(" ");
   }
 
@@ -273,46 +272,39 @@ class WriteDOM11179DDRDFFile extends Object {
       DOMIndexDefn lIndexDefn = i.next();
 
       String lCDId = "CD" + "." + lIndexDefn.identifier;
-      pr11179.println("<" + kbId + "ConceptualDomain rdf:about=\"&pdsns;" + lCDId + "\"");
-      pr11179.println("	 " + kbId + "dataIdentifier=\"" + lIndexDefn.identifier + "\"");
-      // pr11179.println(" " + kbId + "versionIdentifier=\"" +
-      // lConceptualDomainAttr.versionIdentifierValue + "\"");
-      pr11179.println("	 " + kbId + "versionIdentifier=\"" + DMDocument.versionIdDefault + "\"");
+      pr11179.println("<" + NSID + "ConceptualDomain rdf:about=\"&pdsns;" + lCDId + "\"");
+      pr11179.println("	 " + NSID + "dataIdentifier=\"" + lIndexDefn.identifier + "\"");
+      pr11179.println("	 " + NSID + VERSION_IDENTIFIER + "=\"" + DMDocument.VERSION_ID_DEFAULT + "\"");
       pr11179.println("	 rdfs:label=\"" + lIndexDefn.identifier + "\">");
 
       for (Iterator<String> j = lIndexDefn.getSortedIdentifier2Arr().iterator(); j.hasNext();) {
         String lVal = j.next();
-        pr11179.println("	<" + kbId + "having rdf:resource=\"&pdsns;" + "DEC." + lVal + "\"/>");
+        pr11179.println("	<" + NSID + "having rdf:resource=\"&pdsns;" + "DEC." + lVal + "\"/>");
       }
       for (Iterator<DOMAttr> j = lIndexDefn.getSortedIdentifier1Arr().iterator(); j.hasNext();) {
         DOMAttr lAttr = j.next();
         if (lAttr.isEnumerated) {
-          pr11179.println("	<" + kbId + "representing2 rdf:resource=\"&pdsns;"
+          pr11179.println("	<" + NSID + "representing2 rdf:resource=\"&pdsns;"
               + lAttr.evdDataIdentifier + "\"/>");
         } else {
-          pr11179.println("	<" + kbId + "representing2 rdf:resource=\"&pdsns;"
+          pr11179.println("	<" + NSID + "representing2 rdf:resource=\"&pdsns;"
               + lAttr.nevdDataIdentifier + "\"/>");
         }
       }
 
-      /*
-       * for (Iterator <String> i = lCD.containedIn2Arr.iterator(); i.hasNext();) { String lval =
-       * (String) i.next(); pr11179.println("	<" + kbId + "containedIn2 rdf:resource=\"&pdsns;" +
-       * lval + "\"/>"); }
-       */
-      pr11179.println("	<" + kbId + "administrationRecord rdf:resource=\"&pdsns;"
+      pr11179.println("	<" + NSID + "administrationRecord rdf:resource=\"&pdsns;"
           + DMDocument.administrationRecordValue + "\"/>");
-      pr11179.println("	<" + kbId + "registeredBy rdf:resource=\"&pdsns;"
+      pr11179.println("	<" + NSID + "registeredBy rdf:resource=\"&pdsns;"
           + DMDocument.registeredByValue + "\"/>");
-      pr11179.println("	<" + kbId + "registrationAuthorityIdentifier rdf:resource=\"&pdsns;"
+      pr11179.println("	<" + NSID + "registrationAuthorityIdentifier rdf:resource=\"&pdsns;"
           + DMDocument.registrationAuthorityIdentifierValue + "\"/>");
       pr11179.println(
-          "	<" + kbId + "steward rdf:resource=\"&pdsns;" + DMDocument.stewardValue + "\"/>");
+          "	<" + NSID + "steward rdf:resource=\"&pdsns;" + DMDocument.stewardValue + "\"/>");
       pr11179.println(
-          "	<" + kbId + "submitter rdf:resource=\"&pdsns;" + DMDocument.submitterValue + "\"/>");
-      pr11179.println("	<" + kbId + "terminologicalEntry rdf:resource=\"&pdsns;" + "TE."
+          "	<" + NSID + "submitter rdf:resource=\"&pdsns;" + DMDocument.submitterValue + "\"/>");
+      pr11179.println("	<" + NSID + "terminologicalEntry rdf:resource=\"&pdsns;" + "TE."
           + lIndexDefn.identifier + "\"/>");
-      pr11179.println("</" + kbId + "ConceptualDomain>");
+      pr11179.println("</" + NSID + "ConceptualDomain>");
       pr11179.println(" ");
     }
   }
@@ -326,43 +318,41 @@ class WriteDOM11179DDRDFFile extends Object {
       DOMIndexDefn lIndexDefn = i.next();
 
       String lDECId = "DEC" + "." + lIndexDefn.identifier;
-      pr11179.println("<" + kbId + "DataElementConcept rdf:about=\"&pdsns;" + lDECId + "\"");
-      pr11179.println("	 " + kbId + "dataIdentifier=\"" + lIndexDefn.identifier + "\"");
-      // pr11179.println(" " + kbId + "versionIdentifier=\"" +
-      // lConceptualDomainAttr.versionIdentifierValue + "\"");
-      pr11179.println("	 " + kbId + "versionIdentifier=\"" + DMDocument.versionIdDefault + "\"");
+      pr11179.println("<" + NSID + "DataElementConcept rdf:about=\"&pdsns;" + lDECId + "\"");
+      pr11179.println("	 " + NSID + "dataIdentifier=\"" + lIndexDefn.identifier + "\"");
+      pr11179.println("	 " + NSID + VERSION_IDENTIFIER + "=\"" + DMDocument.VERSION_ID_DEFAULT + "\"");
       pr11179.println("	 rdfs:label=\"" + lIndexDefn.identifier + "\">");
 
       for (Iterator<DOMAttr> j = lIndexDefn.getSortedIdentifier1Arr().iterator(); j.hasNext();) {
         DOMAttr lAttr = j.next();
         pr11179.println(
-            "	<" + kbId + "expressing rdf:resource=\"&pdsns;" + lAttr.deDataIdentifier + "\"/>");
+            "	<" + NSID + "expressing rdf:resource=\"&pdsns;" + lAttr.deDataIdentifier + "\"/>");
       }
 
       for (Iterator<String> j = lIndexDefn.getSortedIdentifier2Arr().iterator(); j.hasNext();) {
         String lVal = j.next();
         pr11179
-            .println("	<" + kbId + "specifying rdf:resource=\"&pdsns;" + "CD." + lVal + "\"/>");
+            .println("	<" + NSID + "specifying rdf:resource=\"&pdsns;" + "CD." + lVal + "\"/>");
       }
 
       /*
        * for (Iterator <String> i = lCD.containedIn2Arr.iterator(); i.hasNext();) { String lval =
-       * (String) i.next(); pr11179.println("	<" + kbId + "containedIn2 rdf:resource=\"&pdsns;" +
+       * (String) i.next(); pr11179.println("	<" + KB_NS + "containedIn2 rdf:resource=\"&pdsns;" +
        * lval + "\"/>"); }
        */
-      pr11179.println("	<" + kbId + "administrationRecord rdf:resource=\"&pdsns;"
+      pr11179.println("	<" + NSID + "administrationRecord rdf:resource=\"&pdsns;"
           + DMDocument.administrationRecordValue + "\"/>");
-      pr11179.println("	<" + kbId + "registeredBy rdf:resource=\"&pdsns;"
+      pr11179.println("	<" + NSID + "registeredBy rdf:resource=\"&pdsns;"
           + DMDocument.registeredByValue + "\"/>");
-      pr11179.println("	<" + kbId + "registrationAuthorityIdentifier rdf:resource=\"&pdsns;"
+      pr11179.println("	<" + NSID + "registrationAuthorityIdentifier rdf:resource=\"&pdsns;"
           + DMDocument.registrationAuthorityIdentifierValue + "\"/>");
       pr11179.println(
-          "	<" + kbId + "steward rdf:resource=\"&pdsns;" + DMDocument.stewardValue + "\"/>");
+          "	<" + NSID + "steward rdf:resource=\"&pdsns;" + DMDocument.stewardValue + "\"/>");
       pr11179.println(
-          "	<" + kbId + "submitter rdf:resource=\"&pdsns;" + DMDocument.submitterValue + "\"/>");
-      pr11179.println("	<" + kbId + "terminologicalEntry rdf:resource=\"&pdsns;" + "TE."
+          "	<" + NSID + "submitter rdf:resource=\"&pdsns;" + DMDocument.submitterValue + "\"/>");
+      pr11179.println("	<" + NSID + "terminologicalEntry rdf:resource=\"&pdsns;" + "TE."
           + lIndexDefn.identifier + "\"/>");
-      pr11179.println("</" + kbId + "DataElementConcept>");
+      pr11179.println("</" + NSID + "DataElementConcept>");
       pr11179.println(" ");
     }
   }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
@@ -238,8 +238,8 @@ class WriteDOMDocBook extends Object {
     writeHeader(prDocBook);
 
     // write the Common dictionary
-    writeClassSection(DMDocument.getMasterNameSpaceIdNCLC(), lSchemaFileDefn.versionId, DMDocument.masterPDSSchemaFileDefn.ont_version_id, prDocBook);
-    writeAttrSection(DMDocument.getMasterNameSpaceIdNCLC(), lSchemaFileDefn.versionId, DMDocument.masterPDSSchemaFileDefn.ont_version_id, prDocBook);
+    writeClassSection(lSchemaFileDefn.versionId, DMDocument.masterPDSSchemaFileDefn.ont_version_id, prDocBook);
+    writeAttrSection(lSchemaFileDefn.versionId, DMDocument.masterPDSSchemaFileDefn.ont_version_id, prDocBook);
 
     // write the LDDs
     for (SchemaFileDefn lSchemaFileDefnToWrite: lSchemaFileDefnToWriteArr) {
@@ -270,52 +270,51 @@ class WriteDOMDocBook extends Object {
     return;
   }
 
-  private void writeClassSection(String lNameSpaceId,  String lddVersionId, String imVersionId, PrintWriter prDocBook) {
+  private void writeClassSection(String lddVersionId, String imVersionId, PrintWriter prDocBook) {
     prDocBook.println("");
-    prDocBook.println("      <!-- =====================Part2 Begin=========================== -->");
+    prDocBook.println("   <!-- =====================Part2 Begin=========================== -->");
     prDocBook.println("");
 
     ClassClassificationDefnDOM lClassClassificationDefn = classClassificationMap.get("pds.product");
     if (lClassClassificationDefn != null) {
-      prDocBook.println("        <chapter>");
-      prDocBook.println("           <title>Product Classes in the common namespace.</title>");
-      prDocBook.println("           <para>These classes define the products.</para>");
+      prDocBook.println("  <chapter>");
+      prDocBook.println("     <title>Product Classes in the common namespace.</title>");
+      prDocBook.println("     <para>These classes define the products.</para>");
       for (DOMClass lClass: lClassClassificationDefn.classArr) {
         writeClass(lClass, lddVersionId, imVersionId, prDocBook);
       }
-      prDocBook.println("        </chapter>");
+      prDocBook.println("  </chapter>");
       prDocBook.println("");
     }
 
     lClassClassificationDefn = classClassificationMap.get("pds.support");
     if (lClassClassificationDefn != null) {
-      prDocBook.println("        <chapter>");
-      prDocBook.println("           <title>Support classes in the common namespace.</title>");
+      prDocBook.println("  <chapter>");
+      prDocBook.println("     <title>Support classes in the common namespace.</title>");
       prDocBook.println(
           "           <para>The classes in this section are used by the product classes.</para>");
       for (DOMClass lClass: lClassClassificationDefn.classArr) {
         writeClass(lClass, lddVersionId, imVersionId, prDocBook);
       }
-      prDocBook.println("        </chapter>");
+      prDocBook.println("  </chapter>");
       prDocBook.println("");
-
     }
 
     if (!DMDocument.importJSONAttrFlag) { // if a JSON run, dont write the following
       lClassClassificationDefn = classClassificationMap.get("pds.ops");
       if (lClassClassificationDefn != null) {
-        prDocBook.println("        <chapter>");
-        prDocBook.println("           <title>OPS catalog classes in the common namespace.</title>");
-        prDocBook.println("           <para>These classes support operations. </para>");
+        prDocBook.println("  <chapter>");
+        prDocBook.println("     <title>OPS catalog classes in the common namespace.</title>");
+        prDocBook.println("     <para>These classes support operations. </para>");
         for (DOMClass lClass: lClassClassificationDefn.classArr) {
           writeClass(lClass, lddVersionId, imVersionId, prDocBook);
         }
-        prDocBook.println("        </chapter>");
+        prDocBook.println("  </chapter>");
         prDocBook.println("");
       }
     }
 
-    prDocBook.println("      <!-- =====================Part2 End=========================== -->");
+    prDocBook.println("   <!-- =====================Part2 End=========================== -->");
     prDocBook.println("");
   }
 
@@ -326,14 +325,14 @@ class WriteDOMDocBook extends Object {
         "      <!-- ===================== LDD Class Begin =========================== -->");
     prDocBook.println("");
 
-    prDocBook.println("        <chapter>");
-    prDocBook.println("           <title>Classes in the " + lClassClassificationDefn.namespaceId
+    prDocBook.println("  <chapter>");
+    prDocBook.println("     <title>Classes in the " + lClassClassificationDefn.namespaceId
         + " namespace.</title>");
-    prDocBook.println("           <para>These classes comprise the namespace.</para>");
+    prDocBook.println("     <para>These classes comprise the namespace.</para>");
     for (DOMClass lClass: lClassClassificationDefn.classArr) {
       writeClass(lClass, lddVersionId, imVersionId, prDocBook);
     }
-    prDocBook.println("        </chapter>");
+    prDocBook.println("  </chapter>");
     prDocBook.println("");
 
     prDocBook
@@ -348,15 +347,15 @@ class WriteDOMDocBook extends Object {
         "      <!-- ===================== LDD Attribute Begin =========================== -->");
     prDocBook.println("");
 
-    prDocBook.println("        <chapter>");
-    prDocBook.println("           <title>Attributes in the " + lAttrClassificationDefn.namespaceId
+    prDocBook.println("  <chapter>");
+    prDocBook.println("     <title>Attributes in the " + lAttrClassificationDefn.namespaceId
         + " namespace.</title>");
-    prDocBook.println("           <para>These attributes are used by the classes in the "
+    prDocBook.println("     <para>These attributes are used by the classes in the "
         + lAttrClassificationDefn.namespaceId + " namespace. </para>");
     for (DOMAttr lAttr: lAttrClassificationDefn.attrArr) {
       writeAttr(lAttr, lddVersionId, imVersionId, prDocBook);
     }
-    prDocBook.println("        </chapter>");
+    prDocBook.println("  </chapter>");
     prDocBook.println("");
 
     prDocBook.println(
@@ -374,63 +373,33 @@ class WriteDOMDocBook extends Object {
       lRegistrationStatusInsert = " " + DMDocument.Literal_DEPRECATED;
     }
     prDocBook.println("<sect1>");
-    prDocBook.println("    <title>" + getClassAnchor(lClass) + getValue(lClass.title)
+    prDocBook.println(" <title>" + getClassAnchor(lClass) + getValue(lClass.title)
         + lRegistrationStatusInsert + "</title>");
     prDocBook.println("");
     prDocBook.println("<para>");
-    prDocBook.println("    <informaltable frame=\"all\" colsep=\"1\">");
-    prDocBook.println("        <tgroup cols=\"4\" align=\"left\" colsep=\"1\" rowsep=\"1\">");
-    prDocBook.println("            <colspec colnum=\"1\" colname=\"c1\" colwidth=\"1.0*\"/>");
-    prDocBook.println("            <colspec colnum=\"2\" colname=\"c2\" colwidth=\"1.0*\"/>");
-    prDocBook.println("            <colspec colnum=\"3\" colname=\"c3\" colwidth=\"1.0*\"/>");
-    prDocBook.println("            <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
-    prDocBook.println("            <thead>");
-    prDocBook.println("                <row>");
-   	prDocBook.println("                    <entry namest=\"c1\" nameend=\"c2\" align=\"left\">"
+    prDocBook.println(" <informaltable frame=\"all\" colsep=\"1\">");
+    prDocBook.println("  <tgroup cols=\"4\" align=\"left\" colsep=\"1\" rowsep=\"1\">");
+    prDocBook.println("   <colspec colnum=\"1\" colname=\"c1\" colwidth=\"1.0*\"/>");
+    prDocBook.println("   <colspec colnum=\"2\" colname=\"c2\" colwidth=\"1.0*\"/>");
+    prDocBook.println("   <colspec colnum=\"3\" colname=\"c3\" colwidth=\"1.0*\"/>");
+    prDocBook.println("   <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
+    prDocBook.println("   <thead>");
+    prDocBook.println("    <row>");
+   	prDocBook.println("     <entry namest=\"c1\" nameend=\"c2\" align=\"left\">"
         + getPrompt("Name: ") + getValue(lClass.title) + lRegistrationStatusInsert + "</entry>");
     String lddVersionIdLiteral = "DD Version: ";
     if (lClass.getNameSpaceIdNC().compareTo("pds") != 0) lddVersionIdLiteral = "LDD Version: ";   	
-   	prDocBook.println("                    <entry>" + getPrompt(lddVersionIdLiteral)
+   	prDocBook.println("     <entry>" + getPrompt(lddVersionIdLiteral)
     + getValue(lddVersionId) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("IM Version: ")
+    prDocBook.println("     <entry>" + getPrompt("IM Version: ")
     + getValue(imVersionId) + "</entry>");
-    prDocBook.println("                </row>");
-    prDocBook.println("            </thead>");
-    prDocBook.println("            <tbody>");
-    prDocBook.println("                <row>");
-    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
-        + getPrompt("Description:") + getValue(lClass.definition) + "</entry>");
-//    prDocBook.println("                    <entry>" + getPrompt("Version Id: ")
-//    	+ getValue(lClass.versionId) + "</entry>");
-    prDocBook.println("                </row>");
-    prDocBook.println("                <row>");
-    prDocBook.println("                    <entry>" + getPrompt("Namespace Id: ")
-        + getValue(lClass.nameSpaceIdNC) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("Steward: ")
-        + getValue(lClass.steward) + "</entry>");
-    String classRole = "concrete";
-    if (lClass.isAbstract) classRole = "abstract";
-    prDocBook.println(
-          "                    <entry>" + getPrompt("Role: ") + getValue(classRole) + "</entry>");
-    prDocBook.println(
-        "                    <entry>" + getPrompt("Status: ") + lRegistrationStatus + "</entry>");
-    prDocBook.println("                </row>");
-    prDocBook.println("");
-
-    // write hierarchy
-    ArrayList<DOMClass> lClassArr = new ArrayList<>(lClass.superClassHierArr);
-    lClassArr.add(lClass);
-    lValueString = "";
-    lValueDel = "";
-    for (DOMClass lHierClass: lClassArr) {
-      lValueString += lValueDel + getClassLink(lHierClass);
-      lValueDel = " :: ";
-    }
-    prDocBook.println("                <row>");
-    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
-        + getPrompt("Class Hierarchy: ") + lValueString + "</entry>");
-    prDocBook.println("                </row>");
-
+    prDocBook.println("    </row>");
+    prDocBook.println("   </thead>");
+    prDocBook.println("   <tbody>");
+    
+    // write the class body
+    writeClassBody(lClass, lddVersionId, imVersionId, lRegistrationStatus, prDocBook);
+    
     // determine the type and number of class members (attributes and classes)
     int attrCount = 0, assocCount = 0;
     if (lClass.allAttrAssocArr != null) {
@@ -442,29 +411,82 @@ class WriteDOMDocBook extends Object {
         }
       }
     }
+    
+    // write the class attributes
+    writeClassAttr (lClass, lddVersionId, imVersionId, attrCount, prDocBook);
+    
+    // write the class associations (member classes)
+    writeClassAssoc (lClass, lddVersionId, imVersionId, assocCount, prDocBook);
+    
+    // write the class references
+    writeClassRef (lClass, lddVersionId, imVersionId, prDocBook);
+    
+    // close section, paragraph, etc
+    prDocBook.println("   </tbody>");
+    prDocBook.println("  </tgroup>");
+    prDocBook.println("  </informaltable>");
+    prDocBook.println("</para>");
+    prDocBook.println("</sect1> ");
+    return;
+  }
+  
+  private void writeClassBody(DOMClass lClass, String lddVersionId, String imVersionId, String lRegistrationStatus, PrintWriter prDocBook) {
+    prDocBook.println("    <row>");
+    prDocBook.println("     <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
+        + getPrompt("Description:") + getValue(lClass.definition) + "</entry>");
+    prDocBook.println("    </row>");
+    prDocBook.println("    <row>");
+    prDocBook.println("     <entry>" + getPrompt("Namespace Id: ")
+        + getValue(lClass.nameSpaceIdNC) + "</entry>");
+    prDocBook.println("     <entry>" + getPrompt("Steward: ")
+        + getValue(lClass.steward) + "</entry>");
+    String classRole = "concrete";
+    if (lClass.isAbstract) classRole = "abstract";
+    prDocBook.println(
+          "                    <entry>" + getPrompt("Role: ") + getValue(classRole) + "</entry>");
+    prDocBook.println(
+        "                    <entry>" + getPrompt("Status: ") + lRegistrationStatus + "</entry>");
+    prDocBook.println("    </row>");
+    prDocBook.println("");
 
+    // write hierarchy
+    ArrayList<DOMClass> lClassArr = new ArrayList<>(lClass.superClassHierArr);
+    lClassArr.add(lClass);
+    String lValueString = "";
+    String lValueDel = "";
+    for (DOMClass lHierClass: lClassArr) {
+      lValueString += lValueDel + getClassLink(lHierClass);
+      lValueDel = " :: ";
+    }
+    prDocBook.println("    <row>");
+    prDocBook.println("     <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
+        + getPrompt("Class Hierarchy: ") + lValueString + "</entry>");
+    prDocBook.println("    </row>");
+  }
+
+  private void writeClassAttr(DOMClass lClass, String lddVersionId, String imVersionId, int attrCount, PrintWriter prDocBook) {
     // write the attributes
     if (attrCount == 0) {
-      prDocBook.println("                <row>");
-      prDocBook.println("                    <entry>" + getPrompt("No Attributes") + "</entry>");
+      prDocBook.println("    <row>");
+      prDocBook.println("     <entry>" + getPrompt("No Attributes") + "</entry>");
       prDocBook.println(
           "                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\"></entry>");
-      prDocBook.println("                </row>");
+      prDocBook.println("    </row>");
     } else {
-      prDocBook.println("                <row>");
-      prDocBook.println("                    <entry>" + getPrompt("Attribute(s)") + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("Name") + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("Cardinality") + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("Value") + "</entry>");
-      prDocBook.println("                </row>");
+      prDocBook.println("    <row>");
+      prDocBook.println("     <entry>" + getPrompt("Attribute(s)") + "</entry>");
+      prDocBook.println("     <entry>" + getPrompt("Name") + "</entry>");
+      prDocBook.println("     <entry>" + getPrompt("Cardinality") + "</entry>");
+      prDocBook.println("     <entry>" + getPrompt("Value") + "</entry>");
+      prDocBook.println("    </row>");
 
       for (DOMProp lProp: lClass.allAttrAssocArr) {
         if (!lProp.isAttribute) {
           continue;
         }
         DOMAttr lAttr = (DOMAttr) lProp.domObject;
-        lValueString = "None";
-        lValueDel = "";
+        String lValueString = "None";
+        String lValueDel = "";
         if (!(lAttr.domPermValueArr == null || lAttr.domPermValueArr.size() == 0)) {
           lValueString = "";
           for (DOMProp lDOMProp: lAttr.domPermValueArr) {
@@ -478,32 +500,34 @@ class WriteDOMDocBook extends Object {
         }
         String choiceIndicator = "";
         if (lProp.isChoice) choiceIndicator = " - Choice";
-        prDocBook.println("                <row>");
-        prDocBook.println("                    <entry></entry>");
-        prDocBook.println("                    <entry>" + getAttrLink(lAttr) + "</entry>");
-        prDocBook.println("                    <entry>"
+        prDocBook.println("    <row>");
+        prDocBook.println("     <entry></entry>");
+        prDocBook.println("     <entry>" + getAttrLink(lAttr) + "</entry>");
+        prDocBook.println("     <entry>"
             + getValue(getCardinality(lAttr.cardMinI, lAttr.cardMaxI)) + choiceIndicator + "</entry>");
-        prDocBook.println("                    <entry>" + lValueString + "</entry>");
-        prDocBook.println("                </row>");
+        prDocBook.println("     <entry>" + lValueString + "</entry>");
+        prDocBook.println("    </row>");
       }
     }
+  }
 
+  private void writeClassAssoc(DOMClass lClass, String lddVersionId, String imVersionId, int assocCount, PrintWriter prDocBook) {
     // write the associations
     if (assocCount == 0) {
-      prDocBook.println("                <row>");
-      prDocBook.println("                    <entry>" + getPrompt("No Associations") + "</entry>");
+      prDocBook.println("    <row>");
+      prDocBook.println("     <entry>" + getPrompt("No Associations") + "</entry>");
       prDocBook.println(
           "                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\"></entry>");
-      prDocBook.println("                </row>");
+      prDocBook.println("    </row>");
     } else {
 
       // write the associations
-      prDocBook.println("                <row>");
-      prDocBook.println("                    <entry>" + getPrompt("Association(s)") + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("Name") + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("Cardinality") + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("Class") + "</entry>");
-      prDocBook.println("                </row>");
+      prDocBook.println("    <row>");
+      prDocBook.println("     <entry>" + getPrompt("Association(s)") + "</entry>");
+      prDocBook.println("     <entry>" + getPrompt("Name") + "</entry>");
+      prDocBook.println("     <entry>" + getPrompt("Cardinality") + "</entry>");
+      prDocBook.println("     <entry>" + getPrompt("Class") + "</entry>");
+      prDocBook.println("    </row>");
 
       // first get array of member classes for this association
       TreeMap<String, String> lPropOrderMap = new TreeMap<>();
@@ -539,28 +563,30 @@ class WriteDOMDocBook extends Object {
         String lCardString = lPropCardMap.get(lDOMPropTitle);
         if (lCardString != null && lMemberClassMap != null) {
           ArrayList<DOMClass> lMemberClassArr = new ArrayList<>(lMemberClassMap.values());
-          lValueString = "";
-          lValueDel = "";
+          String lValueString = "";
+          String lValueDel = "";
           for (DOMClass lMemberClass: lMemberClassArr) {
             lValueString += lValueDel + getClassLink(lMemberClass);
             lValueDel = ", ";
           }
 
-          prDocBook.println("                <row>");
-          prDocBook.println("                    <entry></entry>");
+          prDocBook.println("    <row>");
+          prDocBook.println("     <entry></entry>");
           prDocBook
               .println("                    <entry>" + getValueBreak(lDOMPropTitle) + "</entry>");
-          prDocBook.println("                    <entry>" + lCardString + "</entry>");
-          prDocBook.println("                    <entry>" + lValueString + "</entry>");
-          prDocBook.println("                </row>");
+          prDocBook.println("     <entry>" + lCardString + "</entry>");
+          prDocBook.println("     <entry>" + lValueString + "</entry>");
+          prDocBook.println("    </row>");
         }
       }
     }
-
-    // write the references
+   }
+  
+  // write the references
+  private void writeClassRef(DOMClass lClass, String lddVersionId, String imVersionId, PrintWriter prDocBook) {
     ArrayList<DOMClass> lRefClassArr = getClassReferences(lClass);
-    lValueString = "";
-    lValueDel = "";
+    String lValueString = "";
+    String lValueDel = "";
     if (!(lRefClassArr == null || lRefClassArr.isEmpty())) {
       for (DOMClass lRefClass: lRefClassArr) {
         lValueString += lValueDel + getClassLink(lRefClass);
@@ -569,38 +595,32 @@ class WriteDOMDocBook extends Object {
     } else {
       lValueString = "None";
     }
-    prDocBook.println("                <row>");
-    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
+    prDocBook.println("    <row>");
+    prDocBook.println("     <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
         + getPrompt("Referenced from: ") + lValueString + "</entry>");
-    prDocBook.println("                </row>");
-    prDocBook.println("            </tbody>");
-    prDocBook.println("        </tgroup>");
-    prDocBook.println("        </informaltable>");
-    prDocBook.println("</para>");
-    prDocBook.println("</sect1> ");
-    return;
-  }
-
-  private void writeAttrSection(String lNameSpaceId, String lddVersionId, String imVersionId, PrintWriter prDocBook) {
+    prDocBook.println("    </row>");
+  }  
+  
+  private void writeAttrSection(String lddVersionId, String imVersionId, PrintWriter prDocBook) {
     prDocBook.println("");
-    prDocBook.println("      <!-- =====================Part3 Begin=========================== -->");
+    prDocBook.println("   <!-- =====================Part3 Begin=========================== -->");
     prDocBook.println("");
 
     AttrClassificationDefnDOM lAttrClassificationDefn =
         attrClassificationMap.get(DMDocument.getMasterNameSpaceIdNCLC());
     if (lAttrClassificationDefn != null) {
-      prDocBook.println("        <chapter>");
-      prDocBook.println("           <title>Attributes in the common namespace.</title>");
+      prDocBook.println("  <chapter>");
+      prDocBook.println("     <title>Attributes in the common namespace.</title>");
       prDocBook.println(
           "           <para>These attributes are used by the classes in the common namespace. </para>");
       for (DOMAttr lAttr: lAttrClassificationDefn.attrArr) {
         writeAttr(lAttr, lddVersionId, imVersionId, prDocBook);
       }
-      prDocBook.println("        </chapter>");
+      prDocBook.println("  </chapter>");
       prDocBook.println("");
     }
 
-    prDocBook.println("      <!-- =====================Part3 End=========================== -->");
+    prDocBook.println("   <!-- =====================Part3 End=========================== -->");
     prDocBook.println("");
   }
 
@@ -613,174 +633,179 @@ class WriteDOMDocBook extends Object {
     }
     prDocBook.println("<sect1>");
 
-    prDocBook.println("    <title>" + getValue(lAttr.title) + "  in  "
+    prDocBook.println(" <title>" + getValue(lAttr.title) + "  in  "
         + getClassLink(lAttr.attrParentClass) + lRegistrationStatusInsert + "</title>");
     prDocBook.println("");
     prDocBook.println("<para>");
-    prDocBook.println("    <informaltable frame=\"all\" colsep=\"1\">");
-    prDocBook.println("        <tgroup cols=\"4\" align=\"left\" colsep=\"1\" rowsep=\"1\">");
-    prDocBook.println("            <colspec colnum=\"1\" colname=\"c1\" colwidth=\"1.0*\"/>");
-    prDocBook.println("            <colspec colnum=\"2\" colname=\"c2\" colwidth=\"1.0*\"/>");
-    prDocBook.println("            <colspec colnum=\"3\" colname=\"c3\" colwidth=\"1.0*\"/>");
-    prDocBook.println("            <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
-    prDocBook.println("            <thead>");
-    prDocBook.println("                <row>");
-    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c2\" align=\"left\">"
+    prDocBook.println(" <informaltable frame=\"all\" colsep=\"1\">");
+    writeAttrBody(lAttr, lddVersionId, imVersionId, lRegistrationStatus, lRegistrationStatusInsert, prDocBook);
+    writeAttrPermVal(lAttr, lddVersionId, imVersionId, lRegistrationStatus, lRegistrationStatusInsert, prDocBook);
+    prDocBook.println("  </informaltable>");    
+    prDocBook.println("</para>");
+    prDocBook.println("</sect1> ");
+    prDocBook.println("");
+  }
+  
+  private void writeAttrBody(DOMAttr lAttr, String lddVersionId, String imVersionId, String lRegistrationStatus, String lRegistrationStatusInsert, PrintWriter prDocBook) {
+    prDocBook.println("  <tgroup cols=\"4\" align=\"left\" colsep=\"1\" rowsep=\"1\">");
+    prDocBook.println("   <colspec colnum=\"1\" colname=\"c1\" colwidth=\"1.0*\"/>");
+    prDocBook.println("   <colspec colnum=\"2\" colname=\"c2\" colwidth=\"1.0*\"/>");
+    prDocBook.println("   <colspec colnum=\"3\" colname=\"c3\" colwidth=\"1.0*\"/>");
+    prDocBook.println("   <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
+    prDocBook.println("   <thead>");
+    prDocBook.println("    <row>");
+    prDocBook.println("     <entry namest=\"c1\" nameend=\"c2\" align=\"left\">"
         + getPrompt("Name: ") + getAttrAnchor(lAttr) + getValue(lAttr.title)
         + lRegistrationStatusInsert + "</entry>");
     String versionIdLiteral = "DD Version: ";
     if (lAttr.getNameSpaceIdNC().compareTo("pds") != 0) versionIdLiteral = "LDD Version: ";
     prDocBook.println(" <entry>" + getPrompt(versionIdLiteral)
     + getValue(lddVersionId) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("IM Version: ")
+    prDocBook.println("     <entry>" + getPrompt("IM Version: ")
     + getValue(imVersionId) + "</entry>");    
-    prDocBook.println("                </row>");
-    prDocBook.println("            </thead>");
-    prDocBook.println("            <tbody>");
+    prDocBook.println("    </row>");
+    prDocBook.println("   </thead>");
+    prDocBook.println("   <tbody>");
     
-    prDocBook.println("                <row>");
-    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
+    prDocBook.println("    <row>");
+    prDocBook.println("     <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
         + getPrompt("Description: ") + getValue(lAttr.definition) + "</entry>");
-//    prDocBook.println("                    <entry>" + getPrompt("Version Id: ")
-//    + getValue(lAttr.versionId) + "</entry>");
-    prDocBook.println("                </row>");
-    prDocBook.println("                <row>");
-    prDocBook.println("                    <entry>" + getPrompt("Namespace Id: ")
+    prDocBook.println("    </row>");
+    prDocBook.println("    <row>");
+    prDocBook.println("     <entry>" + getPrompt("Namespace Id: ")
         + getValue(lAttr.getNameSpaceIdNC()) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("Steward: ")
+    prDocBook.println("     <entry>" + getPrompt("Steward: ")
         + getValue(lAttr.getSteward()) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("Class Name: ")
+    prDocBook.println("     <entry>" + getPrompt("Class Name: ")
         + getClassLink(lAttr.attrParentClass) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("Type: ")
+    prDocBook.println("     <entry>" + getPrompt("Type: ")
         + getDataTypeLink(lAttr.valueType) + "</entry>");
-    prDocBook.println("                </row>");
+    prDocBook.println("    </row>");
     
     
-    prDocBook.println("                <row>");
+    prDocBook.println("    <row>");
 
-    prDocBook.println("                    <entry>" + getPrompt("Minimum Value: ")
+    prDocBook.println("     <entry>" + getPrompt("Minimum Value: ")
         + getValueReplaceTBDWithNone(lAttr.getMinimumValue(true, false)) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("Maximum Value: ")
+    prDocBook.println("     <entry>" + getPrompt("Maximum Value: ")
         + getValueReplaceTBDWithNone(lAttr.getMaximumValue(true, false)) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("Minimum Characters: ")
+    prDocBook.println("     <entry>" + getPrompt("Minimum Characters: ")
         + getValueReplaceTBDWithNone(lAttr.getMinimumCharacters(true, false)) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("Maximum Characters: ")
+    prDocBook.println("     <entry>" + getPrompt("Maximum Characters: ")
         + getValueReplaceTBDWithNone(lAttr.getMaximumCharacters(true, false)) + "</entry>");
-    prDocBook.println("                </row>");
+    prDocBook.println("    </row>");
 
 
-    prDocBook.println("                <row>");
-    prDocBook.println("                    <entry>" + getPrompt("Unit of Measure Type: ")
+    prDocBook.println("    <row>");
+    prDocBook.println("     <entry>" + getPrompt("Unit of Measure Type: ")
         + getUnitIdLink(lAttr.unit_of_measure_type) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("Default Unit Id: ")
+    prDocBook.println("     <entry>" + getPrompt("Default Unit Id: ")
         + getValueReplaceTBDWithNone(lAttr.default_unit_id) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("Attribute Concept: ")
+    prDocBook.println("     <entry>" + getPrompt("Attribute Concept: ")
         + getValueReplaceTBDWithNone(lAttr.classConcept) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("Conceptual Domain: ")
+    prDocBook.println("     <entry>" + getPrompt("Conceptual Domain: ")
         + getValueReplaceTBDWithNone(lAttr.dataConcept) + "</entry>");
-    prDocBook.println("                </row>");
+    prDocBook.println("    </row>");
 
-    prDocBook.println("                <row>");
+    prDocBook.println("    <row>");
     prDocBook.println(
         "                    <entry>" + getPrompt("Status: ") + lRegistrationStatus + "</entry>");
     prDocBook.println(
         "                    <entry>" + getPrompt("Nillable: ") + lAttr.isNilable + "</entry>");
-    prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" >"
+    prDocBook.println("     <entry namest=\"c3\" nameend=\"c4\" >"
         + getPrompt("Pattern: ") + getValueReplaceTBDWithNone(lAttr.getPattern(true)) + "</entry>");
-    prDocBook.println("                </row>");
+    prDocBook.println("    </row>");
     prDocBook.println("");
-
+  }
+  
+  private void writeAttrPermVal(DOMAttr lAttr, String lddVersionId, String imVersionId, String lRegistrationStatus, String lRegistrationStatusInsert, PrintWriter prDocBook) {
     if (lAttr.domPermValueArr == null || lAttr.domPermValueArr.size() == 0) {
-      prDocBook.println("                <row>");
-      prDocBook
-          .println("                    <entry>" + getPrompt("Permissible Value(s)") + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("No Values") + "</entry>");
-      prDocBook.println(
-          "                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\"></entry>");
-      prDocBook.println("                </row>");
-    } else {
-      prDocBook.println("                <row>");
-      prDocBook
-          .println("                    <entry>" + getPrompt("Permissible Value(s)") + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("Value") + "</entry>");
-      prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">"
-          + getPrompt("Value Meaning") + "</entry>");
-      prDocBook.println("                </row>");
+        prDocBook.println("    <row>");
+        prDocBook
+            .println("                    <entry>" + getPrompt("Permissible Value(s)") + "</entry>");
+        prDocBook.println("     <entry>" + getPrompt("No Values") + "</entry>");
+        prDocBook.println(
+            "                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\"></entry>");
+        prDocBook.println("    </row>");
+      } else {
+        prDocBook.println("    <row>");
+        prDocBook
+            .println("                    <entry>" + getPrompt("Permissible Value(s)") + "</entry>");
+        prDocBook.println("     <entry>" + getPrompt("Value") + "</entry>");
+        prDocBook.println("     <entry namest=\"c3\" nameend=\"c4\" align=\"left\">"
+            + getPrompt("Value Meaning") + "</entry>");
+        prDocBook.println("    </row>");
 
-      for (DOMProp lProp: lAttr.domPermValueArr) {
-        if (!(lProp.domObject instanceof DOMPermValDefn)) {
-          continue;
-        }
-        DOMPermValDefn lPermValueDefn = (DOMPermValDefn) lProp.domObject;
-        if (lPermValueDefn.value.compareTo("...") == 0) {
-          continue;
-        }
-        lRegistrationStatusInsert = "";
-        if (lPermValueDefn.registrationStatus.compareTo("Retired") == 0) {
-          lRegistrationStatusInsert = " - " + DMDocument.Literal_DEPRECATED;
-        }
+        for (DOMProp lProp: lAttr.domPermValueArr) {
+          if (!(lProp.domObject instanceof DOMPermValDefn)) {
+            continue;
+          }
+          DOMPermValDefn lPermValueDefn = (DOMPermValDefn) lProp.domObject;
+          if (lPermValueDefn.value.compareTo("...") == 0) {
+            continue;
+          }
+          lRegistrationStatusInsert = "";
+          if (lPermValueDefn.registrationStatus.compareTo("Retired") == 0) {
+            lRegistrationStatusInsert = " - " + DMDocument.Literal_DEPRECATED;
+          }
 
-        String lDependValue = lAttr.valueDependencyMap.get(lPermValueDefn.value);
-        String lDependClause = "";
-        if (lDependValue != null) {
-          lDependClause = " (" + lDependValue + ")";
-        }
+          String lDependValue = lAttr.valueDependencyMap.get(lPermValueDefn.value);
+          String lDependClause = "";
+          if (lDependValue != null) {
+            lDependClause = " (" + lDependValue + ")";
+          }
 
-        String lValueMeaning = lPermValueDefn.value_meaning;
-        if (lValueMeaning == null) {
-          lValueMeaning = "TBD_value_meaning";
-        }
+          String lValueMeaning = lPermValueDefn.value_meaning;
+          if (lValueMeaning == null) {
+            lValueMeaning = "TBD_value_meaning";
+          }
 
-        if (lAttr.title.compareTo("pattern") == 0) {
-          if ((lValueMeaning == null) || (lValueMeaning.indexOf("TBD") == 0)) {
-            lValueMeaning = "";
+          if (lAttr.title.compareTo("pattern") == 0) {
+            if ((lValueMeaning == null) || (lValueMeaning.indexOf("TBD") == 0)) {
+              lValueMeaning = "";
+            }
+          }
+          prDocBook.println("    <row>");
+          prDocBook.println("     <entry></entry>");
+          prDocBook.println(
+              "                    <entry>" + getValueAnchor(lAttr, getValue(lPermValueDefn.value))
+                  + getValueBreak(getValue(lPermValueDefn.value)) + getValue(lDependClause)
+                  + lRegistrationStatusInsert + "</entry>");
+          prDocBook.println("     <entry namest=\"c3\" nameend=\"c4\" align=\"left\">"
+              + getValue(lValueMeaning) + "</entry>");
+          prDocBook.println("    </row>");
+        }
+      }
+      if (!(lAttr.permValueExtArr == null || lAttr.permValueExtArr.isEmpty())) {
+
+        for (PermValueExtDefn lPermValueExt: lAttr.permValueExtArr) {
+          if (lPermValueExt.permValueExtArr == null || lPermValueExt.permValueExtArr.isEmpty()) {
+            continue;
+          }
+          prDocBook.println("    <row>");
+          prDocBook.println("     <entry>"
+              + getPrompt("Extended Value(s) for: " + getValueBreak(lPermValueExt.xpath))
+              + "</entry>");
+          prDocBook.println("     <entry>" + getPrompt("Value") + "</entry>");
+          prDocBook.println("     <entry namest=\"c3\" nameend=\"c4\" align=\"left\">"
+              + getPrompt("Value Meaning") + "</entry>");
+          prDocBook.println("    </row>");
+
+          for (PermValueDefn lPermValueDefn: lPermValueExt.permValueExtArr) {
+            prDocBook.println("    <row>");
+            prDocBook.println("     <entry></entry>");
+            prDocBook.println(
+                "                    <entry>" + getValueBreak(lPermValueDefn.value) + "</entry>");
+            prDocBook
+                .println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">"
+                    + getValue(lPermValueDefn.value_meaning) + "</entry>");
+            prDocBook.println("    </row>");
           }
         }
-        prDocBook.println("                <row>");
-        prDocBook.println("                    <entry></entry>");
-        prDocBook.println(
-            "                    <entry>" + getValueAnchor(lAttr, getValue(lPermValueDefn.value))
-                + getValueBreak(getValue(lPermValueDefn.value)) + getValue(lDependClause)
-                + lRegistrationStatusInsert + "</entry>");
-        prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">"
-            + getValue(lValueMeaning) + "</entry>");
-        prDocBook.println("                </row>");
       }
-    }
-    if (!(lAttr.permValueExtArr == null || lAttr.permValueExtArr.isEmpty())) {
 
-      for (PermValueExtDefn lPermValueExt: lAttr.permValueExtArr) {
-        if (lPermValueExt.permValueExtArr == null || lPermValueExt.permValueExtArr.isEmpty()) {
-          continue;
-        }
-        prDocBook.println("                <row>");
-        prDocBook.println("                    <entry>"
-            + getPrompt("Extended Value(s) for: " + getValueBreak(lPermValueExt.xpath))
-            + "</entry>");
-        prDocBook.println("                    <entry>" + getPrompt("Value") + "</entry>");
-        prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">"
-            + getPrompt("Value Meaning") + "</entry>");
-        prDocBook.println("                </row>");
-
-        for (PermValueDefn lPermValueDefn: lPermValueExt.permValueExtArr) {
-          prDocBook.println("                <row>");
-          prDocBook.println("                    <entry></entry>");
-          prDocBook.println(
-              "                    <entry>" + getValueBreak(lPermValueDefn.value) + "</entry>");
-          prDocBook
-              .println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">"
-                  + getValue(lPermValueDefn.value_meaning) + "</entry>");
-          prDocBook.println("                </row>");
-        }
-      }
-    }
-
-    prDocBook.println("            </tbody>");
-    prDocBook.println("        </tgroup>");
-    prDocBook.println("        </informaltable>");
-    prDocBook.println("</para>");
-    prDocBook.println("</sect1> ");
-    prDocBook.println("");
+      prDocBook.println("   </tbody>");
+      prDocBook.println("  </tgroup>");
   }
 
   private void writeDataTypeSection(String lNameSpaceIdNC, PrintWriter prDocBook) {
@@ -807,9 +832,9 @@ class WriteDOMDocBook extends Object {
       return;
     }
 
-    prDocBook.println("    <chapter>");
-    prDocBook.println("       <title>Data Types in the common namespace.</title>");
-    prDocBook.println("       <para>These classes define the data types. </para>");
+    prDocBook.println(" <chapter>");
+    prDocBook.println("    <title>Data Types in the common namespace.</title>");
+    prDocBook.println("    <para>These classes define the data types. </para>");
 
     // Write the data types
     String lSchemaBaseType = "None", lMinChar = "None", lMaxChar = "None", lMinVal = "None",
@@ -876,80 +901,79 @@ class WriteDOMDocBook extends Object {
           .println("    <title>" + getClassAnchor(lClass) + getValue(lClass.title) + "</title>");
       prDocBook.println("");
       prDocBook.println("<para>");
-      prDocBook.println("    <informaltable frame=\"all\" colsep=\"1\">");
-      prDocBook.println("        <tgroup cols=\"4\" align=\"left\" colsep=\"1\" rowsep=\"1\">");
-      prDocBook.println("            <colspec colnum=\"1\" colname=\"c1\" colwidth=\"1.0*\"/>");
-      prDocBook.println("            <colspec colnum=\"2\" colname=\"c2\" colwidth=\"1.0*\"/>");
-      prDocBook.println("            <colspec colnum=\"3\" colname=\"c3\" colwidth=\"1.0*\"/>");
-      prDocBook.println("            <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
-      prDocBook.println("            <thead>");
-      prDocBook.println("                <row>");
-      prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">"
+      prDocBook.println(" <informaltable frame=\"all\" colsep=\"1\">");
+      prDocBook.println("  <tgroup cols=\"4\" align=\"left\" colsep=\"1\" rowsep=\"1\">");
+      prDocBook.println("   <colspec colnum=\"1\" colname=\"c1\" colwidth=\"1.0*\"/>");
+      prDocBook.println("   <colspec colnum=\"2\" colname=\"c2\" colwidth=\"1.0*\"/>");
+      prDocBook.println("   <colspec colnum=\"3\" colname=\"c3\" colwidth=\"1.0*\"/>");
+      prDocBook.println("   <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
+      prDocBook.println("   <thead>");
+      prDocBook.println("    <row>");
+      prDocBook.println("     <entry namest=\"c1\" nameend=\"c3\" align=\"left\">"
           + getPrompt("Name: ") + getValue(lClass.title) + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("Version Id: ")
+      prDocBook.println("     <entry>" + getPrompt("Version Id: ")
           + getValue(lClass.versionId) + "</entry>");
-      prDocBook.println("                </row>");
-      prDocBook.println("            </thead>");
-      prDocBook.println("            <tbody>");
-      prDocBook.println("                <row>");
-      prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
+      prDocBook.println("    </row>");
+      prDocBook.println("   </thead>");
+      prDocBook.println("   <tbody>");
+      prDocBook.println("    <row>");
+      prDocBook.println("     <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
           + getPrompt("Description ") + getValue(lClass.definition) + "</entry>");
-      prDocBook.println("                </row>");
-      prDocBook.println("                <row>");
-      prDocBook.println("                    <entry>" + getPrompt("Schema Base Type:  ")
+      prDocBook.println("    </row>");
+      prDocBook.println("    <row>");
+      prDocBook.println("     <entry>" + getPrompt("Schema Base Type:  ")
           + getValueReplaceTBDWithNone(lSchemaBaseType) + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("") + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("") + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("") + "</entry>");
-      prDocBook.println("                </row>");
-      prDocBook.println("                <row>");
-      prDocBook.println("                    <entry>" + getPrompt("Minimum Value: ")
+      prDocBook.println("     <entry>" + getPrompt("") + "</entry>");
+      prDocBook.println("     <entry>" + getPrompt("") + "</entry>");
+      prDocBook.println("     <entry>" + getPrompt("") + "</entry>");
+      prDocBook.println("    </row>");
+      prDocBook.println("    <row>");
+      prDocBook.println("     <entry>" + getPrompt("Minimum Value: ")
           + getValueReplaceTBDWithNone(lMinVal) + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("Maximum Value: ")
+      prDocBook.println("     <entry>" + getPrompt("Maximum Value: ")
           + getValueReplaceTBDWithNone(lMaxVal) + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("Minimum Characters: ")
+      prDocBook.println("     <entry>" + getPrompt("Minimum Characters: ")
           + getValueReplaceTBDWithNone(lMinChar) + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("Maximum Characters: ")
+      prDocBook.println("     <entry>" + getPrompt("Maximum Characters: ")
           + getValueReplaceTBDWithNone(lMaxChar) + "</entry>");
-      prDocBook.println("                </row>");
+      prDocBook.println("    </row>");
 
       if (lPatternArr == null || lPatternArr.isEmpty()) {
-        prDocBook.println("                <row>");
-        prDocBook.println("                    <entry>" + "</entry>");
-        prDocBook.println("                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\">"
+        prDocBook.println("    <row>");
+        prDocBook.println("     <entry>" + "</entry>");
+        prDocBook.println("     <entry namest=\"c2\" nameend=\"c4\" align=\"left\">"
             + getPrompt("No Pattern") + "</entry>");
-        prDocBook.println("                </row>");
+        prDocBook.println("    </row>");
       } else {
-        prDocBook.println("                <row>");
-        prDocBook.println("                    <entry>" + "</entry>");
-        prDocBook.println("                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\">"
+        prDocBook.println("    <row>");
+        prDocBook.println("     <entry>" + "</entry>");
+        prDocBook.println("     <entry namest=\"c2\" nameend=\"c4\" align=\"left\">"
             + getPrompt("Pattern") + "</entry>");
-        prDocBook.println("                </row>");
+        prDocBook.println("    </row>");
         for (String lPattern: lPatternArr) {
-          prDocBook.println("                <row>");
-          prDocBook.println("                    <entry>" + "</entry>");
+          prDocBook.println("    <row>");
+          prDocBook.println("     <entry>" + "</entry>");
           prDocBook
               .println("                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\">"
                   + getValue(lPattern) + "</entry>");
-          prDocBook.println("                </row>");
+          prDocBook.println("    </row>");
         }
       }
 
       prDocBook.println("");
-      prDocBook.println("            </tbody>");
-      prDocBook.println("        </tgroup>");
-      prDocBook.println("        </informaltable>");
+      prDocBook.println("   </tbody>");
+      prDocBook.println("  </tgroup>");
+      prDocBook.println("  </informaltable>");
       prDocBook.println("</para>");
       prDocBook.println("</sect1> ");
     }
-    prDocBook.println("    </chapter>");
+    prDocBook.println(" </chapter>");
     prDocBook.println("");
-    prDocBook.println("      <!-- ===================== Part4a End=========================== -->");
+    prDocBook.println("   <!-- ===================== Part4a End=========================== -->");
     prDocBook.println("");
   }
 
   private void writeUnitsSection(String lNameSpaceIdNC, PrintWriter prDocBook) {
-    ArrayList<String> lPatternArr = new ArrayList<>();
     prDocBook.println("");
     prDocBook
         .println("      <!-- =====================Part4b Begin=========================== -->");
@@ -972,9 +996,9 @@ class WriteDOMDocBook extends Object {
       return;
     }
 
-    prDocBook.println("    <chapter>");
-    prDocBook.println("       <title>Units of Measure in the common namespace.</title>");
-    prDocBook.println("       <para>These classes define the units of measure. </para>");
+    prDocBook.println(" <chapter>");
+    prDocBook.println("    <title>Units of Measure in the common namespace.</title>");
+    prDocBook.println("    <para>These classes define the units of measure. </para>");
 
     for (DOMClass lClass: sortUnitsArr) {
       lDOMPermValueArr = new ArrayList<>();
@@ -992,37 +1016,37 @@ class WriteDOMDocBook extends Object {
           .println("    <title>" + getClassAnchor(lClass) + getValue(lClass.title) + "</title>");
       prDocBook.println("");
       prDocBook.println("<para>");
-      prDocBook.println("    <informaltable frame=\"all\" colsep=\"1\">");
-      prDocBook.println("        <tgroup cols=\"4\" align=\"left\" colsep=\"1\" rowsep=\"1\">");
-      prDocBook.println("            <colspec colnum=\"1\" colname=\"c1\" colwidth=\"1.0*\"/>");
-      prDocBook.println("            <colspec colnum=\"2\" colname=\"c2\" colwidth=\"1.0*\"/>");
-      prDocBook.println("            <colspec colnum=\"3\" colname=\"c3\" colwidth=\"1.0*\"/>");
-      prDocBook.println("            <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
-      prDocBook.println("            <thead>");
-      prDocBook.println("                <row>");
-      prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">"
+      prDocBook.println(" <informaltable frame=\"all\" colsep=\"1\">");
+      prDocBook.println("  <tgroup cols=\"4\" align=\"left\" colsep=\"1\" rowsep=\"1\">");
+      prDocBook.println("   <colspec colnum=\"1\" colname=\"c1\" colwidth=\"1.0*\"/>");
+      prDocBook.println("   <colspec colnum=\"2\" colname=\"c2\" colwidth=\"1.0*\"/>");
+      prDocBook.println("   <colspec colnum=\"3\" colname=\"c3\" colwidth=\"1.0*\"/>");
+      prDocBook.println("   <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
+      prDocBook.println("   <thead>");
+      prDocBook.println("    <row>");
+      prDocBook.println("     <entry namest=\"c1\" nameend=\"c3\" align=\"left\">"
           + getPrompt("Name:  ") + getValue(lClass.title) + "</entry>");
-      prDocBook.println("                    <entry>" + getPrompt("Version Id:  ")
+      prDocBook.println("     <entry>" + getPrompt("Version Id:  ")
           + getValue(lClass.versionId) + "</entry>");
-      prDocBook.println("                </row>");
-      prDocBook.println("            </thead>");
-      prDocBook.println("            <tbody>");
-      prDocBook.println("                <row>");
-      prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
+      prDocBook.println("    </row>");
+      prDocBook.println("   </thead>");
+      prDocBook.println("   <tbody>");
+      prDocBook.println("    <row>");
+      prDocBook.println("     <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
           + getPrompt("Description: ") + getValue(lClass.definition) + "</entry>");
-      prDocBook.println("                </row>");
-      prDocBook.println("                <row>");
-      prDocBook.println("                    <entry>" + "</entry>");
-      prDocBook.println("                    <entry namest=\"c2\" nameend=\"c4\" align=\"left\">"
+      prDocBook.println("    </row>");
+      prDocBook.println("    <row>");
+      prDocBook.println("     <entry>" + "</entry>");
+      prDocBook.println("     <entry namest=\"c2\" nameend=\"c4\" align=\"left\">"
           + getPrompt("Unit Id") + "</entry>");
-      prDocBook.println("                </row>");
+      prDocBook.println("    </row>");
 
       if (!lDOMPermValueArr.isEmpty()) {
         for (DOMProp lDOMProp: lDOMPermValueArr) {
           if (lDOMProp.domObject != null && lDOMProp.domObject instanceof DOMPermValDefn) {
             DOMPermValDefn lDOMPermValDefn = (DOMPermValDefn) lDOMProp.domObject;
-            prDocBook.println("                <row>");
-            prDocBook.println("                    <entry>" + "</entry>");
+            prDocBook.println("    <row>");
+            prDocBook.println("     <entry>" + "</entry>");
             prDocBook.println(
                 "                    <entry>" + getValue(lDOMPermValDefn.value) + "</entry>");
             String lValueMeaning = lDOMPermValDefn.value_meaning;
@@ -1032,30 +1056,30 @@ class WriteDOMDocBook extends Object {
             prDocBook
                 .println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">"
                     + getValue(lValueMeaning) + "</entry>");
-            prDocBook.println("                </row>");
+            prDocBook.println("    </row>");
           }
         }
       } else {
-        prDocBook.println("                <row>");
-        prDocBook.println("                    <entry>" + "</entry>");
-        prDocBook.println("                    <entry>" + "None" + "</entry>");
-        prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">"
+        prDocBook.println("    <row>");
+        prDocBook.println("     <entry>" + "</entry>");
+        prDocBook.println("     <entry>" + "None" + "</entry>");
+        prDocBook.println("     <entry namest=\"c3\" nameend=\"c4\" align=\"left\">"
             + getValue("") + "</entry>");
-        prDocBook.println("                </row>");
+        prDocBook.println("    </row>");
       }
 
       prDocBook.println("");
-      prDocBook.println("            </tbody>");
-      prDocBook.println("        </tgroup>");
-      prDocBook.println("        </informaltable>");
+      prDocBook.println("   </tbody>");
+      prDocBook.println("  </tgroup>");
+      prDocBook.println("  </informaltable>");
       prDocBook.println("</para>");
       prDocBook.println("</sect1> ");
     }
 
     // finalize Part 4
-    prDocBook.println("         </chapter>");
+    prDocBook.println("   </chapter>");
     prDocBook.println("");
-    prDocBook.println("      <!-- ===================== Part4b End=========================== -->");
+    prDocBook.println("   <!-- ===================== Part4b End=========================== -->");
     prDocBook.println("");
   }
 
@@ -1064,146 +1088,144 @@ class WriteDOMDocBook extends Object {
     prDocBook.println(
         "<?xml-model href=\"http://www.oasis-open.org/docbook/xml/5.0/rng/docbook.rng\" schematypens=\"http://relaxng.org/ns/structure/1.0\"?>");
     prDocBook.println("<book xmlns=\"http://docbook.org/ns/docbook\"");
-    prDocBook.println("    xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"5.0\">");
-    prDocBook.println("    <info>");
-    prDocBook.println("        <title>" + DMDocument.ddDocTitle + "</title>");
-    prDocBook.println("        <subtitle>Abridged - Version "
+    prDocBook.println(" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"5.0\">");
+    prDocBook.println(" <info>");
+    prDocBook.println("  <title>" + DMDocument.ddDocTitle + "</title>");
+    prDocBook.println("  <subtitle>Abridged - Version "
         + DMDocument.getMasterPDSSchemaFileDefn().ont_version_id + "</subtitle>");
-    prDocBook.println("        <author>");
-    prDocBook.println("            <orgname>" + DMDocument.ddDocTeam + "</orgname>");
-    prDocBook.println("        </author>");
-    prDocBook.println("        <releaseinfo>Generated from Information Model Version "
+    prDocBook.println("  <author>");
+    prDocBook.println("   <orgname>" + DMDocument.ddDocTeam + "</orgname>");
+    prDocBook.println("  </author>");
+    prDocBook.println("  <releaseinfo>Generated from Information Model Version "
         + DMDocument.getMasterPDSSchemaFileDefn().ont_version_id + " on " + DMDocument.sTodaysDate
         + "</releaseinfo>");
     prDocBook.println(
-        "        <releaseinfo>Contains namespace ids: " + writtenNamespaceIds + "</releaseinfo>");
-    prDocBook.println("        <date>" + DMDocument.sTodaysDate + "</date>");
-    prDocBook.println("    </info>");
-    prDocBook.println("        ");
-    prDocBook.println("        <chapter>");
-    prDocBook.println("            <title>Introduction</title>");
+        "    <releaseinfo>Contains namespace ids: " + writtenNamespaceIds + "</releaseinfo>");
+    prDocBook.println("  <date>" + DMDocument.sTodaysDate + "</date>");
+    prDocBook.println(" </info>");
+    prDocBook.println("  ");
+    prDocBook.println("  <chapter>");
+    prDocBook.println("   <title>Introduction</title>");
     prDocBook.println(
-        "            <para>The Data Dictionary defines the organization and components of product labels. Components of a product label include classes and their attributes.</para>");
-    prDocBook.println("            <para>");
-    prDocBook.println("            </para>");
-    prDocBook.println("            <sect1>");
-    prDocBook.println("                <title>Audience</title>");
+        "    <para>The Data Dictionary defines the organization and components of product labels. Components of a product label include classes and their attributes.</para>");
+    prDocBook.println("   <para>");
+    prDocBook.println("   </para>");
+    prDocBook.println("   <sect1>");
+    prDocBook.println("    <title>Audience</title>");
     prDocBook.println(
-        "                <para>The Data Dictionary - Abridged - has been abstracted from the unabridged version with the needs of data providers and data end users in mind. It contains full definitions but not all the fine detail or repetition necessary to support the underlying Information Model.</para>");
-    prDocBook.println("                <para>");
-    prDocBook.println("                </para>");
-    prDocBook.println("            </sect1>");
-    prDocBook.println("            <sect1>");
-    prDocBook.println("                <title>Acknowledgements</title>");
+        "    <para>The Data Dictionary - Abridged - has been abstracted from the unabridged version with the needs of data providers and data end users in mind. It contains full definitions but not all the fine detail or repetition necessary to support the underlying Information Model.</para>");
+    prDocBook.println("    <para>");
+    prDocBook.println("    </para>");
+    prDocBook.println("   </sect1>");
+    prDocBook.println("   <sect1>");
+    prDocBook.println("    <title>Acknowledgements</title>");
     prDocBook.println(
-        "                <para>The Data Dictionary and the Information Model is a joint effort involving discipline experts functioning as a data design working group.</para>");
-    prDocBook.println("                <para>");
-    prDocBook.println("                </para>");
-    prDocBook.println("            </sect1>");
-    prDocBook.println("            <sect1>");
-    prDocBook.println("                <title>Scope</title>");
+        "    <para>The Data Dictionary and the Information Model is a joint effort involving discipline experts functioning as a data design working group.</para>");
+    prDocBook.println("    <para>");
+    prDocBook.println("    </para>");
+    prDocBook.println("   </sect1>");
+    prDocBook.println("   <sect1>");
+    prDocBook.println("    <title>Scope</title>");
     prDocBook.println(
-        "                <para>The Data Dictionary defines the common and discipline level classes and attributes used to create product labels. It also defines the meta-attributes (i.e. attributes about attributes) used to define attributes. This abridged version includes only one entry for each attribute where the unabridge version includes an entry for each use of an attribute in a class.</para>");
-    prDocBook.println("                <para>");
-    prDocBook.println("                </para>");
-    prDocBook.println("            </sect1>");
-    prDocBook.println("            <sect1>");
-    prDocBook.println("                <title>Applicable Documents</title>");
-    prDocBook.println("                <para>");
-    prDocBook
-        .println("                    <emphasis role=\"bold\">Controlling Documents</emphasis>");
+        "    <para>The Data Dictionary defines the common and discipline level classes and attributes used to create product labels. It also defines the meta-attributes (i.e. attributes about attributes) used to define attributes. This abridged version includes only one entry for each attribute where the unabridge version includes an entry for each use of an attribute in a class.</para>");
+    prDocBook.println("    <para>");
+    prDocBook.println("    </para>");
+    prDocBook.println("   </sect1>");
+    prDocBook.println("   <sect1>");
+    prDocBook.println("    <title>Applicable Documents</title>");
+    prDocBook.println("    <para>");
+    prDocBook.println("     <emphasis role=\"bold\">Controlling Documents</emphasis>");
     prDocBook.println("");
-    prDocBook.println("                    <itemizedlist>");
-    prDocBook.println("                        <listitem>");
-    prDocBook.println("                            <para>");
+    prDocBook.println("     <itemizedlist>");
+    prDocBook.println("         <listitem>");
+    prDocBook.println("             <para>");
     prDocBook.println(
-        "                                Information Model Specification - The Information Model is used as the source for class, attribute, and data type definitions. The model is presented in document format as the Information Model Specification.");
-    prDocBook.println("                            </para>");
-    prDocBook.println("                        </listitem>");
-    prDocBook.println("                        <listitem>");
-    prDocBook.println("                            <para>");
+        "    Information Model Specification - The Information Model is used as the source for class, attribute, and data type definitions. The model is presented in document format as the Information Model Specification.");
+    prDocBook.println("             </para>");
+    prDocBook.println("         </listitem>");
+    prDocBook.println("         <listitem>");
+    prDocBook.println("             <para>");
     prDocBook.println(
-        "                                ISO/IEC 11179:3 Registry Metamodel and Basic Attributes Specification, 2003. - The ISO/IEC 11179 specification provides the schema for the data dictionary.");
-    prDocBook.println("                            </para>");
-    prDocBook.println("                        </listitem>");
-    prDocBook.println("                    </itemizedlist>");
+        "    ISO/IEC 11179:3 Registry Metamodel and Basic Attributes Specification, 2003. - The ISO/IEC 11179 specification provides the schema for the data dictionary.");
+    prDocBook.println("             </para>");
+    prDocBook.println("         </listitem>");
+    prDocBook.println("     </itemizedlist>");
     if (!DMDocument.importJSONAttrFlag) {
-      prDocBook
-          .println("                    <emphasis role=\"bold\">Reference Documents</emphasis>");
-      prDocBook.println("                    <itemizedlist>");
-      prDocBook.println("                        <listitem>");
-      prDocBook.println("                            <para>");
+      prDocBook.println("     <emphasis role=\"bold\">Reference Documents</emphasis>");
+      prDocBook.println("     <itemizedlist>");
+      prDocBook.println("         <listitem>");
+      prDocBook.println("             <para>");
       prDocBook.println(
-          "                                Planetary Science Data Dictionary - The online version of the PDS3 data dictionary was used as the source for a few data elements being carried over from the PDS3 data standards.");
-      prDocBook.println("                            </para>");
-      prDocBook.println("                        </listitem>");
-      prDocBook.println("                        ");
-      prDocBook.println("                    </itemizedlist>");
+          "    Planetary Science Data Dictionary - The online version of the PDS3 data dictionary was used as the source for a few data elements being carried over from the PDS3 data standards.");
+      prDocBook.println("             </para>");
+      prDocBook.println("         </listitem>");
+      prDocBook.println("         ");
+      prDocBook.println("     </itemizedlist>");
     }
-    prDocBook.println("                </para>");
-    prDocBook.println("            </sect1>");
-    prDocBook.println("            <sect1>");
-    prDocBook.println("                <title>Terminology</title>");
+    prDocBook.println("    </para>");
+    prDocBook.println("   </sect1>");
+    prDocBook.println("   <sect1>");
+    prDocBook.println("    <title>Terminology</title>");
     prDocBook.println(
-        "                <para>This document uses very specific engineering terminology to describe the various structures involved.  It is particularly important that readers who have absorbed the Standards Reference bear in mind that terms which are familiar in that context can have very different meanings in the present document. </para>");
+        "    <para>This document uses very specific engineering terminology to describe the various structures involved.  It is particularly important that readers who have absorbed the Standards Reference bear in mind that terms which are familiar in that context can have very different meanings in the present document. </para>");
     prDocBook.println(
-        "                <para>Following are some definitions of essential terms used throughout this document.</para>");
-    prDocBook.println("                <itemizedlist>");
-    prDocBook.println("                    <listitem>");
+        "    <para>Following are some definitions of essential terms used throughout this document.</para>");
+    prDocBook.println("    <itemizedlist>");
+    prDocBook.println("     <listitem>");
     prDocBook.println(
-        "                        <para>An <emphasis role=\"italic\">attribute</emphasis> is a property or characteristic that provides a unit of information. For example, 'color' and 'length' are possible attributes. </para>");
-    prDocBook.println("                    </listitem>");
-    prDocBook.println("                    <listitem>");
+        "      <para>An <emphasis role=\"italic\">attribute</emphasis> is a property or characteristic that provides a unit of information. For example, 'color' and 'length' are possible attributes. </para>");
+    prDocBook.println("     </listitem>");
+    prDocBook.println("     <listitem>");
     prDocBook.println(
-        "                        <para>A <emphasis role=\"italic\">class</emphasis> is a set of attributes (including a name) which defines a family.  A class is generic - a template from which individual members of the family may be constructed.");
-    prDocBook.println("                        </para>");
-    prDocBook.println("                    </listitem>");
-    prDocBook.println("                    <listitem>");
+        "      <para>A <emphasis role=\"italic\">class</emphasis> is a set of attributes (including a name) which defines a family.  A class is generic - a template from which individual members of the family may be constructed.");
+    prDocBook.println("         </para>");
+    prDocBook.println("     </listitem>");
+    prDocBook.println("     <listitem>");
     prDocBook.println(
-        "                        <para>A <emphasis role=\"italic\">conceptual object</emphasis> is an object which is intangible (and, because it is intangible, does not fit into a digital archive).  Examples of 'conceptual objects' include the Cassini mission and NASA's strategic plan for solar system exploration.  Note that a PDF describing the Cassini mission is a digital object, not a conceptual object (nor a component of a conceptual object). </para>");
-    prDocBook.println("                    </listitem>");
-    prDocBook.println("                    <listitem>");
+        "      <para>A <emphasis role=\"italic\">conceptual object</emphasis> is an object which is intangible (and, because it is intangible, does not fit into a digital archive).  Examples of 'conceptual objects' include the Cassini mission and NASA's strategic plan for solar system exploration.  Note that a PDF describing the Cassini mission is a digital object, not a conceptual object (nor a component of a conceptual object). </para>");
+    prDocBook.println("     </listitem>");
+    prDocBook.println("     <listitem>");
     prDocBook.println(
-        "                        <para>A <emphasis role=\"italic\">data element</emphasis> is a unit of data for which the definition, identification, representation and <emphasis role=\"italic\">permissible values</emphasis> are specified by means of a set of attributes. For example, the concept of a <emphasis role=\"italic\">calibration_lamp_state_flag</emphasis> is used to indicate whether the lamp used for onboard camera calibration was turned on or off during the capture of an image. The <emphasis role=\"italic\"> data element</emphasis> aspect of this concept is the named attribute (or data element)  <emphasis role=\"italic\">calibration_lamp_state_flag</emphasis>.</para>");
-    prDocBook.println("                    </listitem>");
-    prDocBook.println("                    <listitem>");
+        "      <para>A <emphasis role=\"italic\">data element</emphasis> is a unit of data for which the definition, identification, representation and <emphasis role=\"italic\">permissible values</emphasis> are specified by means of a set of attributes. For example, the concept of a <emphasis role=\"italic\">calibration_lamp_state_flag</emphasis> is used to indicate whether the lamp used for onboard camera calibration was turned on or off during the capture of an image. The <emphasis role=\"italic\"> data element</emphasis> aspect of this concept is the named attribute (or data element)  <emphasis role=\"italic\">calibration_lamp_state_flag</emphasis>.</para>");
+    prDocBook.println("     </listitem>");
+    prDocBook.println("     <listitem>");
     prDocBook.println(
-        "                        <para>A <emphasis role=\"italic\">data object</emphasis> is a physical, conceptual, or digital object.</para>");
-    prDocBook.println("                    </listitem>");
-    prDocBook.println("                    <listitem>");
+        "      <para>A <emphasis role=\"italic\">data object</emphasis> is a physical, conceptual, or digital object.</para>");
+    prDocBook.println("     </listitem>");
+    prDocBook.println("     <listitem>");
     prDocBook.println(
-        "                        <para>A <emphasis role=\"italic\">digital object</emphasis> is an object which is real data - for example, a binary image of a redwood tree or an ASCII table of atmospheric composition versus altitude.</para>");
-    prDocBook.println("                    </listitem>");
-    prDocBook.println("                    <listitem>");
+        "      <para>A <emphasis role=\"italic\">digital object</emphasis> is an object which is real data - for example, a binary image of a redwood tree or an ASCII table of atmospheric composition versus altitude.</para>");
+    prDocBook.println("     </listitem>");
+    prDocBook.println("     <listitem>");
     prDocBook.println(
-        "                        <para><emphasis role=\"italic\">Formal</emphasis> as used in the definition of attributes that are names indicates that an established procedure was involved in creating the name.</para>");
-    prDocBook.println("                    </listitem>");
-    prDocBook.println("                    <listitem>");
+        "      <para><emphasis role=\"italic\">Formal</emphasis> as used in the definition of attributes that are names indicates that an established procedure was involved in creating the name.</para>");
+    prDocBook.println("     </listitem>");
+    prDocBook.println("     <listitem>");
     prDocBook.println(
-        "                        <para>A <emphasis role=\"italic\">unique identifier</emphasis> is a special type of identifier used to provide a reference number which is unique in a context.</para>");
-    prDocBook.println("                    </listitem>");
-    prDocBook.println("                    <listitem>");
+        "      <para>A <emphasis role=\"italic\">unique identifier</emphasis> is a special type of identifier used to provide a reference number which is unique in a context.</para>");
+    prDocBook.println("     </listitem>");
+    prDocBook.println("     <listitem>");
     prDocBook.println(
-        "                        <para><emphasis role=\"italic\">Local</emphasis> refers to the context within a single label.</para>");
-    prDocBook.println("                    </listitem>");
-    prDocBook.println("                    <listitem>");
+        "      <para><emphasis role=\"italic\">Local</emphasis> refers to the context within a single label.</para>");
+    prDocBook.println("     </listitem>");
+    prDocBook.println("     <listitem>");
     prDocBook.println(
-        "                        <para><emphasis role=\"italic\">Logical</emphasis> as used in the definition of logical identifier indicates that the identifier logically groups a set of objects. </para>");
-    prDocBook.println("                    </listitem>");
-    prDocBook.println("                    <listitem>");
+        "      <para><emphasis role=\"italic\">Logical</emphasis> as used in the definition of logical identifier indicates that the identifier logically groups a set of objects. </para>");
+    prDocBook.println("     </listitem>");
+    prDocBook.println("     <listitem>");
     prDocBook.println(
-        "                        <para>A <emphasis role=\"italic\">physical object</emphasis> is an object which is physical or tangible (and, therefore, does not itself fit into a digital archive).  Examples of 'physical objects' include the planet Saturn and the Venus Express magnetometer.  Note that an ASCII file describing Saturn is a digital object, not a physical object (nor a component of a physical object).  </para>");
-    prDocBook.println("                    </listitem>");
-    prDocBook.println("                    <listitem>");
+        "      <para>A <emphasis role=\"italic\">physical object</emphasis> is an object which is physical or tangible (and, therefore, does not itself fit into a digital archive).  Examples of 'physical objects' include the planet Saturn and the Venus Express magnetometer.  Note that an ASCII file describing Saturn is a digital object, not a physical object (nor a component of a physical object).  </para>");
+    prDocBook.println("     </listitem>");
+    prDocBook.println("     <listitem>");
     prDocBook.println(
-        "                        <para>A <emphasis role=\"italic\">resource</emphasis> is the target (referent) of any Uniform Resource Identifier; the thing to which a URI points.</para>");
-    prDocBook.println("                    </listitem>");
-    prDocBook.println("                </itemizedlist>");
+        "      <para>A <emphasis role=\"italic\">resource</emphasis> is the target (referent) of any Uniform Resource Identifier; the thing to which a URI points.</para>");
+    prDocBook.println("     </listitem>");
+    prDocBook.println("    </itemizedlist>");
     prDocBook.println("");
-    prDocBook.println("                <para>");
-    prDocBook.println("                </para>");
-    prDocBook.println("            </sect1>");
-    prDocBook.println("        </chapter>");
+    prDocBook.println("    <para>");
+    prDocBook.println("    </para>");
+    prDocBook.println("   </sect1>");
+    prDocBook.println("  </chapter>");
     prDocBook.println("");
     return;
   }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
@@ -387,11 +387,14 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("            <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
     prDocBook.println("            <thead>");
     prDocBook.println("                <row>");
-    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">"
+//    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">"
+   	    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c2\" align=\"left\">"
         + getPrompt("Name: ") + getValue(lClass.title) + lRegistrationStatusInsert + "</entry>");
     // prDocBook.println(" <entry>" + getPrompt("Version Id: ") + getValue("1.0.0.0") + "</entry>");
     prDocBook.println("                    <entry>" + getPrompt("Version Id: ")
         + getValue(lClass.versionId) + "</entry>");
+    prDocBook.println("                    <entry>" + getPrompt("IM Version Id: ")
+    + getValue(DMDocument.masterPDSSchemaFileDefn.ont_version_id) + "</entry>");
     prDocBook.println("                </row>");
     prDocBook.println("            </thead>");
     prDocBook.println("            <tbody>");
@@ -623,13 +626,12 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("            <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
     prDocBook.println("            <thead>");
     prDocBook.println("                <row>");
-    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">"
+    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c2\" align=\"left\">"
         + getPrompt("Name: ") + getAttrAnchor(lAttr) + getValue(lAttr.title)
         + lRegistrationStatusInsert + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("Version Id: ")
-        + getValue("1.0.0.0") + "</entry>");
-    // prDocBook.println(" <entry>" + getPrompt("Version Id: ") + getValue(lAttr.versionId) +
-    // "</entry>");
+    prDocBook.println(" <entry>" + getPrompt("Version Id: ") + getValue(lAttr.versionId) + "</entry>");
+    prDocBook.println("                    <entry>" + getPrompt("IM Version Id: ")
+    + getValue(DMDocument.masterPDSSchemaFileDefn.ont_version_id) + "</entry>");    
     prDocBook.println("                </row>");
     prDocBook.println("            </thead>");
     prDocBook.println("            <tbody>");

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
@@ -387,10 +387,8 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("            <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
     prDocBook.println("            <thead>");
     prDocBook.println("                <row>");
-//    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">"
    	    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c2\" align=\"left\">"
         + getPrompt("Name: ") + getValue(lClass.title) + lRegistrationStatusInsert + "</entry>");
-    // prDocBook.println(" <entry>" + getPrompt("Version Id: ") + getValue("1.0.0.0") + "</entry>");
     prDocBook.println("                    <entry>" + getPrompt("Version Id: ")
         + getValue(lClass.versionId) + "</entry>");
     prDocBook.println("                    <entry>" + getPrompt("IM Version Id: ")
@@ -902,8 +900,6 @@ class WriteDOMDocBook extends Object {
       prDocBook.println("                <row>");
       prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">"
           + getPrompt("Name: ") + getValue(lClass.title) + "</entry>");
-      // prDocBook.println(" <entry>" + getPrompt("Version Id: ") + getValue("1.0.0.0") +
-      // "</entry>");
       prDocBook.println("                    <entry>" + getPrompt("Version Id: ")
           + getValue(lClass.versionId) + "</entry>");
       prDocBook.println("                </row>");
@@ -1023,8 +1019,6 @@ class WriteDOMDocBook extends Object {
       prDocBook.println("                <row>");
       prDocBook.println("                    <entry namest=\"c1\" nameend=\"c3\" align=\"left\">"
           + getPrompt("Name:  ") + getValue(lClass.title) + "</entry>");
-      // prDocBook.println(" <entry>" + getPrompt("Version Id: ") + getValue("1.0.0.0") +
-      // "</entry>");
       prDocBook.println("                    <entry>" + getPrompt("Version Id:  ")
           + getValue(lClass.versionId) + "</entry>");
       prDocBook.println("                </row>");

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
@@ -70,7 +70,7 @@ class WriteDOMDocBook extends Object {
       lSchemaFileDefnToWriteArr = new ArrayList<>();
       lSchemaFileDefnToWriteArr.add(DMDocument.getMasterPDSSchemaFileDefn());
     } else {
-      // intialize array to capture namespaces to be written
+      // initialize array to capture namespaces to be written
       ArrayList<String> lDDNamespaceArr = new ArrayList<>();
       lSchemaFileDefnToWriteArr = new ArrayList<>();
 
@@ -90,7 +90,6 @@ class WriteDOMDocBook extends Object {
       }
     }
 
-    // System.out.println("");
     for (SchemaFileDefn lSchemaFileDefn: lSchemaFileDefnToWriteArr) {
       classClassificationMap.put(lSchemaFileDefn.nameSpaceIdNC,
           new ClassClassificationDefnDOM(lSchemaFileDefn.nameSpaceIdNC));
@@ -387,11 +386,13 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("            <colspec colnum=\"4\" colname=\"c4\" colwidth=\"1.0*\"/>");
     prDocBook.println("            <thead>");
     prDocBook.println("                <row>");
-   	    prDocBook.println("                    <entry namest=\"c1\" nameend=\"c2\" align=\"left\">"
+   	prDocBook.println("                    <entry namest=\"c1\" nameend=\"c2\" align=\"left\">"
         + getPrompt("Name: ") + getValue(lClass.title) + lRegistrationStatusInsert + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("Version Id: ")
-        + getValue(lClass.versionId) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("IM Version Id: ")
+    String versionIdLiteral = "DD Version: ";
+    if (lClass.getNameSpaceIdNC().compareTo("pds") != 0) versionIdLiteral = "LDD Version: ";   	
+   	prDocBook.println("                    <entry>" + getPrompt(versionIdLiteral)
+    + getValue(DMDocument.masterLDDSchemaFileDefn.versionId) + "</entry>");
+    prDocBook.println("                    <entry>" + getPrompt("IM Version: ")
     + getValue(DMDocument.masterPDSSchemaFileDefn.ont_version_id) + "</entry>");
     prDocBook.println("                </row>");
     prDocBook.println("            </thead>");
@@ -399,6 +400,8 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("                <row>");
     prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
         + getPrompt("Description:") + getValue(lClass.definition) + "</entry>");
+//    prDocBook.println("                    <entry>" + getPrompt("Version Id: ")
+//    	+ getValue(lClass.versionId) + "</entry>");
     prDocBook.println("                </row>");
     prDocBook.println("                <row>");
     prDocBook.println("                    <entry>" + getPrompt("Namespace Id: ")
@@ -567,8 +570,6 @@ class WriteDOMDocBook extends Object {
       lValueString = "None";
     }
     prDocBook.println("                <row>");
-    // prDocBook.println(" <entry namest=\"c1\" nameend=\"c4\" align=\"left\">" +
-    // getPrompt("Referenced from: ") + getValue(lValueString) + "</entry>");
     prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
         + getPrompt("Referenced from: ") + lValueString + "</entry>");
     prDocBook.println("                </row>");
@@ -627,43 +628,35 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("                    <entry namest=\"c1\" nameend=\"c2\" align=\"left\">"
         + getPrompt("Name: ") + getAttrAnchor(lAttr) + getValue(lAttr.title)
         + lRegistrationStatusInsert + "</entry>");
-    prDocBook.println(" <entry>" + getPrompt("Version Id: ") + getValue(lAttr.versionId) + "</entry>");
-    prDocBook.println("                    <entry>" + getPrompt("IM Version Id: ")
+    String versionIdLiteral = "DD Version: ";
+    if (lAttr.getNameSpaceIdNC().compareTo("pds") != 0) versionIdLiteral = "LDD Version: ";
+    prDocBook.println(" <entry>" + getPrompt(versionIdLiteral)
+    + getValue(DMDocument.masterLDDSchemaFileDefn.versionId) + "</entry>");
+    prDocBook.println("                    <entry>" + getPrompt("IM Version: ")
     + getValue(DMDocument.masterPDSSchemaFileDefn.ont_version_id) + "</entry>");    
     prDocBook.println("                </row>");
     prDocBook.println("            </thead>");
     prDocBook.println("            <tbody>");
+    
     prDocBook.println("                <row>");
     prDocBook.println("                    <entry namest=\"c1\" nameend=\"c4\" align=\"left\">"
         + getPrompt("Description: ") + getValue(lAttr.definition) + "</entry>");
+//    prDocBook.println("                    <entry>" + getPrompt("Version Id: ")
+//    + getValue(lAttr.versionId) + "</entry>");
     prDocBook.println("                </row>");
     prDocBook.println("                <row>");
-    // prDocBook.println(" <entry>" + getPrompt("Namespace Id: ") +
-    // getValue(lAttr.attrNameSpaceIdNC) + "</entry>");
     prDocBook.println("                    <entry>" + getPrompt("Namespace Id: ")
         + getValue(lAttr.getNameSpaceIdNC()) + "</entry>");
-    // prDocBook.println(" <entry>" + getPrompt("Steward: ") + getValue(lAttr.steward) +
-    // "</entry>");
     prDocBook.println("                    <entry>" + getPrompt("Steward: ")
         + getValue(lAttr.getSteward()) + "</entry>");
-    // prDocBook.println(" <entry>" + getPrompt("Class Name: ") + getValueBreak(lAttr.className) +
-    // "</entry>");
-    // prDocBook.println(" <entry>" + getPrompt("Class Name: ") + getClassLink(lParentClass) +
-    // "</entry>");
     prDocBook.println("                    <entry>" + getPrompt("Class Name: ")
         + getClassLink(lAttr.attrParentClass) + "</entry>");
     prDocBook.println("                    <entry>" + getPrompt("Type: ")
         + getDataTypeLink(lAttr.valueType) + "</entry>");
     prDocBook.println("                </row>");
+    
+    
     prDocBook.println("                <row>");
-    // prDocBook.println(" <entry>" + getPrompt("Minimum Value: ") +
-    // getValueReplaceTBDWithNone(lAttr.minimum_value) + "</entry>");
-    // prDocBook.println(" <entry>" + getPrompt("Maximum Value: ") +
-    // getValueReplaceTBDWithNone(lAttr.maximum_value) + "</entry>");
-    // prDocBook.println(" <entry>" + getPrompt("Minimum Characters: ") +
-    // getValueReplaceTBDWithNone(lAttr.minimum_characters) + "</entry>");
-    // prDocBook.println(" <entry>" + getPrompt("Maximum Characters: ") +
-    // getValueReplaceTBDWithNone(lAttr.maximum_characters) + "</entry>");
 
     prDocBook.println("                    <entry>" + getPrompt("Minimum Value: ")
         + getValueReplaceTBDWithNone(lAttr.getMinimumValue(true, false)) + "</entry>");
@@ -692,8 +685,6 @@ class WriteDOMDocBook extends Object {
         "                    <entry>" + getPrompt("Status: ") + lRegistrationStatus + "</entry>");
     prDocBook.println(
         "                    <entry>" + getPrompt("Nillable: ") + lAttr.isNilable + "</entry>");
-    // prDocBook.println(" <entry namest=\"c3\" nameend=\"c4\" >" + getPrompt("Pattern: ") +
-    // getValueReplaceTBDWithNone(lAttr.pattern) + "</entry>");
     prDocBook.println("                    <entry namest=\"c3\" nameend=\"c4\" >"
         + getPrompt("Pattern: ") + getValueReplaceTBDWithNone(lAttr.getPattern(true)) + "</entry>");
     prDocBook.println("                </row>");
@@ -776,8 +767,6 @@ class WriteDOMDocBook extends Object {
           prDocBook.println("                    <entry></entry>");
           prDocBook.println(
               "                    <entry>" + getValueBreak(lPermValueDefn.value) + "</entry>");
-          // prDocBook.println(" <entry>" + getValueAnchor(lAttr, lPermValueDefn.value) +
-          // getValueBreak (lPermValueDefn.value) + "</entry>");
           prDocBook
               .println("                    <entry namest=\"c3\" nameend=\"c4\" align=\"left\">"
                   + getValue(lPermValueDefn.value_meaning) + "</entry>");
@@ -800,9 +789,6 @@ class WriteDOMDocBook extends Object {
     prDocBook
         .println("      <!-- =====================Part4a Begin=========================== -->");
     prDocBook.println("");
-    // prDocBook.println(" <chapter>");
-    // prDocBook.println(" <title>Data Types in the common namespace.</title>");
-    // prDocBook.println(" <para>These classes define the data types. </para>");
 
     // Sort the data types
     TreeMap<String, DOMClass> sortDataTypeMap = new TreeMap<>();
@@ -968,9 +954,6 @@ class WriteDOMDocBook extends Object {
     prDocBook
         .println("      <!-- =====================Part4b Begin=========================== -->");
     prDocBook.println("");
-    // prDocBook.println(" <chapter>");
-    // prDocBook.println(" <title>Units of Measure in the common namespace.</title>");
-    // prDocBook.println(" <para>These classes define the units of measure. </para>");
 
     // get the units
     ArrayList<DOMProp> lDOMPermValueArr;
@@ -1221,7 +1204,6 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("                </para>");
     prDocBook.println("            </sect1>");
     prDocBook.println("        </chapter>");
-    // prDocBook.println(" </part>");
     prDocBook.println("");
     return;
   }
@@ -1232,9 +1214,6 @@ class WriteDOMDocBook extends Object {
   }
 
   private String getPrompt(String lPrompt) {
-    // return "<emphasis role=\"italic\">" + "<emphasis role=\"bold\">" + lPrompt + "</emphasis>" +
-    // "</emphasis>";
-    // return "<emphasis role=\"italic\">" + lPrompt + "</emphasis>";
     return "<emphasis>" + lPrompt + "</emphasis>";
   }
 
@@ -1255,12 +1234,6 @@ class WriteDOMDocBook extends Object {
   }
 
   private String getValueAnchor(DOMAttr lAttr, String lValue) {
-    // String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." +
-    // lAttr.attrNameSpaceIdNC + "." + lAttr.parentClassTitle + "." + lAttr.attrNameSpaceIdNC + "."
-    // + lAttr.title + "." + lValue;
-    // String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." +
-    // lAttr.attrNameSpaceIdNC + "." + lAttr.attrParentClass.title + "." + lAttr.attrNameSpaceIdNC +
-    // "." + lAttr.title + "." + lValue;
     String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "."
         + lAttr.classNameSpaceIdNC + "." + lAttr.attrParentClass.title + "." + lAttr.nameSpaceIdNC
         + "." + lAttr.title + "." + lValue;
@@ -1283,12 +1256,6 @@ class WriteDOMDocBook extends Object {
   }
 
   private String getAttrAnchor(DOMAttr lAttr) {
-    // String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." +
-    // lAttr.attrNameSpaceIdNC + "." + lAttr.parentClassTitle + "." + lAttr.attrNameSpaceIdNC + "."
-    // + lAttr.title;
-    // String lAnchor = DMDocument.registrationAuthorityIdentifierValue + "." +
-    // lAttr.attrNameSpaceIdNC + "." + lAttr.attrParentClass.title + "." + lAttr.attrNameSpaceIdNC +
-    // "." + lAttr.title;
     String lAnchor =
         DMDocument.registrationAuthorityIdentifierValue + "." + lAttr.classNameSpaceIdNC + "."
             + lAttr.attrParentClass.title + "." + lAttr.nameSpaceIdNC + "." + lAttr.title;
@@ -1407,7 +1374,6 @@ class WriteDOMDocBook extends Object {
   }
 
   // locally defined classes for classifying classes and attributes
-
   public class ClassClassificationDefnDOM {
     String identifier;
     String namespaceId;

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDocBook.java
@@ -238,8 +238,8 @@ class WriteDOMDocBook extends Object {
     writeHeader(prDocBook);
 
     // write the Common dictionary
-    writeClassSection(DMDocument.getMasterNameSpaceIdNCLC(), prDocBook);
-    writeAttrSection(DMDocument.getMasterNameSpaceIdNCLC(), prDocBook);
+    writeClassSection(DMDocument.getMasterNameSpaceIdNCLC(), lSchemaFileDefn.versionId, DMDocument.masterPDSSchemaFileDefn.ont_version_id, prDocBook);
+    writeAttrSection(DMDocument.getMasterNameSpaceIdNCLC(), lSchemaFileDefn.versionId, DMDocument.masterPDSSchemaFileDefn.ont_version_id, prDocBook);
 
     // write the LDDs
     for (SchemaFileDefn lSchemaFileDefnToWrite: lSchemaFileDefnToWriteArr) {
@@ -250,14 +250,14 @@ class WriteDOMDocBook extends Object {
           classClassificationMap.get(lSchemaFileDefnToWrite.nameSpaceIdNCLC);
       if (lClassClassificationDefn != null) {
         if (lClassClassificationDefn.classArr.size() > 0) {
-          writeClassSection(lClassClassificationDefn, prDocBook);
+          writeClassSection(lClassClassificationDefn, lSchemaFileDefnToWrite.versionId, DMDocument.masterPDSSchemaFileDefn.ont_version_id, prDocBook);
         }
       }
       AttrClassificationDefnDOM lAttrClassificationDefn =
           attrClassificationMap.get(lSchemaFileDefnToWrite.nameSpaceIdNCLC);
       if (lAttrClassificationDefn != null) {
         if (lAttrClassificationDefn.attrArr.size() > 0) {
-          writeAttrSection(lAttrClassificationDefn, prDocBook);
+          writeAttrSection(lAttrClassificationDefn, lSchemaFileDefnToWrite.versionId, DMDocument.masterPDSSchemaFileDefn.ont_version_id, prDocBook);
         }
       }
     }
@@ -270,7 +270,7 @@ class WriteDOMDocBook extends Object {
     return;
   }
 
-  private void writeClassSection(String lNameSpaceId, PrintWriter prDocBook) {
+  private void writeClassSection(String lNameSpaceId,  String lddVersionId, String imVersionId, PrintWriter prDocBook) {
     prDocBook.println("");
     prDocBook.println("      <!-- =====================Part2 Begin=========================== -->");
     prDocBook.println("");
@@ -281,7 +281,7 @@ class WriteDOMDocBook extends Object {
       prDocBook.println("           <title>Product Classes in the common namespace.</title>");
       prDocBook.println("           <para>These classes define the products.</para>");
       for (DOMClass lClass: lClassClassificationDefn.classArr) {
-        writeClass(lClass, prDocBook);
+        writeClass(lClass, lddVersionId, imVersionId, prDocBook);
       }
       prDocBook.println("        </chapter>");
       prDocBook.println("");
@@ -294,7 +294,7 @@ class WriteDOMDocBook extends Object {
       prDocBook.println(
           "           <para>The classes in this section are used by the product classes.</para>");
       for (DOMClass lClass: lClassClassificationDefn.classArr) {
-        writeClass(lClass, prDocBook);
+        writeClass(lClass, lddVersionId, imVersionId, prDocBook);
       }
       prDocBook.println("        </chapter>");
       prDocBook.println("");
@@ -308,7 +308,7 @@ class WriteDOMDocBook extends Object {
         prDocBook.println("           <title>OPS catalog classes in the common namespace.</title>");
         prDocBook.println("           <para>These classes support operations. </para>");
         for (DOMClass lClass: lClassClassificationDefn.classArr) {
-          writeClass(lClass, prDocBook);
+          writeClass(lClass, lddVersionId, imVersionId, prDocBook);
         }
         prDocBook.println("        </chapter>");
         prDocBook.println("");
@@ -319,7 +319,7 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("");
   }
 
-  private void writeClassSection(ClassClassificationDefnDOM lClassClassificationDefn,
+  private void writeClassSection(ClassClassificationDefnDOM lClassClassificationDefn, String lddVersionId, String imVersionId, 
       PrintWriter prDocBook) {
     prDocBook.println("");
     prDocBook.println(
@@ -331,7 +331,7 @@ class WriteDOMDocBook extends Object {
         + " namespace.</title>");
     prDocBook.println("           <para>These classes comprise the namespace.</para>");
     for (DOMClass lClass: lClassClassificationDefn.classArr) {
-      writeClass(lClass, prDocBook);
+      writeClass(lClass, lddVersionId, imVersionId, prDocBook);
     }
     prDocBook.println("        </chapter>");
     prDocBook.println("");
@@ -342,7 +342,7 @@ class WriteDOMDocBook extends Object {
   }
 
   private void writeAttrSection(AttrClassificationDefnDOM lAttrClassificationDefn,
-      PrintWriter prDocBook) {
+		  String lddVersionId, String imVersionId, PrintWriter prDocBook) {
     prDocBook.println("");
     prDocBook.println(
         "      <!-- ===================== LDD Attribute Begin =========================== -->");
@@ -354,7 +354,7 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("           <para>These attributes are used by the classes in the "
         + lAttrClassificationDefn.namespaceId + " namespace. </para>");
     for (DOMAttr lAttr: lAttrClassificationDefn.attrArr) {
-      writeAttr(lAttr, prDocBook);
+      writeAttr(lAttr, lddVersionId, imVersionId, prDocBook);
     }
     prDocBook.println("        </chapter>");
     prDocBook.println("");
@@ -364,7 +364,7 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("");
   }
 
-  private void writeClass(DOMClass lClass, PrintWriter prDocBook) {
+  private void writeClass(DOMClass lClass, String lddVersionId, String imVersionId, PrintWriter prDocBook) {
     String lValueString = "";
     String lValueDel = "";
     String lRegistrationStatus = "Active";
@@ -388,12 +388,12 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("                <row>");
    	prDocBook.println("                    <entry namest=\"c1\" nameend=\"c2\" align=\"left\">"
         + getPrompt("Name: ") + getValue(lClass.title) + lRegistrationStatusInsert + "</entry>");
-    String versionIdLiteral = "DD Version: ";
-    if (lClass.getNameSpaceIdNC().compareTo("pds") != 0) versionIdLiteral = "LDD Version: ";   	
-   	prDocBook.println("                    <entry>" + getPrompt(versionIdLiteral)
-    + getValue(DMDocument.masterLDDSchemaFileDefn.versionId) + "</entry>");
+    String lddVersionIdLiteral = "DD Version: ";
+    if (lClass.getNameSpaceIdNC().compareTo("pds") != 0) lddVersionIdLiteral = "LDD Version: ";   	
+   	prDocBook.println("                    <entry>" + getPrompt(lddVersionIdLiteral)
+    + getValue(lddVersionId) + "</entry>");
     prDocBook.println("                    <entry>" + getPrompt("IM Version: ")
-    + getValue(DMDocument.masterPDSSchemaFileDefn.ont_version_id) + "</entry>");
+    + getValue(imVersionId) + "</entry>");
     prDocBook.println("                </row>");
     prDocBook.println("            </thead>");
     prDocBook.println("            <tbody>");
@@ -581,7 +581,7 @@ class WriteDOMDocBook extends Object {
     return;
   }
 
-  private void writeAttrSection(String lNameSpaceId, PrintWriter prDocBook) {
+  private void writeAttrSection(String lNameSpaceId, String lddVersionId, String imVersionId, PrintWriter prDocBook) {
     prDocBook.println("");
     prDocBook.println("      <!-- =====================Part3 Begin=========================== -->");
     prDocBook.println("");
@@ -594,7 +594,7 @@ class WriteDOMDocBook extends Object {
       prDocBook.println(
           "           <para>These attributes are used by the classes in the common namespace. </para>");
       for (DOMAttr lAttr: lAttrClassificationDefn.attrArr) {
-        writeAttr(lAttr, prDocBook);
+        writeAttr(lAttr, lddVersionId, imVersionId, prDocBook);
       }
       prDocBook.println("        </chapter>");
       prDocBook.println("");
@@ -604,7 +604,7 @@ class WriteDOMDocBook extends Object {
     prDocBook.println("");
   }
 
-  private void writeAttr(DOMAttr lAttr, PrintWriter prDocBook) {
+  private void writeAttr(DOMAttr lAttr, String lddVersionId, String imVersionId, PrintWriter prDocBook) {
     String lRegistrationStatus = "Active";
     String lRegistrationStatusInsert = "";
     if (lAttr.registrationStatus.compareTo("Retired") == 0) {
@@ -631,9 +631,9 @@ class WriteDOMDocBook extends Object {
     String versionIdLiteral = "DD Version: ";
     if (lAttr.getNameSpaceIdNC().compareTo("pds") != 0) versionIdLiteral = "LDD Version: ";
     prDocBook.println(" <entry>" + getPrompt(versionIdLiteral)
-    + getValue(DMDocument.masterLDDSchemaFileDefn.versionId) + "</entry>");
+    + getValue(lddVersionId) + "</entry>");
     prDocBook.println("                    <entry>" + getPrompt("IM Version: ")
-    + getValue(DMDocument.masterPDSSchemaFileDefn.ont_version_id) + "</entry>");    
+    + getValue(imVersionId) + "</entry>");    
     prDocBook.println("                </row>");
     prDocBook.println("            </thead>");
     prDocBook.println("            <tbody>");


### PR DESCRIPTION
As a user, I want to easily identify which IM and LDD version the WebHelp documentation is for #939

## 🗒️ Summary
Modified the DocBook writer to include the IM version id for each class and attribute definition. Also fixed a problem with class and attribute version ids. 

## ⚙️ Test Data and/or Report
The attached snippet from the generated DocBook files shows the IM version id in class and attribute definitions.
[array.pdf](https://github.com/user-attachments/files/21799801/array.pdf)

## ♻️ Related Issues
Resolves #939


