### PR TITLE
LDDTool does not error when multiple Schematron rules have the same context

### DIFF
--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -1347,25 +1347,33 @@ public class LDDDOMParser extends Object {
   }
 
   private void getRule(SchemaFileDefn lSchemaFileDefn, Element docEle) {
-    ArrayList<String> lValueArr = new ArrayList<>();
+	  ArrayList<String> lValueArr = new ArrayList<>();
+	  // rule_context values seen in THIS Ingest_LDD; first rule for a context wins
+	  TreeMap<String, String> lLocalContextMap = new TreeMap<>();
 
-    // get a nodelist of <DD_Class> elements
-    NodeList n2 = docEle.getElementsByTagName("DD_Rule");
-    if (n2 != null && n2.getLength() > 0) {
-      for (int i = 0; i < n2.getLength(); i++) {
-        // get the elements
-        Element el = (Element) n2.item(i);
-        String lLocalIdentifier = "TBD_lLocalIdentifier";
-        String lValue1 = getTextValue(el, "local_identifier");
-        if (!(lValue1 == null || (lValue1.indexOf("TBD") == 0))) {
-          lLocalIdentifier = lValue1;
-        }
+	  NodeList n2 = docEle.getElementsByTagName("DD_Rule");
+	  if (n2 != null && n2.getLength() > 0) {
+	    for (int i = 0; i < n2.getLength(); i++) {
+	      Element el = (Element) n2.item(i);
+	      String lLocalIdentifier = "TBD_lLocalIdentifier";
+	      String lValue1 = getTextValue(el, "local_identifier");
+	      if (!(lValue1 == null || (lValue1.indexOf("TBD") == 0))) { lLocalIdentifier = lValue1; }
 
-        String lContext = "TBD_lContext";
-        String lValue2 = getTextValue(el, "rule_context");
-        if (!(lValue2 == null || (lValue2.indexOf("TBD") == 0))) {
-          lContext = lValue2;
-        }
+	      String lContext = "TBD_lContext";
+	      String lValue2 = getTextValue(el, "rule_context");
+	      if (!(lValue2 == null || (lValue2.indexOf("TBD") == 0))) { lContext = lValue2; }
+	      
+	      // in a single Ingest_LDD, rules are not merged: keep the first, reject the rest
+	      String lFirstLocalIdentifier = lLocalContextMap.get(lContext);
+	      if (lFirstLocalIdentifier != null) {
+	        Utility.registerMessage("2>error Rule: <" + lLocalIdentifier
+	            + "> - The rule_context '" + lContext + "' is already used by rule <"
+	            + lFirstLocalIdentifier + "> in this local data dictionary."
+	            + " Rules are not merged; only the first rule is used."
+	            + " Combine the DD_Rule_Statements into a single DD_Rule.");
+	        continue;                          // discard the duplicate - first rule wins
+	      }
+	      lLocalContextMap.put(lContext, lLocalIdentifier);
 
         DOMRule lDOMRule = new DOMRule(lContext);
         lDOMRule.setRDFIdentifier();

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -1375,68 +1375,66 @@ public class LDDDOMParser extends Object {
 	      }
 	      lLocalContextMap.put(lContext, lLocalIdentifier);
 
-        DOMRule lDOMRule = new DOMRule(lContext);
-        lDOMRule.setRDFIdentifier();
+	      DOMRule lDOMRule = new DOMRule(lContext);
+	      lDOMRule.setRDFIdentifier();
 
-        if (ruleMap.get(lDOMRule.rdfIdentifier) == null) {
-          ruleMap.put(lDOMRule.rdfIdentifier, lDOMRule);
-          ruleArr.add(lDOMRule);
-          lDOMRule.nameSpaceIdNC = lSchemaFileDefn.nameSpaceIdNC;
-          lDOMRule.attrNameSpaceNC = lSchemaFileDefn.nameSpaceIdNC;
-          lDOMRule.attrTitle = "Rule";
-          lDOMRule.classNameSpaceNC = lSchemaFileDefn.nameSpaceIdNC;
-          lDOMRule.classSteward = lSchemaFileDefn.stewardId;
-          lDOMRule.xpath = lContext;
-
-          // get the let assign values
-          lValueArr = getXMLValueArr("rule_assign", el);
-          if (!(lValueArr == null || lValueArr.isEmpty())) {
-            lDOMRule.letAssignArr = lValueArr;
-          }
-
-          // get the rule statements
-          ArrayList<Element> lElementStmtArr = getElement("DD_Rule_Statement", el);
-          for (Iterator<Element> j = lElementStmtArr.iterator(); j.hasNext();) {
-            Element lElement = j.next();
-
-            DOMAssert lDOMAssertDefn = new DOMAssert("Rule");
-            lDOMRule.assertArr.add(lDOMAssertDefn);
-
-            String lValue3 = getTextValue(lElement, "rule_type");
-            if (!(lValue3 == null || (lValue3.indexOf("TBD") == 0))) {
-              if (lValue3.compareTo("Assert") == 0) {
-                lDOMAssertDefn.assertType = "RAW";
-              } else if (lValue3.compareTo("Assert Every") == 0) {
-                lDOMAssertDefn.assertType = "EVERY";
-              } else if (lValue3.compareTo("Assert If") == 0) {
-                lDOMAssertDefn.assertType = "IF";
-              } else if (lValue3.compareTo("Report") == 0) {
-                lDOMAssertDefn.assertType = "REPORT";
-              }
-            }
-
-            String lValue4 = getTextValue(lElement, "rule_test");
-            if (!(lValue4 == null || (lValue4.indexOf("TBD") == 0))) {
-              lDOMAssertDefn.assertStmt = lValue4;
-            }
-
-            String lValue5 = getTextValue(lElement, "rule_message");
-            if (!(lValue5 == null || (lValue5.indexOf("TBD") == 0))) {
-              lDOMAssertDefn.assertMsg = lValue5;
-            }
-
-            String lValue6 = getTextValue(lElement, "rule_description");
-            if (!(lValue6 == null || (lValue6.indexOf("TBD") == 0))) {
-              lDOMAssertDefn.specMesg = lValue6;
-            }
-
-            // get the statement values
-            lValueArr = getXMLValueArr("rule_value", lElement);
-            if (!(lValueArr == null || lValueArr.isEmpty())) {
-              lDOMAssertDefn.testValArr = lValueArr;
-            }
-          }
-        }
+	      ruleMap.put(lDOMRule.rdfIdentifier, lDOMRule);
+	      ruleArr.add(lDOMRule);
+	      lDOMRule.nameSpaceIdNC = lSchemaFileDefn.nameSpaceIdNC;
+	      lDOMRule.attrNameSpaceNC = lSchemaFileDefn.nameSpaceIdNC;
+	      lDOMRule.attrTitle = "Rule";
+	      lDOMRule.classNameSpaceNC = lSchemaFileDefn.nameSpaceIdNC;
+	      lDOMRule.classSteward = lSchemaFileDefn.stewardId;
+	      lDOMRule.xpath = lContext;
+	
+	      // get the let assign values
+	      lValueArr = getXMLValueArr("rule_assign", el);
+	      if (!(lValueArr == null || lValueArr.isEmpty())) {
+	        lDOMRule.letAssignArr = lValueArr;
+	      }
+	
+	      // get the rule statements
+	      ArrayList<Element> lElementStmtArr = getElement("DD_Rule_Statement", el);
+	      for (Iterator<Element> j = lElementStmtArr.iterator(); j.hasNext();) {
+	        Element lElement = j.next();
+	
+	        DOMAssert lDOMAssertDefn = new DOMAssert("Rule");
+	        lDOMRule.assertArr.add(lDOMAssertDefn);
+	
+	        String lValue3 = getTextValue(lElement, "rule_type");
+	        if (!(lValue3 == null || (lValue3.indexOf("TBD") == 0))) {
+	          if (lValue3.compareTo("Assert") == 0) {
+	            lDOMAssertDefn.assertType = "RAW";
+	          } else if (lValue3.compareTo("Assert Every") == 0) {
+	            lDOMAssertDefn.assertType = "EVERY";
+	          } else if (lValue3.compareTo("Assert If") == 0) {
+	            lDOMAssertDefn.assertType = "IF";
+	          } else if (lValue3.compareTo("Report") == 0) {
+	            lDOMAssertDefn.assertType = "REPORT";
+	          }
+	        }
+	
+	        String lValue4 = getTextValue(lElement, "rule_test");
+	        if (!(lValue4 == null || (lValue4.indexOf("TBD") == 0))) {
+	          lDOMAssertDefn.assertStmt = lValue4;
+	        }
+	
+	        String lValue5 = getTextValue(lElement, "rule_message");
+	        if (!(lValue5 == null || (lValue5.indexOf("TBD") == 0))) {
+	          lDOMAssertDefn.assertMsg = lValue5;
+	        }
+	
+	        String lValue6 = getTextValue(lElement, "rule_description");
+	        if (!(lValue6 == null || (lValue6.indexOf("TBD") == 0))) {
+	          lDOMAssertDefn.specMesg = lValue6;
+	        }
+	
+	        // get the statement values
+	        lValueArr = getXMLValueArr("rule_value", lElement);
+	        if (!(lValueArr == null || lValueArr.isEmpty())) {
+	          lDOMAssertDefn.testValArr = lValueArr;
+	        }
+	      }
       }
     }
   }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -50,6 +50,8 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
 import gov.nasa.pds.model.plugin.util.Utility;
 
 /**
@@ -166,11 +168,12 @@ public class LDDDOMParser extends Object {
   }
 
   public void getLocalDD() throws java.io.IOException {
-    // parse the xml file and get the dom object
-    parseXmlFile(gSchemaFileDefn);
+    if (!parseXmlFile(gSchemaFileDefn)) {
+      throw new IOException(
+          "Could not parse Ingest_LDD file: " + gSchemaFileDefn.LDDToolInputFileName);
+    }
     Utility.registerMessage("0>info getLocalDD.parseXmlFile() Done");
 
-    // process the dom document for classes, attributes, etc
     parseDocument(gSchemaFileDefn);
     Utility.registerMessage("0>info getLocalDD.parseDocument() Done");
   }
@@ -196,21 +199,29 @@ public class LDDDOMParser extends Object {
     Utility.registerMessage("0>info getLocalDD Done");
   }
 
-  private void parseXmlFile(SchemaFileDefn lSchemaFileDefn) {
-    // get the factory
+  private boolean parseXmlFile(SchemaFileDefn lSchemaFileDefn) {
+    String lFileName = lSchemaFileDefn.LDDToolInputFileName;
     DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
     try {
-      // Using factory get an instance of document builder
       DocumentBuilder db = dbf.newDocumentBuilder();
-      // parse using builder to get DOM representation of the XML file
-      dom = db.parse(lSchemaFileDefn.LDDToolInputFileName);
-    } catch (ParserConfigurationException pce) {
-      pce.printStackTrace();
+      dom = db.parse(lFileName);
+      return true;
+    } catch (SAXParseException spe) {
+      Utility.registerMessage("3>error Could not parse Ingest_LDD file: " + lFileName
+          + " [line " + spe.getLineNumber() + ", column " + spe.getColumnNumber() + "] "
+          + spe.getMessage());
     } catch (SAXException se) {
-      se.printStackTrace();
+      Utility.registerMessage("3>error Could not parse Ingest_LDD file: " + lFileName
+          + " - " + se.getMessage());
+    } catch (ParserConfigurationException pce) {
+      Utility.registerMessage("3>error Could not configure the XML parser for Ingest_LDD file: "
+          + lFileName + " - " + pce.getMessage());
     } catch (IOException ioe) {
-      ioe.printStackTrace();
+      Utility.registerMessage("3>error Could not read Ingest_LDD file: " + lFileName
+          + " - " + ioe.getMessage());
     }
+    dom = null;
+    return false;
   }
 
   private void parseDocument(SchemaFileDefn lSchemaFileDefn) {

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -2451,7 +2451,7 @@ public class LDDDOMParser extends Object {
         DOMInfoModel.masterDOMRuleMap.put(lRule.rdfIdentifier, lRule);
       } else {
         Utility.registerMessage(
-            "2>warning Found duplicate attribute - lAttr.identifier:" + lRule.identifier);
+            "2>warning Found duplicate rule - lRule.identifier:" + lRule.identifier);
       }
     }
   }

--- a/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
+++ b/model-dmdocument/src/main/java/gov/nasa/pds/model/plugin/LDDDOMParser.java
@@ -1366,7 +1366,7 @@ public class LDDDOMParser extends Object {
 	      // in a single Ingest_LDD, rules are not merged: keep the first, reject the rest
 	      String lFirstLocalIdentifier = lLocalContextMap.get(lContext);
 	      if (lFirstLocalIdentifier != null) {
-	        Utility.registerMessage("2>error Rule: <" + lLocalIdentifier
+	        Utility.registerMessage("2>warning Rule: <" + lLocalIdentifier
 	            + "> - The rule_context '" + lContext + "' is already used by rule <"
 	            + lFirstLocalIdentifier + "> in this local data dictionary."
 	            + " Rules are not merged; only the first rule is used."

--- a/model-lddtool/src/test/resources/data/update_version/github1059/PDS4_PROVRuleTest_IngestLDD_pass.xml
+++ b/model-lddtool/src/test/resources/data/update_version/github1059/PDS4_PROVRuleTest_IngestLDD_pass.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model
+    href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1A00.sch"
+    schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+  <!-- PDS4 Local Data Dictionary Extended Ingest File -->
+
+  <!-- Minimal fixture for the duplicate DD_Rule rule_context test.                            -->
+  <!-- The One DD_Rule definition at the bottom has one rule_context.                          -->
+  <!-- There are three rule asserts in the single context                                      -->
+
+<Ingest_LDD
+    xmlns="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+                        http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1K00.xsd">
+
+  <name>Provenance</name>
+  <ldd_version_id>1.0.0.0</ldd_version_id>
+  <dictionary_type>Discipline</dictionary_type>
+  <full_name>Steve Hughes</full_name>
+  <steward_id>prov</steward_id>
+  <namespace_id>prov</namespace_id>
+  <comment>
+    Test-only local data dictionary. It defines one rule that has three asserts sharing the same context.
+    LDDTool's duplicate rule_context check is being exercised. Not for operational use.
+  </comment>
+  <last_modification_date_time>2026-07-29T12:00:00Z</last_modification_date_time>
+
+
+  <!-- ======= Attribute Definitions ======= -->
+
+  <DD_Attribute>
+    <name>attribute</name>
+    <version_id>1.0</version_id>
+    <local_identifier>attribute</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Steve Hughes</submitter_name>
+    <definition>The attribute component of an attribute-value pair.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_Short_String_Collapsed</value_data_type>
+      <minimum_characters>1</minimum_characters>
+      <maximum_characters>255</maximum_characters>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+
+  <DD_Attribute>
+    <name>value</name>
+    <version_id>1.0</version_id>
+    <local_identifier>value</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Steve Hughes</submitter_name>
+    <definition>The value component of an attribute-value pair.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_Short_String_Collapsed</value_data_type>
+      <minimum_characters>1</minimum_characters>
+      <maximum_characters>255</maximum_characters>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+
+
+  <!-- ======= Class Definitions ======= -->
+
+  <DD_Class>
+    <name>Attributes</name>
+    <version_id>1.0</version_id>
+    <local_identifier>Attributes</local_identifier>
+    <submitter_name>Steve Hughes</submitter_name>
+    <definition>A set of attribute-value pairs. This is the class the three rules target.</definition>
+    <element_flag>false</element_flag>
+
+    <DD_Association>
+      <identifier_reference>attribute</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>1</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+
+    <DD_Association>
+      <identifier_reference>value</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>1</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+  </DD_Class>
+
+  <DD_Class>
+    <name>Provenance</name>
+    <version_id>1.0</version_id>
+    <local_identifier>Provenance</local_identifier>
+    <submitter_name>Steve Hughes</submitter_name>
+    <definition>The exposed Discipline_Area insert that carries the Attributes class.</definition>
+    <element_flag>true</element_flag>
+
+    <DD_Association>
+      <identifier_reference>Attributes</identifier_reference>
+      <reference_type>component_of</reference_type>
+      <minimum_occurrences>1</minimum_occurrences>
+      <maximum_occurrences>unbounded</maximum_occurrences>
+    </DD_Association>
+  </DD_Class>
+
+
+  <!-- ======= Rule Definitions - one rule, three shared rule_context ======= -->
+
+  <DD_Rule>
+    <local_identifier>duplicate_context_rule_1</local_identifier>
+    <rule_context>//prov:Attributes</rule_context>
+
+    <DD_Rule_Statement>
+      <rule_type>Assert</rule_type>
+      <rule_test>prov:attribute</rule_test>
+      <rule_message>Rule Assert 1: prov:attribute must be present.</rule_message>
+    </DD_Rule_Statement>
+    
+    <DD_Rule_Statement>
+      <rule_type>Assert</rule_type>
+      <rule_test>prov:value</rule_test>
+      <rule_message>Rule Assert 2: prov:value must be present.</rule_message>
+    </DD_Rule_Statement>
+    
+    <DD_Rule_Statement>
+      <rule_type>Assert</rule_type>
+      <rule_test>string-length(prov:value) &gt; 0</rule_test>
+      <rule_message>Rule Assert 3: prov:value must not be empty.</rule_message>
+    </DD_Rule_Statement>
+    
+  </DD_Rule>
+
+</Ingest_LDD>

--- a/model-lddtool/src/test/resources/data/update_version/github1059/PDS4_PROVRuleTest_IngestLDD_warning.xml
+++ b/model-lddtool/src/test/resources/data/update_version/github1059/PDS4_PROVRuleTest_IngestLDD_warning.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model
+    href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1A00.sch"
+    schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+  <!-- PDS4 Local Data Dictionary Extended Ingest File -->
+
+  <!-- Minimal fixture for the duplicate DD_Rule rule_context test.                            -->
+  <!-- The three DD_Rule definitions at the bottom all declare the same rule_context.          -->
+  <!-- Rules in a single Ingest_LDD are not merged, so this must be reported as an error: the   -->
+  <!-- first rule wins and the other two are discarded. Everything above the rules is only      -->
+  <!-- present to give the rule context something to point at.                                 -->
+
+<Ingest_LDD
+    xmlns="http://pds.nasa.gov/pds4/pds/v1"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1
+                        http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1K00.xsd">
+
+  <name>Provenance</name>
+  <ldd_version_id>1.0.0.0</ldd_version_id>
+  <dictionary_type>Discipline</dictionary_type>
+  <full_name>Steve Hughes</full_name>
+  <steward_id>prov</steward_id>
+  <namespace_id>prov</namespace_id>
+  <comment>
+    Test-only local data dictionary. It defines three rules that share one rule_context so that
+    LDDTool's duplicate rule_context check can be exercised. Not for operational use.
+  </comment>
+  <last_modification_date_time>2026-07-29T12:00:00Z</last_modification_date_time>
+
+
+  <!-- ======= Attribute Definitions ======= -->
+
+  <DD_Attribute>
+    <name>attribute</name>
+    <version_id>1.0</version_id>
+    <local_identifier>attribute</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Steve Hughes</submitter_name>
+    <definition>The attribute component of an attribute-value pair.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_Short_String_Collapsed</value_data_type>
+      <minimum_characters>1</minimum_characters>
+      <maximum_characters>255</maximum_characters>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+
+  <DD_Attribute>
+    <name>value</name>
+    <version_id>1.0</version_id>
+    <local_identifier>value</local_identifier>
+    <nillable_flag>false</nillable_flag>
+    <submitter_name>Steve Hughes</submitter_name>
+    <definition>The value component of an attribute-value pair.</definition>
+    <DD_Value_Domain>
+      <enumeration_flag>false</enumeration_flag>
+      <value_data_type>ASCII_Short_String_Collapsed</value_data_type>
+      <minimum_characters>1</minimum_characters>
+      <maximum_characters>255</maximum_characters>
+      <unit_of_measure_type>Units_of_None</unit_of_measure_type>
+    </DD_Value_Domain>
+  </DD_Attribute>
+
+
+  <!-- ======= Class Definitions ======= -->
+
+  <DD_Class>
+    <name>Attributes</name>
+    <version_id>1.0</version_id>
+    <local_identifier>Attributes</local_identifier>
+    <submitter_name>Steve Hughes</submitter_name>
+    <definition>A set of attribute-value pairs. This is the class the three rules target.</definition>
+    <element_flag>false</element_flag>
+
+    <DD_Association>
+      <identifier_reference>attribute</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>1</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+
+    <DD_Association>
+      <identifier_reference>value</identifier_reference>
+      <reference_type>attribute_of</reference_type>
+      <minimum_occurrences>1</minimum_occurrences>
+      <maximum_occurrences>1</maximum_occurrences>
+    </DD_Association>
+  </DD_Class>
+
+  <DD_Class>
+    <name>Provenance</name>
+    <version_id>1.0</version_id>
+    <local_identifier>Provenance</local_identifier>
+    <submitter_name>Steve Hughes</submitter_name>
+    <definition>The exposed Discipline_Area insert that carries the Attributes class.</definition>
+    <element_flag>true</element_flag>
+
+    <DD_Association>
+      <identifier_reference>Attributes</identifier_reference>
+      <reference_type>component_of</reference_type>
+      <minimum_occurrences>1</minimum_occurrences>
+      <maximum_occurrences>unbounded</maximum_occurrences>
+    </DD_Association>
+  </DD_Class>
+
+
+  <!-- ======= Rule Definitions - three rules, one shared rule_context ======= -->
+
+  <DD_Rule>
+    <local_identifier>duplicate_context_rule_1</local_identifier>
+    <rule_context>//prov:Attributes</rule_context>
+
+    <DD_Rule_Statement>
+      <rule_type>Assert</rule_type>
+      <rule_test>prov:attribute</rule_test>
+      <rule_message>Rule 1: prov:attribute must be present.</rule_message>
+    </DD_Rule_Statement>
+  </DD_Rule>
+
+  <DD_Rule>
+    <local_identifier>duplicate_context_rule_2</local_identifier>
+    <rule_context>//prov:Attributes</rule_context>
+
+    <DD_Rule_Statement>
+      <rule_type>Assert</rule_type>
+      <rule_test>prov:value</rule_test>
+      <rule_message>Rule 2: prov:value must be present.</rule_message>
+    </DD_Rule_Statement>
+  </DD_Rule>
+
+  <DD_Rule>
+    <local_identifier>duplicate_context_rule_3</local_identifier>
+    <rule_context>//prov:Attributes</rule_context>
+
+    <DD_Rule_Statement>
+      <rule_type>Assert</rule_type>
+      <rule_test>string-length(prov:value) &gt; 0</rule_test>
+      <rule_message>Rule 3: prov:value must not be empty.</rule_message>
+    </DD_Rule_Statement>
+  </DD_Rule>
+
+</Ingest_LDD>

--- a/model-lddtool/src/test/resources/features/integration.feature
+++ b/model-lddtool/src/test/resources/features/integration.feature
@@ -70,6 +70,7 @@ Feature: <testId>
     Examples:
       | testId                                  | testName                                                                            | inputDirectory                                      | outputDirectory                     | commandArgs                                                    | assertType    | output        | actualOutputFile     |
       | "NASA-PDS/pds4-information-model#1059a" | "NASA-PDS/pds4-information-model#1059a prov Ingest_LDD processes with warning"      | "src/test/resources/data/update_version/github1059" | "target/generated-files/github1059" | "-lp {inputDirectory}/PDS4_PROVRuleTest_IngestLDD_warning.xml" | "contain"     | ">>> WARNING" | "lddtool-output.txt" |
+      | "NASA-PDS/pds4-information-model#1059b" | "NASA-PDS/pds4-information-model#1059b prov Ingest_LDD processes with no warning"   | "src/test/resources/data/update_version/github1059" | "target/generated-files/github1059" | "-lp {inputDirectory}/PDS4_PROVRuleTest_IngestLDD_pass.xml"    | "not contain" | ">>> WARNING" | "lddtool-output.txt" |
       
       
           

--- a/model-lddtool/src/test/resources/features/integration.feature
+++ b/model-lddtool/src/test/resources/features/integration.feature
@@ -59,5 +59,17 @@ Feature: <testId>
       | "NASA-PDS/pds4-information-model#867Ra" | "Check schema for 1R00"                                                         | "src/test/resources/data/update_version/github867/1R00"  | "target/generated-files/github867Ra" | "-p -V 1R00"                                    | "PDS4_PDS_1R00.xsd"             | "PDS4_PDS_1R00.xsd"                   | "PDS4 XML/Schema"                |
       | "NASA-PDS/pds4-information-model#867Rb" | "Check schematron for 1R00"                                                     | "src/test/resources/data/update_version/github867/1R00"  | "target/generated-files/github867Rb" | "-p -V 1R00"                                    | "PDS4_PDS_1R00.sch"             | "PDS4_PDS_1R00.sch"                   | "PDS4 Schematron for Name Space" |
       | "NASA-PDS/pds4-information-model#867Rc" | "Check pins output for 1R00"                                                    | "src/test/resources/data/update_version/github867/1R00"  | "target/generated-files/github867Rc" | "-p -V 1R00"                                    | "dd11179_GenPClass.pins"        | "dd11179_GenPClass.pins"              | ""                               |
+
+      
+  Scenario Outline: Verifying lddtool output against specified assertions
+    Given the directories <inputDirectory>, <outputDirectory>, and command arguments <commandArgs>
+    When lddtool is run
+    Then the produced output from lddtool command should <assertType> <output> in <actualOutputFile> file      
+      
+    @NASA-PDS/pds4-information-model#1059 @B18.0
+    Examples:
+      | testId                                  | testName                                                                            | inputDirectory                                      | outputDirectory                     | commandArgs                                                    | assertType    | output        | actualOutputFile     |
+      | "NASA-PDS/pds4-information-model#1059a" | "NASA-PDS/pds4-information-model#1059a prov Ingest_LDD processes with warning"      | "src/test/resources/data/update_version/github1059" | "target/generated-files/github1059" | "-lp {inputDirectory}/PDS4_PROVRuleTest_IngestLDD_warning.xml" | "contain"     | ">>> WARNING" | "lddtool-output.txt" |
+      
       
           


### PR DESCRIPTION
## 🗒️ Summary
LDDTool (aka DMDocument) was modified so that when running with argument "-l" (Ingest_LDD parsing mode) a warning is issued for the case were two or more rules are defined having same context (xpath). 

Note: Issuing a "high priority warning with explanation" instead of an error was decided during implementation since it seemed  appropriate for the following reasons. The legacy LDDs remain operational but are now flagged, the issue had seldom occurred since the omission of a rule is relatively obvious, and testing is much easier. However, this change in requirements will be presented to the DDWG for their approval. If disapproved a new SCR will be submitted.

### 🤖 AI Assistance Disclosure

- [x ] AI generated substantial portions of this code

- A Claude Code Controlled Maintenance Assistant was set up for the application. The assistant was used to generate the proposed changes including the changes to the affected modules and the new test code. The assistant version of the application was kept separate from the operational application and simply referenced as guidance.

Estimated % of code influenced by AI: _95_ %

## ⚙️ Test Data and/or Report
Two integration feature tests, pass and warning, were created to detect whether LDDTool detected two or more rules with the same context.  github1059


## ♻️ Related Issues
- resolves#1059

## 🤓 Reviewer Checklist

*Reviewers: Please verify the following before approving this pull request.*

### Documentation and PR Content
- [ ] **Documentation:** README, Wiki, or inline documentation (Sphinx, Javadoc, Docstrings) have been updated to reflect these changes.
- [ ] **Issue Traceability:** The PR is linked to a valid GitHub Issue
- [ ] **PR Title:** The PR title is "user-friendly" clearly identifying what is being fixed or the new feature being added, that if you saw it in the Release Notes for a tool, you would be able to get the gist of what was done.

### Security & Quality
- [ ] **SonarCloud:** Confirmed no new High or Critical security findings.
- [ ] **Secrets Detection:** Verified that the Secrets Detection scan passed and no sensitive information (keys, tokens, PII) is exposed.
- [ ] **Code Quality:** Code follows organization style guidelines and best practices for the specific language (e.g., PEP 8, Google Java Style).

### Testing & Validation
- [ ] **Test Accuracy:** Verified that test data is accurate, representative of real-world PDS4 scenarios, and sufficient for the logic being tested.
- [ ] **Coverage:** Automated tests cover new logic and edge cases.
- [ ] **Local Verification:** (If applicable) Successfully built and ran the changes in a local or staging environment.

### Maintenance
- [ ] **Backward Compatibility:** Confirmed that these changes do not break existing downstream dependencies or API contracts (or that breaking changes are clearly documented).
