### PR TITLE
Added new permissible value for File_Area_Observational.Header.parsing_standard_id: `CDF 3.9 ISTP/IACG`

### DIFF
--- a/model-lddtool/src/test/resources/data/update_version/github942/aaaReadme.txt
+++ b/model-lddtool/src/test/resources/data/update_version/github942/aaaReadme.txt
@@ -1,0 +1,111 @@
+﻿
+IM#942: new permissible value for File_Area_Observational.Header.parsing_standard_id: CDF 3.9 ISTP/IACG
+          -- modifications to SCH:
+
+--- only validate local directory; no children directories
+cd D:\WINWORD\Standards-DataDictionary\PDS4_SCRs\CCB-60_parsing_standard_id_20250430\aaaBuild_testcases_20250827
+validate_363 -t *.xml -r log_validate.txt --schema PDS4_PDS_1P00.xsd --schematron PDS4_PDS_1P00.sch --skip-content-validation --local
+
+Change this:
+
+  <sch:pattern>
+    <sch:rule context="pds:Header/pds:parsing_standard_id">
+      <sch:assert test=". = ('7-Bit ASCII Text', 'CDF 3.4 ISTP/IACG', 'CDF 3.5 ISTP/IACG', 'CDF 3.6 ISTP/IACG', 'CDF 3.7 ISTP/IACG', 'CDF 3.8 ISTP/IACG', 'FITS 3.0', 'FITS 4.0', 'ISIS2', 'ISIS2 History Label', 'ISIS3', 'PDS DSV 1', 'PDS ODL 2', 'PDS3', 'Pre-PDS3', 'TIFF 6.0', 'UTF-8 Text', 'VICAR1', 'VICAR2')">
+        <title>pds:Header/pds:parsing_standard_id/pds:parsing_standard_id</title>
+        The attribute pds:Header/pds:parsing_standard_id must be equal to one of the following values '7-Bit ASCII Text', 'CDF 3.4 ISTP/IACG', 'CDF 3.5 ISTP/IACG', 'CDF 3.6 ISTP/IACG', 'CDF 3.7 ISTP/IACG', 'CDF 3.8 ISTP/IACG', 'CDF 3.9 ISTP/IACG', 'FITS 3.0', 'FITS 4.0', 'ISIS2', 'ISIS2 History Label', 'ISIS3', 'PDS DSV 1', 'PDS ODL 2', 'PDS3', 'Pre-PDS3', 'TIFF 6.0', 'UTF-8 Text', 'VICAR1', 'VICAR2'.</sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  
+To this:
+
+  <sch:pattern>
+    <sch:rule context="pds:Header/pds:parsing_standard_id">
+      <sch:assert test=". = ('7-Bit ASCII Text', 'CDF 3.4 ISTP/IACG', 'CDF 3.5 ISTP/IACG', 'CDF 3.6 ISTP/IACG', 'CDF 3.7 ISTP/IACG', 'CDF 3.8 ISTP/IACG', 'CDF 3.9 ISTP/IACG', 'FITS 3.0', 'FITS 4.0', 'ISIS2', 'ISIS2 History Label', 'ISIS3', 'PDS DSV 1', 'PDS ODL 2', 'PDS3', 'Pre-PDS3', 'TIFF 6.0', 'UTF-8 Text', 'VICAR1', 'VICAR2')">
+        <title>pds:Header/pds:parsing_standard_id/pds:parsing_standard_id</title>
+        The attribute pds:Header/pds:parsing_standard_id must be equal to one of the following values '7-Bit ASCII Text', 'CDF 3.4 ISTP/IACG', 'CDF 3.5 ISTP/IACG', 'CDF 3.6 ISTP/IACG', 'CDF 3.7 ISTP/IACG', 'CDF 3.8 ISTP/IACG', 'CDF 3.9 ISTP/IACG', 'FITS 3.0', 'FITS 4.0', 'ISIS2', 'ISIS2 History Label', 'ISIS3', 'PDS DSV 1', 'PDS ODL 2', 'PDS3', 'Pre-PDS3', 'TIFF 6.0', 'UTF-8 Text', 'VICAR1', 'VICAR2'.</sch:assert>
+    </sch:rule>
+  </sch:pattern>
+  
+    
+=============================
+PDS Validate Tool Report
+
+Configuration:
+   Version     3.6.3
+   Date        2025-08-28T16:03:05Z
+
+Parameters:
+   Targets                        [file:/D:/WINWORD/Standards-DataDictionary/PDS4_SCRs/CCB-60_parsing_standard_id_20250430/aaaBuild_testcases_20250827/tc_Fail_invalid-value_20250828.xml, file:/D:/WINWORD/Standards-DataDictionary/PDS4_SCRs/CCB-60_parsing_standard_id_20250430/aaaBuild_testcases_20250827/tc_Valid_new_value_20250828.xml]
+   User Specified Schemas         [file:/D:/WINWORD/Standards-DataDictionary/PDS4_SCRs/CCB-60_parsing_standard_id_20250430/aaaBuild_testcases_20250827/PDS4_PDS_1P00.xsd]
+   User Specified Schematrons     [file:/D:/WINWORD/Standards-DataDictionary/PDS4_SCRs/CCB-60_parsing_standard_id_20250430/aaaBuild_testcases_20250827/PDS4_PDS_1P00.sch]
+   Severity Level                 WARNING
+   Recurse Directories            false
+   File Filters Used              [*.xml, *.XML]
+   Data Content Validation        off
+   Product Level Validation       on
+   Max Errors                     100000
+   Registered Contexts File       E:\PDS_Validate_tool\validate_v3_6_3_20241122\validate-3.6.3\resources\registered_context_products.json
+
+
+
+Product Level Validation Results
+
+  FAIL: file:/D:/WINWORD/Standards-DataDictionary/PDS4_SCRs/CCB-60_parsing_standard_id_20250430/aaaBuild_testcases_20250827/tc_Fail_invalid-value_20250828.xml
+      ERROR  [error.label.schematron]   line 104, 28: The attribute pds:Header/pds:parsing_standard_id must be equal to one of the following values '7-Bit ASCII Text', 'CDF 3.4 ISTP/IACG', 'CDF 3.5 ISTP/IACG', 'CDF 3.6 ISTP/IACG', 'CDF 3.7 ISTP/IACG', 'CDF 3.8 ISTP/IACG', 'CDF 3.9 ISTP/IACG', 'FITS 3.0', 'FITS 4.0', 'ISIS2', 'ISIS2 History Label', 'ISIS3', 'PDS DSV 1', 'PDS ODL 2', 'PDS3', 'Pre-PDS3', 'TIFF 6.0', 'UTF-8 Text', 'VICAR1', 'VICAR2'.
+      WARNING  [warning.label.context_ref_mismatch]   line 47: Context reference name mismatch. Value: 'Product_Observational' Expected one of: '[Mars Reconnaissance Orbiter]'
+        1 product validation(s) completed
+
+  PASS: file:/D:/WINWORD/Standards-DataDictionary/PDS4_SCRs/CCB-60_parsing_standard_id_20250430/aaaBuild_testcases_20250827/tc_Valid_new_value_20250828.xml
+      WARNING  [warning.label.context_ref_mismatch]   line 47: Context reference name mismatch. Value: 'Product_Observational' Expected one of: '[Mars Reconnaissance Orbiter]'
+        2 product validation(s) completed
+
+Summary:
+
+  2 product(s)
+  1 error(s)
+  2 warning(s)
+
+  Product Validation Summary:
+    1          product(s) passed
+    1          product(s) failed
+    0          product(s) skipped
+    2          product(s) total
+
+  Referential Integrity Check Summary:
+    0          check(s) passed
+    0          check(s) failed
+    0          check(s) skipped
+    0          check(s) total
+
+  Message Types:
+    1            error.label.schematron
+    2            warning.label.context_ref_mismatch
+
+End of Report
+=============================
+
+=============================
+mvn clean test
+=============================
+
+[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 130.6 s -- in cucumber.CucumberTest
+[INFO]
+[INFO] Results:
+[INFO]
+[INFO] Tests run: 42, Failures: 0, Errors: 0, Skipped: 0
+[INFO]
+[INFO] ------------------------------------------------------------------------
+[INFO] Reactor Summary for PDS4 Information Model 15.4.0-SNAPSHOT:
+[INFO]
+[INFO] PDS4 Information Model ............................. SUCCESS [  0.172 s]
+[INFO] Model DM-Document Maven Plugin ..................... SUCCESS [  9.201 s]
+[INFO] Model Ontology ..................................... SUCCESS [  0.603 s]
+[INFO] Local Data Dictionary Tool ......................... SUCCESS [02:32 min]
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time:  02:43 min
+[INFO] Finished at: 2025-09-09T07:47:57-07:00
+[INFO] ------------------------------------------------------------------------
+
+D:\GitHub_projects\pds4-information-model>

--- a/model-lddtool/src/test/resources/data/update_version/github942/tc_Fail_invalid-value_20250828.xml
+++ b/model-lddtool/src/test/resources/data/update_version/github942/tc_Fail_invalid-value_20250828.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="PDS4_PDS_1P00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Observational xmlns="http://pds.nasa.gov/pds4/pds/v1" 
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 PDS4_PDS_1P00.xsd">
+  
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:mro_hirise:map_projected_rdr:esp_043896_2055_red</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>MRO MARS HIGH RESOLUTION IMAGING SCIENCE EXPERIMENT REDUCED DATA RECORD EQUIRECTANGULAR PROJECTION</title>
+    <information_model_version>1.25.0.0</information_model_version>
+    <product_class>Product_Observational</product_class>
+    <Alias_List>
+      <Alias>
+        <alternate_id>/HiRISE/Users/rod/pds4_sample_data_workfiles/RDR/ESP_043896_2055/ESP_043896_2055_RED.tif</alternate_id>
+        <comment>Original filename at PDS4 archive, on-line at HiRISE Node</comment>
+      </Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2024-07-17</modification_date>
+        <version_id>1.0</version_id>
+        <description>This PDS4 detached label for HiRISE map projected 
+          "Reduced Data Record" product.
+        </description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Observation_Area>
+    <Time_Coordinates>
+      <start_date_time>2015-12-07T21:26:02.757Z</start_date_time>
+      <stop_date_time>2015-12-07T21:26:04.637Z</stop_date_time>
+      <local_true_solar_time>15.01252</local_true_solar_time>
+      <solar_longitude unit="deg">78.493145</solar_longitude>
+    </Time_Coordinates>
+    <Primary_Result_Summary>
+      <purpose>Science</purpose>
+      <processing_level>Derived</processing_level>
+      <description>Calibrated, mosaicked and map-projected HiRISE observation of the target in GeoTIFF format</description>
+    </Primary_Result_Summary>
+    <Investigation_Area>
+      <name>Product_Observational</name>
+      <type>Mission</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:investigation:mission.mars_reconnaissance_orbiter</lid_reference>
+        <reference_type>data_to_investigation</reference_type>
+        <comment>This is the PDS4 logical identifier for MRO</comment>
+      </Internal_Reference>
+    </Investigation_Area>
+    <Observing_System>
+      <Observing_System_Component>
+        <name>HIGH RESOLUTION IMAGING SCIENCE EXPERIMENT</name>
+        <type>Instrument</type>
+        <Internal_Reference>
+          <lid_reference>urn:nasa:pds:context:instrument:hirise.mro</lid_reference>
+          <reference_type>is_instrument</reference_type>
+        </Internal_Reference>
+      </Observing_System_Component>
+    </Observing_System>
+    <Target_Identification>
+      <name>Mars</name>
+      <type>Planet</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:target:planet.mars</lid_reference>
+        <reference_type>data_to_target</reference_type>
+      </Internal_Reference>
+    </Target_Identification>
+    <Mission_Area>
+    </Mission_Area>
+    <Discipline_Area>
+    </Discipline_Area>
+  </Observation_Area>
+  <Reference_List>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:mro_hirise:collection_naming_tbd:hirise_rdr_sis</lid_reference>
+      <reference_type>data_to_document</reference_type>
+      <comment>documentation and citation(s) for this data product</comment>
+    </Internal_Reference>
+    <External_Reference>
+      <doi>10.1029/2005JE002605</doi>
+      <reference_text>McEwen, Alfred S. ; Eliason, Eric M. ; Bergstrom, James W. ; 
+        Bridges, Nathan T. ; Hansen, Candice J. ; Delamere, W. Alan ; Grant, John A. ; 
+        Gulick, Virginia C. ; Herkenhoff, Kenneth E. ; Keszthelyi, Laszlo ; 
+        Kirk, Randolph L. ; Mellon, Michael T. ; Squyres, Steven W. ; Thomas, Nicolas ; 
+        Weitz, Catherine M. (2007) Mars Reconnaissance Orbiter's High Resolution Imaging Science 
+        Experiment (HiRISE) Journal of Geophysical Research, Volume 112, Issue E5
+      </reference_text>
+      <description>instrument overview</description>
+    </External_Reference>
+  </Reference_List>
+  <File_Area_Observational>
+    <File>
+      <file_name>ESP_043896_2055_RED2.tif</file_name>
+      <local_identifier>DATA_FILE</local_identifier>
+      <creation_date_time>2015-12-16T15:47:59Z</creation_date_time>
+      <file_size unit="byte">1184018549</file_size>
+    </File>
+    <Header>
+      <offset unit="byte">0</offset>
+      <object_length unit="byte">152747</object_length>
+      <!-- Invalid enumerated value -->
+      <parsing_standard_id>CDF 3.9 ISTP/IACGgggg</parsing_standard_id>
+      
+      <description>TIFF/GeoTIFF header. The TIFF/GeoTIFF format is used throughout the geospatial and science communities to share geographic image data. </description>
+    </Header>
+    <Array_3D_Image>
+      <local_identifier>Array_2D_Image</local_identifier>
+      <offset unit="byte">152747</offset>
+      <axes>3</axes>
+      <axis_index_order>Last Index Fastest</axis_index_order>
+      <Element_Array>
+        <data_type>UnsignedLSB2</data_type>
+        <scaling_factor>8.30305496949213998e-05</scaling_factor>
+        <value_offset>0.112092366553879996</value_offset>
+      </Element_Array>
+      <Axis_Array>
+        <axis_name>Band</axis_name>
+        <elements>1</elements>
+        <sequence_number>1</sequence_number>
+      </Axis_Array>
+      <Axis_Array>
+        <axis_name>Line</axis_name>
+        <elements>25319</elements>
+        <sequence_number>2</sequence_number>
+      </Axis_Array>
+      <Axis_Array>
+        <axis_name>Sample</axis_name>
+        <elements>23379</elements>
+        <sequence_number>3</sequence_number>
+      </Axis_Array>
+      <Special_Constants>
+        <missing_constant>0</missing_constant>
+        <invalid_constant>0</invalid_constant>
+        <high_instrument_saturation>1022</high_instrument_saturation>
+        <high_representation_saturation>1023</high_representation_saturation>
+        <low_instrument_saturation>2</low_instrument_saturation>
+        <low_representation_saturation>1</low_representation_saturation>
+      </Special_Constants>
+    </Array_3D_Image>
+  </File_Area_Observational>
+  <File_Area_Observational_Supplemental>
+    <File>
+      <file_name>ESP_043896_2055_RED2.LBL</file_name>
+      <comment>Original PDS3 label for this data product</comment>
+    </File>
+    <Stream_Text>
+      <offset unit="byte">0</offset>
+      <parsing_standard_id>PDS3</parsing_standard_id>
+      <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+    </Stream_Text>
+  </File_Area_Observational_Supplemental>
+  <File_Area_Observational_Supplemental>
+    <File>
+      <file_name>ESP_043896_2055_RED2.JPEG</file_name>
+      <comment>Original PDS3 product, a JPEG2000 encoded image</comment>
+    </File>
+    <Encoded_Image>
+      <offset unit="byte">0</offset>
+      <!-- test 'JPEG' as new enumerated value -->
+      <encoding_standard_id>JPEG</encoding_standard_id>
+    </Encoded_Image>
+  </File_Area_Observational_Supplemental>
+</Product_Observational>

--- a/model-lddtool/src/test/resources/data/update_version/github942/tc_Valid_new_value_20250828.xml
+++ b/model-lddtool/src/test/resources/data/update_version/github942/tc_Valid_new_value_20250828.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="PDS4_PDS_1P00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<Product_Observational xmlns="http://pds.nasa.gov/pds4/pds/v1" 
+  xmlns:pds="http://pds.nasa.gov/pds4/pds/v1" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 PDS4_PDS_1P00.xsd">
+   
+  <Identification_Area>
+    <logical_identifier>urn:nasa:pds:mro_hirise:map_projected_rdr:esp_043896_2055_red</logical_identifier>
+    <version_id>1.0</version_id>
+    <title>MRO MARS HIGH RESOLUTION IMAGING SCIENCE EXPERIMENT REDUCED DATA RECORD EQUIRECTANGULAR PROJECTION</title>
+    <information_model_version>1.25.0.0</information_model_version>
+    <product_class>Product_Observational</product_class>
+    <Alias_List>
+      <Alias>
+        <alternate_id>/HiRISE/Users/rod/pds4_sample_data_workfiles/RDR/ESP_043896_2055/ESP_043896_2055_RED.tif</alternate_id>
+        <comment>Original filename at PDS4 archive, on-line at HiRISE Node</comment>
+      </Alias>
+    </Alias_List>
+    <Modification_History>
+      <Modification_Detail>
+        <modification_date>2024-07-17</modification_date>
+        <version_id>1.0</version_id>
+        <description>This PDS4 detached label for HiRISE map projected 
+                    "Reduced Data Record" product.
+                </description>
+      </Modification_Detail>
+    </Modification_History>
+  </Identification_Area>
+  <Observation_Area>
+    <Time_Coordinates>
+      <start_date_time>2015-12-07T21:26:02.757Z</start_date_time>
+      <stop_date_time>2015-12-07T21:26:04.637Z</stop_date_time>
+      <local_true_solar_time>15.01252</local_true_solar_time>
+      <solar_longitude unit="deg">78.493145</solar_longitude>
+    </Time_Coordinates>
+    <Primary_Result_Summary>
+      <purpose>Science</purpose>
+      <processing_level>Derived</processing_level>
+      <description>Calibrated, mosaicked and map-projected HiRISE observation of the target in GeoTIFF format</description>
+    </Primary_Result_Summary>
+    <Investigation_Area>
+      <name>Product_Observational</name>
+      <type>Mission</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:investigation:mission.mars_reconnaissance_orbiter</lid_reference>
+        <reference_type>data_to_investigation</reference_type>
+        <comment>This is the PDS4 logical identifier for MRO</comment>
+      </Internal_Reference>
+    </Investigation_Area>
+    <Observing_System>
+      <Observing_System_Component>
+        <name>HIGH RESOLUTION IMAGING SCIENCE EXPERIMENT</name>
+        <type>Instrument</type>
+        <Internal_Reference>
+          <lid_reference>urn:nasa:pds:context:instrument:hirise.mro</lid_reference>
+          <reference_type>is_instrument</reference_type>
+        </Internal_Reference>
+      </Observing_System_Component>
+    </Observing_System>
+    <Target_Identification>
+      <name>Mars</name>
+      <type>Planet</type>
+      <Internal_Reference>
+        <lid_reference>urn:nasa:pds:context:target:planet.mars</lid_reference>
+        <reference_type>data_to_target</reference_type>
+      </Internal_Reference>
+    </Target_Identification>
+    <Mission_Area>
+    </Mission_Area>
+    <Discipline_Area>
+    </Discipline_Area>
+  </Observation_Area>
+  <Reference_List>
+    <Internal_Reference>
+      <lid_reference>urn:nasa:pds:mro_hirise:collection_naming_tbd:hirise_rdr_sis</lid_reference>
+      <reference_type>data_to_document</reference_type>
+      <comment>documentation and citation(s) for this data product</comment>
+    </Internal_Reference>
+    <External_Reference>
+      <doi>10.1029/2005JE002605</doi>
+      <reference_text>McEwen, Alfred S. ; Eliason, Eric M. ; Bergstrom, James W. ; 
+                Bridges, Nathan T. ; Hansen, Candice J. ; Delamere, W. Alan ; Grant, John A. ; 
+                Gulick, Virginia C. ; Herkenhoff, Kenneth E. ; Keszthelyi, Laszlo ; 
+                Kirk, Randolph L. ; Mellon, Michael T. ; Squyres, Steven W. ; Thomas, Nicolas ; 
+                Weitz, Catherine M. (2007) Mars Reconnaissance Orbiter's High Resolution Imaging Science 
+                Experiment (HiRISE) Journal of Geophysical Research, Volume 112, Issue E5
+            </reference_text>
+      <description>instrument overview</description>
+    </External_Reference>
+  </Reference_List>
+  <File_Area_Observational>
+    <File>
+      <file_name>ESP_043896_2055_RED.tif</file_name>
+      <local_identifier>DATA_FILE</local_identifier>
+      <creation_date_time>2015-12-16T15:47:59Z</creation_date_time>
+      <file_size unit="byte">1184018549</file_size>
+    </File>
+    <Header>
+      <offset unit="byte">0</offset>
+      <object_length unit="byte">152747</object_length>
+      <!-- new value -->
+      <parsing_standard_id>CDF 3.9 ISTP/IACG</parsing_standard_id>
+      
+      <description>TIFF/GeoTIFF header. The TIFF/GeoTIFF format is used throughout the geospatial and science communities to share geographic image data. </description>
+    </Header>
+    <Array_3D_Image>
+      <local_identifier>Array_2D_Image</local_identifier>
+      <offset unit="byte">152747</offset>
+      <axes>3</axes>
+      <axis_index_order>Last Index Fastest</axis_index_order>
+      <Element_Array>
+        <data_type>UnsignedLSB2</data_type>
+        <scaling_factor>8.30305496949213998e-05</scaling_factor>
+        <value_offset>0.112092366553879996</value_offset>
+      </Element_Array>
+      <Axis_Array>
+        <axis_name>Band</axis_name>
+        <elements>1</elements>
+        <sequence_number>1</sequence_number>
+      </Axis_Array>
+      <Axis_Array>
+        <axis_name>Line</axis_name>
+        <elements>25319</elements>
+        <sequence_number>2</sequence_number>
+      </Axis_Array>
+      <Axis_Array>
+        <axis_name>Sample</axis_name>
+        <elements>23379</elements>
+        <sequence_number>3</sequence_number>
+      </Axis_Array>
+      <Special_Constants>
+        <missing_constant>0</missing_constant>
+        <invalid_constant>0</invalid_constant>
+        <high_instrument_saturation>1022</high_instrument_saturation>
+        <high_representation_saturation>1023</high_representation_saturation>
+        <low_instrument_saturation>2</low_instrument_saturation>
+        <low_representation_saturation>1</low_representation_saturation>
+      </Special_Constants>
+    </Array_3D_Image>
+  </File_Area_Observational>
+  <File_Area_Observational_Supplemental>
+    <File>
+      <file_name>ESP_043896_2055_RED.LBL</file_name>
+      <comment>Original PDS3 label for this data product</comment>
+    </File>
+    <Stream_Text>
+      <offset unit="byte">0</offset>
+      <parsing_standard_id>PDS3</parsing_standard_id>
+      <record_delimiter>Carriage-Return Line-Feed</record_delimiter>
+    </Stream_Text>
+  </File_Area_Observational_Supplemental>
+  <File_Area_Observational_Supplemental>
+    <File>
+      <file_name>ESP_043896_2055_RED.JPEG</file_name>
+      <comment>Original PDS3 product, a JPEG2000 encoded image</comment>
+    </File>
+    <Encoded_Image>
+      <offset unit="byte">0</offset>
+      <!-- test 'JPEG' as new enumerated value -->
+      <encoding_standard_id>JPEG</encoding_standard_id>
+    </Encoded_Image>
+  </File_Area_Observational_Supplemental>
+</Product_Observational>

--- a/model-lddtool/src/test/resources/features/validate.feature
+++ b/model-lddtool/src/test/resources/features/validate.feature
@@ -60,4 +60,5 @@ Feature: pds4_information_model_validate_integration
     @v15.4.x
     Examples: 
 | testId                                  | testName                                                         | testDir      | messageCount| problemEnum         | commandArgs                                                                    | ingestLDDFileName               | pds4Version |
+| NASA-PDS/pds4-information-model#942   | "Added new permissible value for parsing_standard_id (CCB-60)"     | "github942"  |           1 |  "SCHEMATRON_ERROR" | "-t {resourceUpdateVersionDir}/github942/tc_Valid_new_value_20250828.xml {resourceUpdateVersionDir}/github942/tc_Fail_invalid-value_20250828.xml"  | "" | "" |
 | NASA-PDS/pds4-information-model#944   | "Modified pattern for funding_year. (CCB-59)"                      | "github944"  |           2 |  "SCHEMA_ERROR"     | "-t {resourceUpdateVersionDir}/github944/test_case_Valid_20241024.xml {resourceUpdateVersionDir}/github944/tc_VALID_funding_year_20250829.xml {resourceUpdateVersionDir}/github944/tc_FAIL_funding_year_20250829.xml {resourceUpdateVersionDir}/github944/tc_FAIL_funding_year_alpha_20250829"  | "" | "" |


### PR DESCRIPTION
Added new permissible value for File_Area_Observational.Header.parsing_standard_id: "CDF 3.9 ISTP/IACG"

## 🗒️ Summary
The current release of CDF is V.3.9.1. File_Area_Observational.Header.parsing_standard_id currently only supports up to V.3.8. Added CDF 3.9 ISTP/IACG as a permissible value for Header.parsing_standard_id.

## ⚙️ Test Data and/or Report
@rsjoyner to add tests.

## ♻️ Related Issues
Resolves #945
Refs [#60](https://github.com/NASA-PDS/PDS4-CCB/issues/60)

