### PR TITLE
Fix method identified by SonarQube as a "Brain Method" - WriteDOMSpecification.printTableRow2

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSpecification.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMSpecification.java
@@ -108,24 +108,15 @@ public class WriteDOMSpecification extends Object {
         new PrintWriter(new OutputStreamWriter(new FileOutputStream(new File(lFileName)), "UTF-8"));
 
     // Start writing the html document
-    // System.out.println("debug - writing html document");
-
-    // String documentTitle = "PDS4 Information Model Specification";
-    // String documentAuthor = "PDS4 Information Model Specification Team";
-    // String documentSubTitle = "";
 
     prhtml.println("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2//EN\">");
     prhtml.println("<html>");
     prhtml.println("<head>");
-    // prhtml.println("<title>" + documentTitle + "</title>");
     prhtml.println("<title>" + DMDocument.imSpecDocTitle + "</title>");
     prhtml.println("<p align=center>");
-    // prhtml.println("<h1 align=center>" + documentTitle + "</h1><br><br>");
     prhtml.println("<h1 align=center>" + DMDocument.imSpecDocTitle + "</h1><br><br>");
-    // prhtml.println("<h2 align=center>" + documentAuthor + "</h2><br>");
     prhtml.println("<h2 align=center>" + DMDocument.imSpecDocAuthor + "</h2><br>");
     prhtml.println("<h2 align=center>" + sTodaysDate + "</h2><br><br><br>");
-    // prhtml.println("<h2 align=center>" + documentSubTitle + "</h2><br>");
     prhtml.println("<h2 align=center>" + DMDocument.imSpecDocSubTitle + "</h2><br>");
     prhtml.println("<h2 align=center>" + "Version "
         + DMDocument.masterPDSSchemaFileDefn.ont_version_id + "</h2><br>");
@@ -273,7 +264,6 @@ public class WriteDOMSpecification extends Object {
       }
 
       // get lClassAnchorString
-      // System.out.println("lClassId = "+ lClassId);
       DOMClass lClass = DOMInfoModel.masterDOMClassMap.get(lClassId);
       if (lClass == null) {
         continue;
@@ -306,7 +296,6 @@ public class WriteDOMSpecification extends Object {
         }
       }
     }
-    // System.out.println("size of print class array = " +lClassSortMap.size());
     return new ArrayList<>(lClassSortMap.values());
   }
 
@@ -356,7 +345,6 @@ public class WriteDOMSpecification extends Object {
     }
     String lClassAnchorString =
         ("class_" + lClass.nameSpaceIdNC + "_" + lClass.title).toLowerCase();
-    // System.out.println("\ndebug class title:" + lClass.title);
     if ((levelind + 1) < begSectionFormats.size()) {
       levelind += 1;
     }
@@ -409,17 +397,14 @@ public class WriteDOMSpecification extends Object {
     lClassArr.add(lClass);
     PrintOneClassHierarchy(lClassArr, "Hierarchy");
     PrintSubclasses(lClass.subClassHierArr, "Subclass");
-    // System.out.print("-------printing own attr ---------");
-    printTableRow2(lClass.ownedAttrArr, "Attribute");
-    // System.out.print("-------printing inherited attr ---------");
-    printTableRow2(lClass.inheritedAttrArr, "Inherited Attribute");
-
+    printTableRow(lClass.ownedAttrArr, "Attribute");
+    printTableRow(lClass.inheritedAttrArr, "Inherited Attribute");
     printAssoc(lClass.ownedAssocArr, "Association");
     printAssoc(lClass.inheritedAssocArr, "Inherited Association");
+    
     // find and print reference for this class
     ArrayList<DOMClass> refClasses = getClassReferences(lClass.identifier);
     printSimpleTableRow(refClasses, "Referenced from", true);
-
     prhtml.println("</table>");
   }
 
@@ -498,16 +483,14 @@ public class WriteDOMSpecification extends Object {
     }
   }
 
-
   /**
    * Print a table row
    *
    */
-  private void printTableRow2(ArrayList<DOMProp> lPropArr, String relation) {
+  private void printTableRow(ArrayList<DOMProp> lPropArr, String relation) {
     TreeMap<String, DOMProp> lPropSortMap = new TreeMap<>();
     String phRelation = relation;
     String phtitle;
-//    String phcard;
     String phindicator = "&nbsp;";
     boolean firstflag = true;
 
@@ -525,23 +508,15 @@ public class WriteDOMSpecification extends Object {
       DOMAttr lDOMAttr = (DOMAttr) lProp.domObject;
       phtitle = "<a href=\"#" + lDOMAttr.anchorString + "\">" + lDOMAttr.getTitle()
           + lRegistrationStatus + "</a>";
-//      String cmin = lDOMAttr.cardMin; // get min card
-//      String cmax = lDOMAttr.cardMax; // get max card
-//      String phcard = cmin + ".." + cmax;
-//      if (phcard.compareTo("1..0") == 0) phcard = "none";
-      
       String cmin = lDOMAttr.cardMin;
       String cmax = lDOMAttr.cardMax;
       String phcard = cmin.equals(cmax) ? cmin : (cmin + ".." + cmax);
       if (phcard.equals("1..0")) phcard = "none";
-
       
       // attribute is restricted in a subclass as opposed to
       // restricted relative to the attribute in the "USER" class
       if (lProp.isRestrictedInSubclass) phindicator += "R";
       
-      
-      // 555
 	  ArrayList<DOMProp> lValClassArr = new ArrayList<>(lDOMAttr.domPermValueArr);
       if (lValClassArr.isEmpty()) {
         String lClassRdfIdentifier = DMDocument.rdfPrefix + "." + "UNK" + "." + "DUMMY";
@@ -551,34 +526,17 @@ public class WriteDOMSpecification extends Object {
         lValClassArr.add(lDummyClass);
       }
       
-      // 555
       for (DOMProp lDOMProp : lValClassArr) {
           String phvalue = printPermissibleValues(lDOMAttr, lProp, lDOMProp);
           printHTMLTableRow(phRelation, phtitle, phcard, phvalue, phindicator);
           firstflag = false;
           phRelation = phtitle = phcard = phindicator = phvalue = "&nbsp;";
-      }
-      
-      
-      
-//      if (cmin.compareTo(cmax) == 0) cardval = cmin;
-//      phcard = cardval;
-//      firstflag = printPermissibleValues (lDOMAttr, phRelation, phtitle, phcard, phindicator);
-//      // clear fields
-//      phRelation = "&nbsp;";
-//      phtitle = "&nbsp;";
-//      phcard = "&nbsp;";
-//      phindicator = "&nbsp;";  
+      } 
     }
-    
-    
-    
     if (firstflag) {
       printHTMLTableRow(phRelation, "none", "&nbsp;", "&nbsp;", "&nbsp;");
     }
   }
-  
-  // 555
   
   private String printPermissibleValues(DOMAttr attr, DOMProp prop, DOMProp valueProp) {
 	    if (!(valueProp.domObject instanceof DOMPermValDefn)) {
@@ -604,7 +562,7 @@ public class WriteDOMSpecification extends Object {
 	        if (domClass != null) {
 	            anchorString = domClass.anchorString;
 	        } else {
-	            Utility.registerMessage("1>error printTableRow2 - Component Class is missing - lClassId:" + classId);
+	            Utility.registerMessage("1>error printTableRow - Component Class is missing - lClassId:" + classId);
 	        }
 	    } else {
 	        anchorString = ("value_" + attr.classNameSpaceIdNC + "_" + attr.parentClassTitle + "_" 
@@ -612,185 +570,7 @@ public class WriteDOMSpecification extends Object {
 	    }
 
 	    return "<a href=\"#" + anchorString + "\">" + replaceString(value, "μ", "&mu;") + "</a>";
-	}  
-
-  /* 555
-  private boolean printPermissibleValues (DOMAttr lDOMAttr, String phRelation, String phtitle, String phcard, String phindicator) {
-      boolean emptyFlag = true;
-      String phvalue = "&nbsp;";
-//	  ArrayList<DOMProp> lValClassArr = new ArrayList<>(lDOMAttr.domPermValueArr);
-//      if (lValClassArr.isEmpty()) {
-//        String lClassRdfIdentifier = DMDocument.rdfPrefix + "." + "UNK" + "." + "DUMMY";
-//        DOMProp lDummyClass = new DOMProp();
-//        lDummyClass.rdfIdentifier = lClassRdfIdentifier;
-//        lDummyClass.title = "dummy";
-//        lValClassArr.add(lDummyClass);
-//      }
-       
-      for (DOMProp lDOMProp: lValClassArr) {        
-        if (!(lDOMProp.domObject instanceof DOMPermValDefn)) {
-          phvalue = "&nbsp;";
-        } else {
-          DOMPermValDefn permVal = (DOMPermValDefn) lDOMProp.domObject;
-          String value = permVal.value;
-          if (!value.isEmpty()) {
-            String lAnchorString = lDOMAttr.anchorString;
-
-            // check for data types, unit of measure, etc
-            if (lDOMAttr.title.compareTo("data_type") == 0
-                || lDOMAttr.getTitle().compareTo("value_data_type") == 0
-                || lDOMAttr.getTitle().compareTo("unit_of_measure_type") == 0
-                || lDOMAttr.getTitle().compareTo("product_class") == 0) {
-              String lClassId =
-                  DOMInfoModel.getClassIdentifier(DMDocument.masterNameSpaceIdNCLC, value);
-              DOMClass lClass = DOMInfoModel.masterDOMClassIdMap.get(lClassId);
-              if (lClass != null) {
-                lAnchorString = lClass.anchorString;
-              } else {
-                // error
-                Utility.registerMessage("1>error "
-                    + "printTableRow2 - Component Class is missing - lClassId:" + lClassId);
-              }
-            } else {
-              lAnchorString =
-                  ("value_" + lDOMAttr.classNameSpaceIdNC + "_" + lDOMAttr.parentClassTitle + "_"
-                      + lDOMAttr.nameSpaceIdNC + "_" + lDOMAttr.getTitle() + "_" + value)
-                          .toLowerCase();
-            }
-            String lValue = replaceString(value, "μ", "&mu;");
-            phvalue = "<a href=\"#" + lAnchorString + "\">" + lValue + "</a>";
-          } else {
-            phvalue = "&nbsp;";
-          }
-        }
-        printHTMLTableRow(phRelation, phtitle, phcard, phvalue, phindicator);
-        emptyFlag = false;
-        // 555 why are these needed here
-        phRelation = "&nbsp;";
-        phtitle = "&nbsp;";
-        phcard = "&nbsp;";
-        phindicator = "&nbsp;";
-        phvalue = "&nbsp;";
-      }
-      return emptyFlag;
-  }  */  
-  
-  
-  
-  
-//  /**
-//   * Print a table row
-//   *
-//   */
-//  private void printTableRow2(ArrayList<DOMProp> lPropArr, String relation) {
-//    TreeMap<String, DOMProp> lPropSortMap = new TreeMap<>();
-//    String phRelation = relation;
-//    String phtitle;
-//    String phcard;
-//    String phvalue;
-//    String phindicator = "&nbsp;";
-//    boolean firstflag = true;
-//
-//    // sort the local attributes
-//    for (Iterator<DOMProp> i = lPropArr.iterator(); i.hasNext();) {
-//      DOMProp lProp = i.next();
-//      lPropSortMap.put(lProp.domObject.rdfIdentifier, lProp);
-//    }
-//    // System.out.println("printTableRow:"+ lPropSortMap.size());
-//    // process the local attributes
-//    ArrayList<DOMProp> lSortPropArr = new ArrayList<>(lPropSortMap.values());
-//    for (Iterator<DOMProp> i = lSortPropArr.iterator(); i.hasNext();) {
-//      DOMProp lProp = i.next();
-//      String lRegistrationStatus = "";
-//      if (lProp.registrationStatus.compareTo("Retired") == 0) {
-//        lRegistrationStatus = DMDocument.Literal_DEPRECATED;
-//      }
-//
-//      DOMAttr lDOMAttr = (DOMAttr) lProp.domObject;
-//      phtitle = "<a href=\"#" + lDOMAttr.anchorString + "\">" + lDOMAttr.getTitle()
-//          + lRegistrationStatus + "</a>";
-//      String cmin = lDOMAttr.cardMin; // get min card
-//      String cmax = lDOMAttr.cardMax; // get max card
-//      String cardval = cmin + ".." + cmax;
-//      if (cardval.compareTo("1..0") == 0) {
-//        cardval = "none";
-//      }
-//      if (lProp.isRestrictedInSubclass) { // attribute is restricted in a subclass as opposed to
-//                                          // restricted relative to the attribute in the "USER"
-//                                          // class
-//        phindicator += "R";
-//      }
-//      if (cmin.compareTo(cmax) == 0) {
-//        cardval = cmin;
-//      }
-//      phcard = cardval;
-//      phvalue = "";
-//
-//      ArrayList<DOMProp> lValClassArr = new ArrayList<>(lDOMAttr.domPermValueArr);
-//      if (lValClassArr.isEmpty()) {
-//        // System.out.println("attribute value array is empty");
-//        String lClassRdfIdentifier = DMDocument.rdfPrefix + "." + "UNK" + "." + "DUMMY";
-//        DOMProp lDummyClass = new DOMProp();
-//        lDummyClass.rdfIdentifier = lClassRdfIdentifier;
-//        lDummyClass.title = "dummy";
-//        lValClassArr.add(lDummyClass);
-//      }
-//      // System.out.println("getting values - size is "+ lValClassArr.size());
-//      Iterator<DOMProp> k = lValClassArr.iterator();
-//      String value;
-//      // System.out.println("Attr - "+ lProp.identifier+ "--" + lProp.classNameSpaceIdNC);
-//      while (k.hasNext()) {
-//
-//        DOMProp lDOMProp = k.next();
-//
-//        if (!(lDOMProp.domObject instanceof DOMPermValDefn)) {
-//          phvalue = "&nbsp;";
-//        } else {
-//          DOMPermValDefn permVal = (DOMPermValDefn) lDOMProp.domObject;
-//          value = permVal.value;
-//          if (!value.isEmpty()) {
-//            String lAnchorString = lDOMAttr.anchorString;
-//
-//            // check for data types, unit of measure, etc
-//            if (lDOMAttr.title.compareTo("data_type") == 0
-//                || lDOMAttr.getTitle().compareTo("value_data_type") == 0
-//                || lDOMAttr.getTitle().compareTo("unit_of_measure_type") == 0
-//                || lDOMAttr.getTitle().compareTo("product_class") == 0) {
-//              String lClassId =
-//                  DOMInfoModel.getClassIdentifier(DMDocument.masterNameSpaceIdNCLC, value);
-//              DOMClass lClass = DOMInfoModel.masterDOMClassIdMap.get(lClassId);
-//              if (lClass != null) {
-//                lAnchorString = lClass.anchorString;
-//              } else {
-//                // error
-//                Utility.registerMessage("1>error "
-//                    + "printTableRow2 - Component Class is missing - lClassId:" + lClassId);
-//              }
-//            } else {
-//              lAnchorString =
-//                  ("value_" + lDOMAttr.classNameSpaceIdNC + "_" + lDOMAttr.parentClassTitle + "_"
-//                      + lProp.nameSpaceIdNC + "_" + lDOMAttr.getTitle() + "_" + value)
-//                          .toLowerCase();
-//            }
-//            String lValue = replaceString(value, "μ", "&mu;");
-//            phvalue = "<a href=\"#" + lAnchorString + "\">" + lValue + "</a>";
-//          } else {
-//            phvalue = "&nbsp;";
-//          }
-//        }
-//        printHTMLTableRow(phRelation, phtitle, phcard, phvalue, phindicator);
-//        firstflag = false;
-//        phRelation = "&nbsp;";
-//        phtitle = "&nbsp;";
-//        phcard = "&nbsp;";
-//        phindicator = "&nbsp;";
-//        phvalue = "&nbsp;";
-//      }
-//    }
-//    if (firstflag) {
-//      printHTMLTableRow(phRelation, "none", "&nbsp;", "&nbsp;", "&nbsp;");
-//    }
-//  }
+	}
 
   private void printAssoc(ArrayList<DOMProp> lPropArr, String relation) {
     String phRelation = relation;
@@ -833,7 +613,6 @@ public class WriteDOMSpecification extends Object {
         phtitle = "<a href=\"#" + lProp.anchorString + "\">" + lProp.title + "</a>";
       }
       phvalue = "<a href=\"#" + lClassAnchorString + "\">" + lDOMClass.title + "</a>";
-      // System.out.println("anchor string = "+ phvalue);
       String cmin = lProp.cardMin; // get min card
       String cmax = lProp.cardMax; // get max card
       String cardval = cmin + ".." + cmax;
@@ -1173,10 +952,6 @@ public class WriteDOMSpecification extends Object {
   private void printAttrValue(DOMAttr lAttr) {
     String phvalue = "";
     boolean elipflag = false;
-
-    // if (lAttr.hasDOMObject.size() == 0) {
-    // return;
-    // }
     ArrayList<DOMProp> lValClassArr = lAttr.domPermValueArr;
 
     if (lValClassArr.size() > 1) {


### PR DESCRIPTION
Fix method identified by SonarQube as a "Brain Method" in the method WriteDOMSpecification.printTableRow2

## 🗒️ Summary
SonarQube identified the method printTableRow2 as a "Brain Method" in the module WriteDOMSpecification. This resulted from a PR associated with #930. 

Details:
- Used ChatGPT to refactor printTableRow2 into two methods
- Replace "Iterator-based loops" with "for-each loops" for readability. 
- Use getter DOMInfoModel.getMasterDOMClassArr()
- Clean up other code for readibility, e.g. {continue;} -> continue;


## ⚙️ Test Data and/or Report
Before and after versions of the PDS4 Information Model Specification file, "index_1P00.html", were compared using UltraCompare. There were identical except for the creation date/time. The attached file shows the comparison results.

<img width="3840" height="2160" alt="IMSpecDocComparison" src="https://github.com/user-attachments/assets/4e397db1-c3bb-4411-b57b-509ef0dddbc4" />

## ♻️ Related Issues
Resolves #937


