### PR TITLE
Fix issue LDD generator is not generating valid LDDs

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFileLib.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/WriteDOMDDJSONFileLib.java
@@ -280,13 +280,13 @@ class WriteDOMDDJSONFileLib {
 			jsonObjectAssoc.put(formatValue("isAttribute"), formatBooleanValue(true));
 			
 			// get component list, the attributes identifiers
-			jsonObjectAssoc.put(null, getValueClassList (lDOMPropGroup));
+			jsonObjectAssoc.put("attributeId", getValueClassList (lDOMPropGroup));
 		} else {
 			jsonObjectAssoc.put(formatValue("assocType"), formatValue("component_of"));
 			jsonObjectAssoc.put(formatValue("isAttribute"), formatBooleanValue(false));
 			
 			// get component list, the classes identifiers
-			jsonObjectAssoc.put(null, getValueClassList (lDOMPropGroup));
+			jsonObjectAssoc.put("classId", getValueClassList (lDOMPropGroup));
 		}
 		return jsonObjectAssoc;
 	}	


### PR DESCRIPTION
LDD generator is not generating valid LDDs

Updated WriteDOMDDJSONFileLib to use attributeId or classId as the array name in Associations

## 🗒️ Summary
Updated WriteDOMDDJSONFileLib to use "attributeId" or "classId" as the array name in Associations. The name had previously been set to "null" for both. These arrays identify the respective member attributes or classes.

## ⚙️ Test Data and/or Report
The JSON files before and after the change were compared. The results showed that the array names were no longer "null". The attached zip file contains the two JSON files and a capture image of the comparison.

## ♻️ Related Issues
Resolves #947


